### PR TITLE
Strip leading v off of UXP version when pulling chart

### DIFF
--- a/internal/uxp/installers/helm/helm.go
+++ b/internal/uxp/installers/helm/helm.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -352,6 +353,9 @@ func (h *installer) Uninstall() error {
 
 // pullAndLoad pulls and loads a chart or fetches it from the catch.
 func (h *installer) pullAndLoad(version string) (*chart.Chart, error) {
+	// helm strips versions with leading v, which can cause issues when fetching
+	// the chart from the cache.
+	version = strings.TrimPrefix(version, "v")
 	// check to see if version is cached
 	fileName := filepath.Join(h.cacheDir, fmt.Sprintf("%s-%s.tgz", h.chartName, version))
 	if version != "" {


### PR DESCRIPTION
Strips the leading v off of any UXP versions supplied when pulling the
chart so that it matches how Helm caches it. An alternative approach
would be to parse into structured semantic version prior to passing to
Helm, but we prefer to defer that logic to Helm rather than parsing into
semver twice. If additional modification were made by Helm in the
future, this functionality could break, but we would prefer to hit the
issue rather than potentially pulling and installing incorrect UXP versions.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #84 