### PR TITLE
Support population of kubeconfig files

### DIFF
--- a/cmd/up/cloud/controlplane.go
+++ b/cmd/up/cloud/controlplane.go
@@ -23,6 +23,7 @@ import (
 	"github.com/upbound/up-sdk-go/service/tokens"
 
 	"github.com/upbound/up/cmd/up/cloud/controlplane"
+	"github.com/upbound/up/cmd/up/cloud/controlplane/kubeconfig"
 	"github.com/upbound/up/cmd/up/cloud/controlplane/token"
 	"github.com/upbound/up/internal/cloud"
 	"github.com/upbound/up/internal/config"
@@ -78,5 +79,6 @@ type controlPlaneCmd struct {
 	Delete controlplane.DeleteCmd `cmd:"" help:"Delete a control plane."`
 	List   controlplane.ListCmd   `cmd:"" help:"List control planes for the account."`
 
-	Token token.Cmd `cmd:"" name:"token" help:"Interact with control plane tokens."`
+	Kubeconfig kubeconfig.Cmd `cmd:"" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
+	Token      token.Cmd      `cmd:"" name:"token" help:"Interact with control plane tokens."`
 }

--- a/cmd/up/cloud/controlplane/kubeconfig/get.go
+++ b/cmd/up/cloud/controlplane/kubeconfig/get.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeconfig
+
+import (
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/alecthomas/kong"
+	"github.com/google/uuid"
+
+	"github.com/upbound/up/internal/cloud"
+	"github.com/upbound/up/internal/kube"
+)
+
+// AfterApply sets default values in command before assignment and validation.
+func (c *getCmd) AfterApply() error {
+	c.stdin = os.Stdin
+	return nil
+}
+
+// getCmd gets kubeconfig data for an Upbound Cloud control plane.
+type getCmd struct {
+	stdin io.Reader
+
+	File  string   `type:"path" short:"f" help:"File to merge kubeconfig."`
+	Proxy *url.URL `env:"UP_PROXY" default:"https://proxy.upbound.io/env" help:"Endpoint used for Upbound Proxy."`
+	Token string   `required:"" help:"API token used to authenticate."`
+
+	ID uuid.UUID `arg:"" name:"control-plane-ID" required:"" help:"ID of control plane."`
+}
+
+// Run executes the get command.
+func (c *getCmd) Run(kong *kong.Context, cloudCtx *cloud.Context) error {
+	// TODO(hasheddan): consider implementing a custom decoder
+	if c.Token == "-" {
+		b, err := io.ReadAll(c.stdin)
+		if err != nil {
+			return err
+		}
+		c.Token = string(b)
+	}
+	return kube.BuildControlPlaneKubeconfig(c.Proxy, c.ID, c.Token, c.File)
+}

--- a/cmd/up/cloud/controlplane/kubeconfig/get.go
+++ b/cmd/up/cloud/controlplane/kubeconfig/get.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/google/uuid"
@@ -51,7 +52,7 @@ func (c *getCmd) Run(kong *kong.Context, cloudCtx *cloud.Context) error {
 		if err != nil {
 			return err
 		}
-		c.Token = string(b)
+		c.Token = strings.TrimSpace(string(b))
 	}
 	return kube.BuildControlPlaneKubeconfig(c.Proxy, c.ID, c.Token, c.File)
 }

--- a/cmd/up/cloud/controlplane/kubeconfig/kubeconfig.go
+++ b/cmd/up/cloud/controlplane/kubeconfig/kubeconfig.go
@@ -1,0 +1,20 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeconfig
+
+// Cmd contains commands for managing control plane kubeconfig data.
+type Cmd struct {
+	Get getCmd `cmd:"" help:"Get a kubeconfig for a control plane."`
+}

--- a/cmd/up/uxp/connect.go
+++ b/cmd/up/uxp/connect.go
@@ -62,7 +62,7 @@ func (c *connectCmd) Run(kong *kong.Context, uxpCtx *uxp.Context) error {
 		if err != nil {
 			return err
 		}
-		c.CPToken = string(b)
+		c.CPToken = strings.TrimSpace(string(b))
 	}
 	// Remove any trailing newlines from token, which can make piping output
 	// from other commands more convenient.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -92,6 +92,24 @@ Format: `up cloud controlplane <cmd> ...` Alias: `up cloud ctp <cmd> ...`
     - Behavior: Lists all control planes for the
       configured account.
 
+**Subgroup: Kubeconfig**
+
+Format: `up cloud controlplane kubeconfig <cmd> ...` Alias: `up cloud ctp kubeconfig <cmd>...`
+
+- `get <control-plane-ID>`
+    - Flags:
+        - `--token = STRING` (*Required*): API token for authenticating to
+          control plane. If `-` is given the value will be read from stdin.
+        - `-f,--file = FILE`: File to merge `kubeconfig`.
+        - `--proxy = URL` (Env: `UP_PROXY`) (Default:
+          `https://proxy.upbound.io/env`): Endpoint for Upbound control plane
+          proxy.
+    - Behavior: Merges control plane cluster and authentication data into
+      currently configured `kubeconfig`, or one specified by `--file`. The
+      `--token` flag must be provided and must be a valid Upbound API token. A
+      new context will be created for the cluster and authentication data and it
+      will be set as current.
+
 **Subgroup: Token**
 
 Format: `up cloud controlplane token <cmd> ...` Alias: `up cloud ctp token <cmd>...`


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds support for merging `kubeconfig` data for a control plane into local `kubeconfig`.

Fixes #86 

All keys in the new `kubeconfig` entries are structured as `upbound-<control-plane-id>`

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Tested the following scenarios:
- Merge into existing default `kubeconfig` and verify that other entries are not overwritten:
```
cat token.txt | up cloud ctp kubeconfig get 7a25b9a5-43a9-474a-a92d-f2afe839095b --token=-
🤖 (up) k get pods -A
NAMESPACE        NAME                                      READY   STATUS    RESTARTS   AGE
upbound-system   crossplane-8644547dfd-ptwwx               1/1     Running   0          3h19m
upbound-system   crossplane-rbac-manager-57b44db5d-xt76w   1/1     Running   0          3h19m
upbound-system   upbound-agent-59f5c67c64-zrrjt            1/1     Running   0          3h19m
upbound-system   upbound-bootstrapper-69478b8c87-86lmh     1/1     Running   0          3h19m
upbound-system   xgql-67585677b9-8285b                     1/1     Running   2          3h19m
```
- Create new kubeconfig:
```
cat token.txt | up cloud ctp kubeconfig get 7a25b9a5-43a9-474a-a92d-f2afe839095b --token=- -f kube.conf
🤖 (up) k get pods -A --kubeconfig=kube.conf
NAMESPACE        NAME                                      READY   STATUS    RESTARTS   AGE
upbound-system   crossplane-8644547dfd-ptwwx               1/1     Running   0          3h19m
upbound-system   crossplane-rbac-manager-57b44db5d-xt76w   1/1     Running   0          3h19m
upbound-system   upbound-agent-59f5c67c64-zrrjt            1/1     Running   0          3h19m
upbound-system   upbound-bootstrapper-69478b8c87-86lmh     1/1     Running   0          3h19m
upbound-system   xgql-67585677b9-8285b                     1/1     Running   2          3h19m
```