### PR TITLE
Show status when listing control planes

### DIFF
--- a/cmd/up/cloud/controlplane/list.go
+++ b/cmd/up/cloud/controlplane/list.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	listRowFormat = "%v\t%v\t%v\n"
+	listRowFormat = "%v\t%v\t%v\t%v\n"
 )
 
 // ListCmd list control planes in an account on Upbound Cloud.
@@ -43,9 +43,9 @@ func (c *ListCmd) Run(kong *kong.Context, client *accounts.Client, cloudCtx *clo
 		return nil
 	}
 	w := printers.GetNewTabWriter(kong.Stdout)
-	fmt.Fprintf(w, listRowFormat, "NAME", "ID", "SELF-HOSTED")
+	fmt.Fprintf(w, listRowFormat, "NAME", "ID", "SELF-HOSTED", "STATUS")
 	for _, cp := range cps {
-		fmt.Fprintf(w, listRowFormat, cp.ControlPlane.Name, cp.ControlPlane.ID, cp.ControlPlane.SelfHosted)
+		fmt.Fprintf(w, listRowFormat, cp.ControlPlane.Name, cp.ControlPlane.ID, cp.ControlPlane.SelfHosted, cp.Status)
 	}
 	return w.Flush()
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the control plane table output to include the status of each
control plane.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #103 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up) up cloud ctp list -a dan
NAME      ID                                     SELF-HOSTED   STATUS
testing   a463eb73-c0db-4ff7-b1e5-b4262808c4be   false         ready
🤖 (up) up cloud ctp create two -a dan
🤖 (up) up cloud ctp list -a dan
NAME      ID                                     SELF-HOSTED   STATUS
two       82232a45-595a-4727-acfa-b165900ad6f2   false         provisioning
testing   a463eb73-c0db-4ff7-b1e5-b4262808c4be   false         ready
🤖 (up) up cloud ctp delete 82232a45-595a-4727-acfa-b165900ad6f2
🤖 (up) up cloud ctp delete list -a dan
NAME      ID                                     SELF-HOSTED   STATUS
two       82232a45-595a-4727-acfa-b165900ad6f2   false         deleting
testing   a463eb73-c0db-4ff7-b1e5-b4262808c4be   false         ready
```