### PR TITLE
Remove kube cluster ID from attach and defer to agent

### DIFF
--- a/cmd/up/cloud/controlplane/attach.go
+++ b/cmd/up/cloud/controlplane/attach.go
@@ -19,10 +19,7 @@ import (
 	"fmt"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	// Allow auth to all
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -31,64 +28,30 @@ import (
 	"github.com/upbound/up-sdk-go/service/tokens"
 
 	"github.com/upbound/up/internal/cloud"
-	"github.com/upbound/up/internal/kube"
 )
 
 const (
-	kubeIDNamespace = "kube-system"
-	jwtKey          = "jwt"
+	jwtKey = "jwt"
 
-	errKubeSystemUID = "unable to extract kube-system namespace uid for usage as cluster identifier"
-	errNoToken       = "could not identify token in response"
+	errNoToken = "could not identify token in response"
 )
-
-// AfterApply sets default values in command after assignment and validation.
-func (c *AttachCmd) AfterApply() error {
-	if c.KubeClusterID == uuid.Nil {
-		config, err := kube.GetKubeConfig(c.Kubeconfig)
-		if err != nil {
-			return err
-		}
-		client, err := kubernetes.NewForConfig(config)
-		if err != nil {
-			return err
-		}
-		c.kClient = client
-	}
-	return nil
-}
 
 // AttachCmd adds a user or token profile with session token to the up config
 // file.
 type AttachCmd struct {
-	kClient kubernetes.Interface
-
 	Name string `arg:"" required:"" help:"Name of control plane."`
 
-	Description   string    `short:"d" help:"Description for control plane."`
-	KubeClusterID uuid.UUID `help:"ID for self-hosted Kubernetes cluster."`
-	Kubeconfig    string    `type:"existingfile" help:"Override default kubeconfig path."`
-	ViewOnly      bool      `help:"Create control plane with view only permissions."`
+	Description string `short:"d" help:"Description for control plane."`
+	ViewOnly    bool   `help:"Create control plane with view only permissions."`
 }
 
 // Run executes the attach command.
 func (c *AttachCmd) Run(kong *kong.Context, client *cp.Client, token *tokens.Client, cloudCtx *cloud.Context) error {
-	if c.KubeClusterID == uuid.Nil {
-		ns, err := c.kClient.CoreV1().Namespaces().Get(context.Background(), kubeIDNamespace, metav1.GetOptions{})
-		if err != nil {
-			return errors.Wrap(err, errKubeSystemUID)
-		}
-		c.KubeClusterID, err = uuid.Parse(string(ns.GetObjectMeta().GetUID()))
-		if err != nil {
-			return errors.Wrap(err, errKubeSystemUID)
-		}
-	}
 	cpRes, err := client.Create(context.Background(), &cp.ControlPlaneCreateParameters{
-		Account:       cloudCtx.Account,
-		Name:          c.Name,
-		Description:   c.Description,
-		SelfHosted:    true,
-		KubeClusterID: c.KubeClusterID.String(),
+		Account:     cloudCtx.Account,
+		Name:        c.Name,
+		Description: c.Description,
+		SelfHosted:  true,
 	})
 	if err != nil {
 		return err

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,11 +74,6 @@ Format: `up cloud controlplane <cmd> ...` Alias: `up cloud xp <cmd> ...`
 - `attach <name>`
     - Flags:
       - `-d,--description = STRING`: Control plane description.
-      - `--kube-cluster-id = UUID`: UUID for self-hosted control plane.
-        Auto-populated as `metadata.uid` of `kube-system` `Namespace` of
-        currently configured `kubeconfig` if not manually provided.
-      - `--kubeconfig = STRING`: sets `kubeconfig` path. Same defaults as
-        `kubectl` are used if not provided.
       - `--view-only`: creates the self-hosted control plane as view only.
     - Behavior: Creates a self-hosted control plane on Upbound Cloud and returns
       token to connect a UXP instance to it.


### PR DESCRIPTION
Removes setting the kube cluster ID for a control plane when attaching
self-hosted and instead defers the responsibility to the agent upon
connecting.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #89 

Tested with normal `up cloud xp attach <name> | up uxp connect -` flow and successfully provisioned and connected a self-hosted control plane.