### PR TITLE
Support for installing/upgrading charts from local files & dirs

### DIFF
--- a/cmd/up/uxp/common.go
+++ b/cmd/up/uxp/common.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uxp
+
+import "os"
+
+// ChartParams common parameters for installing/upgrading charts
+type ChartParams struct {
+	Unstable bool              `help:"Allow installing unstable UXP versions."`
+	Set      map[string]string `help:"Set Helm parameters."`
+	File     *os.File          `short:"f" help:"Helm parameters file."`
+	Chart    *os.File          `help:"Chart archive file."`
+}

--- a/cmd/up/uxp/common.go
+++ b/cmd/up/uxp/common.go
@@ -19,7 +19,7 @@ import "os"
 // ChartParams common parameters for installing/upgrading charts
 type ChartParams struct {
 	Unstable bool              `help:"Allow installing unstable UXP versions."`
-	Set      map[string]string `help:"Set Helm parameters."`
-	File     *os.File          `short:"f" help:"Helm parameters file."`
-	Chart    *os.File          `help:"Chart archive file."`
+	Set      map[string]string `help:"Set parameters."`
+	File     *os.File          `short:"f" help:"Parameters file."`
+	Bundle   *os.File          `help:"Local bundle path."`
 }

--- a/cmd/up/uxp/install.go
+++ b/cmd/up/uxp/install.go
@@ -17,7 +17,6 @@ package uxp
 import (
 	"context"
 	"io"
-	"os"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -39,7 +38,8 @@ const (
 func (c *installCmd) AfterApply(uxpCtx *uxp.Context) error {
 	installer, err := helm.NewInstaller(uxpCtx.Kubeconfig,
 		helm.WithNamespace(uxpCtx.Namespace),
-		helm.AllowUnstableVersions(c.Unstable))
+		helm.AllowUnstableVersions(c.Unstable),
+		helm.WithChart(c.Chart))
 	if err != nil {
 		return err
 	}
@@ -75,9 +75,7 @@ type installCmd struct {
 
 	Version string `arg:"" optional:"" help:"UXP version to install."`
 
-	Unstable bool              `help:"Allow installing unstable UXP versions."`
-	Set      map[string]string `help:"Set install parameters."`
-	File     *os.File          `short:"f" help:"Parameters file for install."`
+	ChartParams
 }
 
 // Run executes the install command.

--- a/cmd/up/uxp/install.go
+++ b/cmd/up/uxp/install.go
@@ -39,7 +39,7 @@ func (c *installCmd) AfterApply(uxpCtx *uxp.Context) error {
 	installer, err := helm.NewInstaller(uxpCtx.Kubeconfig,
 		helm.WithNamespace(uxpCtx.Namespace),
 		helm.AllowUnstableVersions(c.Unstable),
-		helm.WithChart(c.Chart))
+		helm.WithChart(c.Bundle))
 	if err != nil {
 		return err
 	}

--- a/cmd/up/uxp/upgrade.go
+++ b/cmd/up/uxp/upgrade.go
@@ -16,7 +16,6 @@ package uxp
 
 import (
 	"io"
-	"os"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
@@ -34,6 +33,7 @@ func (c *upgradeCmd) AfterApply(uxpCtx *uxp.Context) error {
 	installer, err := helm.NewInstaller(uxpCtx.Kubeconfig,
 		helm.WithNamespace(uxpCtx.Namespace),
 		helm.AllowUnstableVersions(c.Unstable),
+		helm.WithChart(c.Chart),
 		helm.RollbackOnError(c.Rollback),
 		helm.Force(c.Force))
 	if err != nil {
@@ -65,11 +65,10 @@ type upgradeCmd struct {
 
 	Version string `arg:"" optional:"" help:"UXP version to upgrade to."`
 
-	Rollback bool              `help:"Rollback to previously installed version on failed upgrade."`
-	Unstable bool              `help:"Allow upgrading to unstable UXP versions."`
-	Set      map[string]string `help:"Set upgrade parameters."`
-	File     *os.File          `short:"f" help:"Parameters file for upgrade."`
-	Force    bool              `help:"Force upgrade even if versions are incompatible."`
+	Rollback bool `help:"Rollback to previously installed version on failed upgrade."`
+	Force    bool `help:"Force upgrade even if versions are incompatible."`
+
+	ChartParams
 }
 
 // Run executes the upgrade command.

--- a/cmd/up/uxp/upgrade.go
+++ b/cmd/up/uxp/upgrade.go
@@ -33,7 +33,7 @@ func (c *upgradeCmd) AfterApply(uxpCtx *uxp.Context) error {
 	installer, err := helm.NewInstaller(uxpCtx.Kubeconfig,
 		helm.WithNamespace(uxpCtx.Namespace),
 		helm.AllowUnstableVersions(c.Unstable),
-		helm.WithChart(c.Chart),
+		helm.WithChart(c.Bundle),
 		helm.RollbackOnError(c.Rollback),
 		helm.Force(c.Force))
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
This PR adds support for installing/upgrading crossplane (or uxp) charts from a local  chart archive or a local directory. The local chart to be processed can be specified with the `--bundle` command-line option.

Note: I'm planning to use the changes in this PR in the demo, and I believe it could prove to be useful for development scenarios. If this functionality is already provided by other means, or if you believe it's not appropriate, we can close this PR.


I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Manually tested installing a downloaded UXP chart both from an archive and from a folder containing extracted contents. Also  verified installations & upgrades from a Helm repo still work.