### PR TITLE
Match kubectl behavior in commands that use kubeconfig

### DIFF
--- a/cmd/up/cloud/controlplane/attach.go
+++ b/cmd/up/cloud/controlplane/attach.go
@@ -67,7 +67,7 @@ type AttachCmd struct {
 
 	Description   string    `short:"d" help:"Description for control plane."`
 	KubeClusterID uuid.UUID `help:"ID for self-hosted Kubernetes cluster."`
-	Kubeconfig    string    `env:"KUBECONFIG" type:"existingfile" help:"Override default kubeconfig path."`
+	Kubeconfig    string    `type:"existingfile" help:"Override default kubeconfig path."`
 	ViewOnly      bool      `help:"Create control plane with view only permissions."`
 }
 

--- a/cmd/up/uxp/uxp.go
+++ b/cmd/up/uxp/uxp.go
@@ -42,6 +42,6 @@ type Cmd struct {
 	Upgrade   upgradeCmd   `cmd:"" group:"uxp" help:"Upgrade UXP."`
 	Connect   connectCmd   `cmd:"" group:"uxp" help:"Connect UXP to Upbound Cloud."`
 
-	Kubeconfig string `env:"KUBECONFIG" type:"existingfile" help:"Override default kubeconfig path."`
+	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
 	Namespace  string `short:"n" env:"UXP_NAMESPACE" default:"upbound-system" help:"Kubernetes namespace for UXP."`
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -77,8 +77,8 @@ Format: `up cloud controlplane <cmd> ...` Alias: `up cloud xp <cmd> ...`
       - `--kube-cluster-id = UUID`: UUID for self-hosted control plane.
         Auto-populated as `metadata.uid` of `kube-system` `Namespace` of
         currently configured `kubeconfig` if not manually provided.
-      - `--kubeconfig` (Env: `KUBECONFIG`): overrides default kubeconfig path
-        (`~/.kube/config`).
+      - `--kubeconfig = STRING`: sets `kubeconfig` path. Same defaults as
+        `kubectl` are used if not provided.
       - `--view-only`: creates the self-hosted control plane as view only.
     - Behavior: Creates a self-hosted control plane on Upbound Cloud and returns
       token to connect a UXP instance to it.
@@ -174,8 +174,8 @@ Crossplane, as well as connect it to Upbound Cloud.
 Group flags can be passed for any command in the **UXP** group. Some commands
 may choose not to utilize the group flags when not relevant.
 
-- `--kubeconfig` (Env: `KUBECONFIG`): overrides default kubeconfig path
-  (`~/.kube/config`).
+- `--kubeconfig = STRING`: sets `kubeconfig` path. Same defaults as `kubectl`
+  are used if not provided.
 - `-n,--namespace = STRING` (Env: `UXP_NAMESPACE`) (Default: `upbound-system`):
   Kubernetes namespace used for installing and managing UXP.
 

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -15,11 +15,8 @@
 package kube
 
 import (
-	"path/filepath"
-
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 )
 
 const (
@@ -31,8 +28,7 @@ const (
 
 // GetKubeConfig constructs a Kubernetes REST config from the specified kubeconfig.
 func GetKubeConfig(path string) (*rest.Config, error) {
-	if path == "" {
-		path = filepath.Join(homedir.HomeDir(), KubeconfigDir, KubeconfigFile)
-	}
-	return clientcmd.BuildConfigFromFlags("", path)
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = path
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{}).ClientConfig()
 }

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -26,7 +26,8 @@ const (
 	KubeconfigFile = "config"
 )
 
-// GetKubeConfig constructs a Kubernetes REST config from the specified kubeconfig.
+// GetKubeConfig constructs a Kubernetes REST config from the specified
+// kubeconfig, or falls back to same defaults as kubectl.
 func GetKubeConfig(path string) (*rest.Config, error) {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.ExplicitPath = path


### PR DESCRIPTION
Updates `--kubeconfig` flags to not explicitly use environment variables and instead fall back on default kubeconfig loader chain used by `kubectl`. This means that `up` is only overriding behavior if an explicit existing path is passed to `--kubeconfig`.

Fixes #77 

Tested this out by creating two different kind clusters and running the following scenarios after exporting kubeconfigs to `first.yaml` and `second.yaml`:
- Add list of paths to `KUBECONFIG` that includes `first.yaml` but not `second.yaml` -- first cluster is used
- Add list of paths to `KUBECONFIG` that includes `second.yaml` but not `first.yaml` -- second cluster is used
- Add list of paths to `KUBECONFIG` that includes `first.yaml` _before_ `second.yaml` -- first cluster is used
- Unset `KUBECONFIG` and current context in `~/.kube/kubeconfig` is used
- Explicitly provide filepath via `--kubeconfig` and the specified file is used

 