### PR TITLE
Cache latest chart with proper version on install and upgrade

### DIFF
--- a/internal/uxp/installers/helm/helm.go
+++ b/internal/uxp/installers/helm/helm.go
@@ -351,7 +351,7 @@ func (h *installer) Uninstall() error {
 	return err
 }
 
-// pullAndLoad pulls and loads a chart or fetches it from the catch.
+// pullAndLoad pulls and loads a chart or fetches it from the cache.
 func (h *installer) pullAndLoad(version string) (*chart.Chart, error) { //nolint:gocyclo
 	// check to see if version is cached
 	if version != "" {


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Currently, when a version is not specified on uxp install or upgrade, we
pull the latest stable chart and cache it without version information in
the dedicated uxp chart cache. This means that if a version that was
installed as the latest was subsequently installed explicitly (i.e. by
providing the version), we would unnecessarily pull the chart again when
it was already in the cache.

This updates the pull logic to save charts pulled as latest with their
appropriate version so that they can be identified in future installs.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I removed the chart cache (`rm -rf ~/.cache/up/charts`), then ran `up uxp install` (with no version specified) and observed the proper versioned chart in the cache:

```
🤖 (up) ls ~/.cache/up/charts/
universal-crossplane-1.2.2-up.1.tgz
```
