### PR TITLE
Add support for managing control plane tokens

### DIFF
--- a/cmd/up/cloud/controlplane.go
+++ b/cmd/up/cloud/controlplane.go
@@ -23,6 +23,7 @@ import (
 	"github.com/upbound/up-sdk-go/service/tokens"
 
 	"github.com/upbound/up/cmd/up/cloud/controlplane"
+	"github.com/upbound/up/cmd/up/cloud/controlplane/token"
 	"github.com/upbound/up/internal/cloud"
 	"github.com/upbound/up/internal/config"
 )
@@ -76,4 +77,6 @@ type controlPlaneCmd struct {
 	Create controlplane.CreateCmd `cmd:"" help:"Create a hosted control plane."`
 	Delete controlplane.DeleteCmd `cmd:"" help:"Delete a control plane."`
 	List   controlplane.ListCmd   `cmd:"" help:"List control planes for the account."`
+
+	Token token.Cmd `cmd:"" name:"token" help:"Interact with control plane tokens."`
 }

--- a/cmd/up/cloud/controlplane/attach.go
+++ b/cmd/up/cloud/controlplane/attach.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/alecthomas/kong"
+	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/pkg/errors"
 
 	// Allow auth to all
@@ -63,7 +64,7 @@ func (c *AttachCmd) Run(kong *kong.Context, client *cp.Client, token *tokens.Cli
 	}
 	tRes, err := token.Create(context.Background(), &tokens.TokenCreateParameters{
 		Attributes: tokens.TokenAttributes{
-			Name: c.Name,
+			Name: namesgenerator.GetRandomName(0),
 		},
 		Relationships: tokens.TokenRelationships{
 			Owner: tokens.TokenOwner{
@@ -82,5 +83,5 @@ func (c *AttachCmd) Run(kong *kong.Context, client *cp.Client, token *tokens.Cli
 		return errors.New(errNoToken)
 	}
 	fmt.Fprintf(kong.Stdout, "%s\n", jwt)
-	return err
+	return nil
 }

--- a/cmd/up/cloud/controlplane/token/create.go
+++ b/cmd/up/cloud/controlplane/token/create.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"github.com/docker/docker/pkg/namesgenerator"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/upbound/up-sdk-go/service/tokens"
+	"github.com/upbound/up/internal/cloud"
+)
+
+const (
+	jwtKey = "jwt"
+
+	errNoToken = "could not identify token in response"
+)
+
+// AfterApply constructs and binds Upbound-specific context to any subcommands
+// that have Run() methods that receive it.
+func (c *createCmd) AfterApply(ctx *kong.Context) error {
+	if c.Name == "" {
+		c.Name = namesgenerator.GetRandomName(0)
+	}
+	return nil
+}
+
+// createCmd creates a control plane token on Upbound Cloud.
+type createCmd struct {
+	ID uuid.UUID `arg:"" required:"" help:"ID of control plane."`
+
+	Name string `help:"Name of control plane token."`
+}
+
+// Run executes the create command.
+func (c *createCmd) Run(kong *kong.Context, client *tokens.Client, cloudCtx *cloud.Context) error {
+	tRes, err := client.Create(context.Background(), &tokens.TokenCreateParameters{
+		Attributes: tokens.TokenAttributes{
+			Name: c.Name,
+		},
+		Relationships: tokens.TokenRelationships{
+			Owner: tokens.TokenOwner{
+				Data: tokens.TokenOwnerData{
+					Type: tokens.TokenOwnerControlPlane,
+					ID:   c.ID,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	jwt, ok := tRes.DataSet.Meta[jwtKey]
+	if !ok {
+		return errors.New(errNoToken)
+	}
+	fmt.Fprintf(kong.Stdout, "%s\n", jwt)
+	return nil
+}

--- a/cmd/up/cloud/controlplane/token/create.go
+++ b/cmd/up/cloud/controlplane/token/create.go
@@ -44,7 +44,7 @@ func (c *createCmd) AfterApply(ctx *kong.Context) error {
 
 // createCmd creates a control plane token on Upbound Cloud.
 type createCmd struct {
-	ID uuid.UUID `arg:"" required:"" help:"ID of control plane."`
+	ID uuid.UUID `arg:"" name:"control-plane-ID" required:"" help:"ID of control plane."`
 
 	Name string `help:"Name of control plane token."`
 }

--- a/cmd/up/cloud/controlplane/token/delete.go
+++ b/cmd/up/cloud/controlplane/token/delete.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"context"
+
+	"github.com/alecthomas/kong"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/upbound/up-sdk-go/service/tokens"
+	"github.com/upbound/up/internal/cloud"
+)
+
+const (
+	errDeleteCPToken = "failed to delete control plane token"
+)
+
+// deleteCmd deletes a control plane token on Upbound Cloud.
+type deleteCmd struct {
+	ID uuid.UUID `arg:"" required:"" help:"ID of token."`
+}
+
+// Run executes the delete command.
+func (c *deleteCmd) Run(kong *kong.Context, client *tokens.Client, cloudCtx *cloud.Context) error {
+	return errors.Wrap(client.Delete(context.Background(), c.ID), errDeleteCPToken)
+}

--- a/cmd/up/cloud/controlplane/token/delete.go
+++ b/cmd/up/cloud/controlplane/token/delete.go
@@ -31,7 +31,7 @@ const (
 
 // deleteCmd deletes a control plane token on Upbound Cloud.
 type deleteCmd struct {
-	ID uuid.UUID `arg:"" required:"" help:"ID of token."`
+	ID uuid.UUID `arg:"" name:"token-ID" required:"" help:"ID of token."`
 }
 
 // Run executes the delete command.

--- a/cmd/up/cloud/controlplane/token/list.go
+++ b/cmd/up/cloud/controlplane/token/list.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"github.com/google/uuid"
+	"k8s.io/cli-runtime/pkg/printers"
+
+	cp "github.com/upbound/up-sdk-go/service/controlplanes"
+
+	"github.com/upbound/up/internal/cloud"
+)
+
+const (
+	listRowFormat = "%v\t%v\t%v\n"
+
+	resNoTokens = "No tokens found for control plane."
+)
+
+// listCmd lists tokens for a control plane on Upbound Cloud.
+type listCmd struct {
+	ID uuid.UUID `arg:"" required:"" help:"ID of control plane."`
+}
+
+// Run executes the list command.
+func (c *listCmd) Run(kong *kong.Context, client *cp.Client, cloudCtx *cloud.Context) error {
+	res, err := client.GetTokens(context.Background(), c.ID)
+	if err != nil {
+		return err
+	}
+	if res == nil || len(res.DataSet) == 0 {
+		fmt.Fprintf(kong.Stdout, "%s\n", resNoTokens)
+		return nil
+	}
+	w := printers.GetNewTabWriter(kong.Stdout)
+	fmt.Fprintf(w, listRowFormat, "ID", "NAME", "CREATED")
+	for _, token := range res.DataSet {
+		fmt.Fprintf(w, listRowFormat, token.ID, token.AttributeSet["name"], token.Meta["createdAt"])
+	}
+	return w.Flush()
+}

--- a/cmd/up/cloud/controlplane/token/list.go
+++ b/cmd/up/cloud/controlplane/token/list.go
@@ -35,7 +35,7 @@ const (
 
 // listCmd lists tokens for a control plane on Upbound Cloud.
 type listCmd struct {
-	ID uuid.UUID `arg:"" required:"" help:"ID of control plane."`
+	ID uuid.UUID `arg:"" name:"control-plane-ID" required:"" help:"ID of control plane."`
 }
 
 // Run executes the list command.

--- a/cmd/up/cloud/controlplane/token/token.go
+++ b/cmd/up/cloud/controlplane/token/token.go
@@ -1,0 +1,22 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package token
+
+// Cmd contains commands for interacting with control plane tokens.
+type Cmd struct {
+	Create createCmd `cmd:"" help:"Create a control plane token."`
+	Delete deleteCmd `cmd:"" help:"Delete a control plane token."`
+	List   listCmd   `cmd:"" help:"List tokens for the control plane."`
+}

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/alecthomas/kong"
 
@@ -47,6 +49,7 @@ var cli struct {
 }
 
 func main() {
+	rand.Seed(time.Now().UTC().UnixNano())
 	ctx := kong.Parse(&cli,
 		kong.Name("up"),
 		kong.Description("The Upbound CLI"),

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -77,7 +77,8 @@ Format: `up cloud controlplane <cmd> ...` Alias: `up cloud ctp <cmd> ...`
       - `-d,--description = STRING`: Control plane description.
       - `--view-only`: creates the self-hosted control plane as view only.
     - Behavior: Creates a self-hosted control plane on Upbound Cloud and returns
-      token to connect a UXP instance to it.
+      token to connect a UXP instance to it. The name of the token is randomly
+      generated.
 - `create <name>`
     - Flags:
         - `--description = STRING`: Control plane description.
@@ -90,6 +91,21 @@ Format: `up cloud controlplane <cmd> ...` Alias: `up cloud ctp <cmd> ...`
 - `list`
     - Behavior: Lists all control planes for the
       configured account.
+
+**Subgroup: Token**
+
+Format: `up cloud controlplane token <cmd> ...` Alias: `up cloud ctp token <cmd>...`
+
+- `create <control-plane-ID>`
+    - Flags:
+        - `--name = STRING`: Name of control plane token. Name is randomly
+          generated if not specified.
+    - Behavior: Creates a token for the specified self-hosted control plane ID
+      and prints it to stdout.
+- `delete <token-ID>`
+    - Behavior: Deletes the control plane token with the specified ID.
+- `list <control-plane-ID>`
+    - Behavior: Lists all tokens for the specified control plane.
 
 ## UXP
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/crossplane/crossplane v1.2.2
 	github.com/crossplane/crossplane-runtime v0.13.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/docker/docker v17.12.0-ce-rc1.0.20200926000217-2617742802f6+incompatible
 	github.com/google/addlicense v0.0.0-20210428195630-6d92264d7170
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-containerregistry v0.5.1


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds support for managing control plane tokens in the form of the following commands:

```
cloud
  cloud controlplane token create <control-plane-ID>
    Create a control plane token.

  cloud controlplane token delete <token-ID>
    Delete a control plane token.

  cloud controlplane token list <control-plane-ID>
    List tokens for the control plane.

```

Fixes #88 
Fixes #49 (I am suggesting closing #49 with this as I believe it is a better experience to use `up cloud ctp token create` while we don't have uniqueness in control plane names on Upbound Cloud)

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Tested against self-hosted control planes on Upbound Cloud:

1. Attach cluster
```
🤖 (up) up cloud ctp attach test | up uxp connect -
```
2. List control planes
```
🤖 (up) up cloud ctp list
NAME   ID                                     SELF-HOSTED
test   d0503a32-ad7d-4e3f-8734-9359e3317ca8   true
```
3. List tokens for control plane
```
🤖 (up) up cloud ctp token list d0503a32-ad7d-4e3f-8734-9359e3317ca8
ID                                     NAME          CREATED
50a85d4f-6cf4-4d26-a1a0-43449a07ad62   nice_keller   2021-06-17T18:05:45Z
```
4. Create another control plane token
```
🤖 (up) up cloud ctp token create d0503a32-ad7d-4e3f-8734-9359e3317ca8
<redacted>
```
5. List control plane tokens
```
🤖 (up) up cloud ctp token list d0503a32-ad7d-4e3f-8734-9359e3317ca8
ID                                     NAME                CREATED
50a85d4f-6cf4-4d26-a1a0-43449a07ad62   nice_keller         2021-06-17T18:05:45Z
b2b646de-26c4-4fb0-93b3-8085342b5c43   magical_ramanujan   2021-06-17T18:07:21Z
```
6. Create named token
```
🤖 (up) up cloud ctp token create d0503a32-ad7d-4e3f-8734-9359e3317ca8 --name=test-token
<redacted>
```
7. List control plane tokens
```
🤖 (up) up cloud ctp token list d0503a32-ad7d-4e3f-8734-9359e3317ca8
ID                                     NAME                CREATED
50a85d4f-6cf4-4d26-a1a0-43449a07ad62   nice_keller         2021-06-17T18:05:45Z
b2b646de-26c4-4fb0-93b3-8085342b5c43   magical_ramanujan   2021-06-17T18:07:21Z
d04657f4-22bc-4f31-bfdf-33a128f2d9b3   test-token          2021-06-17T18:08:45Z
```
8. Delete a token
```
🤖 (up) up cloud ctp token delete 50a85d4f-6cf4-4d26-a1a0-43449a07ad62
```
9. List control plane tokens
```
🤖 (up) up cloud ctp token list d0503a32-ad7d-4e3f-8734-9359e3317ca8
ID                                     NAME                CREATED
b2b646de-26c4-4fb0-93b3-8085342b5c43   magical_ramanujan   2021-06-17T18:07:21Z
d04657f4-22bc-4f31-bfdf-33a128f2d9b3   test-token          2021-06-17T18:08:45Z
```