### PR TITLE
Use controlPlanes proxy endpoint as default

### DIFF
--- a/cmd/up/cloud/controlplane/kubeconfig/get.go
+++ b/cmd/up/cloud/controlplane/kubeconfig/get.go
@@ -38,7 +38,7 @@ type getCmd struct {
 	stdin io.Reader
 
 	File  string   `type:"path" short:"f" help:"File to merge kubeconfig."`
-	Proxy *url.URL `env:"UP_PROXY" default:"https://proxy.upbound.io/env" help:"Endpoint used for Upbound Proxy."`
+	Proxy *url.URL `env:"UP_PROXY" default:"https://proxy.upbound.io/controlPlanes" help:"Endpoint used for Upbound Proxy."`
 	Token string   `required:"" help:"API token used to authenticate."`
 
 	ID uuid.UUID `arg:"" name:"control-plane-ID" required:"" help:"ID of control plane."`


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the proxy endpoint default to use controlPlanes instead of the
noew deprecated env endpoint.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Executed same steps as https://github.com/upbound/up/pull/102