### PR TITLE
Remove cloud from up logout command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ other configuration data.
 days by default, meaning that a user must login at least once in any 30 day
 period. Tokens are sensitive and should not be exposed in any setting. However,
 if a token is exposed, assuming it is still present for the given profile in the
-configuration file, it can be revoked by running `up cloud logout --profile
+configuration file, it can be revoked by running `up logout --profile
 <profile-name>`. If a token is exposed and it is no longer present in the
 profile and cannot be retrieved for any reason, the user account should reset
 its password on [Upbound Cloud] immediately. This can be accomplished today by


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Removes the cloud subcommand from up logout as it is no longer valid in
the latest releases.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

n/a