### PR TITLE
Change controlplane alias from xp to ctp

### DIFF
--- a/cmd/up/cloud/cloud.go
+++ b/cmd/up/cloud/cloud.go
@@ -44,7 +44,7 @@ type Cmd struct {
 	Login  loginCmd  `cmd:"" group:"cloud" help:"Login to Upbound Cloud."`
 	Logout logoutCmd `cmd:"" group:"cloud" help:"Logout from Upbound Cloud."`
 
-	ControlPlane controlPlaneCmd `cmd:"" name:"controlplane" aliases:"xp" group:"cloud" help:"Interact with control planes."`
+	ControlPlane controlPlaneCmd `cmd:"" name:"controlplane" aliases:"ctp" group:"cloud" help:"Interact with control planes."`
 
 	Endpoint *url.URL `env:"UP_ENDPOINT" default:"https://api.upbound.io" help:"Endpoint used for Upbound API."`
 	Profile  string   `env:"UP_PROFILE" help:"Profile used to execute command."`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,7 +69,7 @@ may choose not to utilize the group flags when not relevant.
 
 ### Subgroup: Control Plane
 
-Format: `up cloud controlplane <cmd> ...` Alias: `up cloud xp <cmd> ...`
+Format: `up cloud controlplane <cmd> ...` Alias: `up cloud ctp <cmd> ...`
 
 - `attach <name>`
     - Flags:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -82,7 +82,7 @@ $ up cloud controlplane create my-hosted-cp
 ```
 
 ```
-$ up cloud xp create my-hosted-cp
+$ up cloud ctp create my-hosted-cp
 ```
 
 ## Self-Hosted Control Plane
@@ -158,14 +158,14 @@ $ up cloud controlplane attach my-self-hosted-cp
 ```
 
 ```
-$ up cloud xp attach my-self-hosted-cp
+$ up cloud ctp attach my-self-hosted-cp
 <control-plane-token>
 ```
 
 Self-hosted control planes can be created with "view only" permissions:
 
 ```
-$ up cloud xp attach my-self-hosted-cp --view-only
+$ up cloud ctp attach my-self-hosted-cp --view-only
 <control-plane-token>
 ```
 
@@ -184,7 +184,7 @@ $ up cloud controlplane attach my-self-hosted-cp | up uxp connect -
 ```
 
 ```
-$ up cloud xp attach my-self-hosted-cp | up uxp connect -
+$ up cloud ctp attach my-self-hosted-cp | up uxp connect -
 ```
 
 <!-- Named Links -->


### PR DESCRIPTION
The xp shorthand for control plane is confusing because xp is associated
with Crossplane. This updates to instead use ctp which maps closer to
the actual term and does not create conceptual conflicts.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

**NOTE: this is a breaking syntax change, but all functionality is still achievable.**