### PR TITLE
Add support for v1alpha1 Configuration and Provider types

### DIFF
--- a/internal/xpkg/dep/manager/utils.go
+++ b/internal/xpkg/dep/manager/utils.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	metav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
+	metav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 )
 
@@ -35,4 +36,20 @@ func ConvertToV1beta1(in metav1.Dependency) v1beta1.Dependency {
 	}
 
 	return betaD
+}
+
+// ConvertToV1alpha1 converts v1.Dependency types to v1alpha1.Dependency types.
+func ConvertToV1alpha1(in metav1.Dependency) metav1alpha1.Dependency {
+	alphaD := metav1alpha1.Dependency{
+		Version: in.Version,
+	}
+	if in.Provider != nil && in.Configuration == nil {
+		alphaD.Provider = in.Provider
+	}
+
+	if in.Configuration != nil && in.Provider == nil {
+		alphaD.Configuration = in.Configuration
+	}
+
+	return alphaD
 }

--- a/internal/xpkg/snapshot/deprecation_test.go
+++ b/internal/xpkg/snapshot/deprecation_test.go
@@ -1,0 +1,116 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	metav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
+	metav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
+
+	"github.com/upbound/up/internal/xpkg/snapshot/validator"
+)
+
+func TestAPIVersionDeprecation(t *testing.T) {
+	type args struct {
+		o runtime.Object
+	}
+	type want struct {
+		err *validator.Validation
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"V1alpha1Configuration": {
+			reason: "Should return a deprecation warning.",
+			args: args{
+				o: &metav1alpha1.Configuration{
+					TypeMeta: v1.TypeMeta{
+						Kind:       metav1alpha1.ConfigurationKind,
+						APIVersion: metav1alpha1.SchemeGroupVersion.String(),
+					},
+				},
+			},
+			want: want{
+				err: &validator.Validation{
+					TypeCode: validator.WarningTypeCode,
+					Message:  "meta.pkg.crossplane.io/v1alpha1 is deprecated in favor of meta.pkg.crossplane.io/v1",
+					Name:     "apiVersion",
+				},
+			},
+		},
+		"V1alpha1Provider": {
+			reason: "Should return a deprecation warning.",
+			args: args{
+				o: &metav1alpha1.Provider{
+					TypeMeta: v1.TypeMeta{
+						Kind:       metav1alpha1.ProviderKind,
+						APIVersion: metav1alpha1.SchemeGroupVersion.String(),
+					},
+				},
+			},
+			want: want{
+				err: &validator.Validation{
+					TypeCode: validator.WarningTypeCode,
+					Message:  "meta.pkg.crossplane.io/v1alpha1 is deprecated in favor of meta.pkg.crossplane.io/v1",
+					Name:     "apiVersion",
+				},
+			},
+		},
+		"V1Configuration": {
+			reason: "Should return a deprecation warning.",
+			args: args{
+				o: &metav1.Configuration{
+					TypeMeta: v1.TypeMeta{
+						Kind:       metav1.ConfigurationKind,
+						APIVersion: metav1.SchemeGroupVersion.String(),
+					},
+				},
+			},
+		},
+		"V1Provider": {
+			reason: "Should return a deprecation warning.",
+			args: args{
+				o: &metav1.Provider{
+					TypeMeta: v1.TypeMeta{
+						Kind:       metav1.ProviderKind,
+						APIVersion: metav1.SchemeGroupVersion.String(),
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			err := validateAPIVersion(tc.args.o)
+
+			if err != nil {
+				if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+					t.Errorf("\n%s\nAPIVersionDeprecation(...): -want error, +got error:\n%s", tc.reason, diff)
+				}
+			}
+		})
+	}
+}

--- a/internal/xpkg/snapshot/validator.go
+++ b/internal/xpkg/snapshot/validator.go
@@ -31,8 +31,8 @@ import (
 
 	xpextv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	xpextv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
-	v1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
-	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
+	metav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
+	metav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 
 	"github.com/upbound/up/internal/xpkg/snapshot/validator"
 )
@@ -64,20 +64,20 @@ func (s *Snapshot) ValidatorsForObj(o runtime.Object) (map[schema.GroupVersionKi
 		if err := validatorsFromV1XRD(rd, validators); err != nil {
 			return nil, err
 		}
-	case *v1.Configuration:
+	case *metav1.Configuration:
 		if err := s.validatorsForV1Configuration(rd, validators); err != nil {
 			return nil, err
 		}
-	case *v1beta1.Configuration:
-		if err := s.validatorsForV1Beta1Configuration(rd, validators); err != nil {
+	case *metav1alpha1.Configuration:
+		if err := s.validatorsForV1Alpha1Configuration(rd, validators); err != nil {
 			return nil, err
 		}
-	case *v1.Provider:
+	case *metav1.Provider:
 		if err := s.validatorsForV1Provider(rd, validators); err != nil {
 			return nil, err
 		}
-	case *v1beta1.Provider:
-		if err := s.validatorsForV1Beta1Provider(rd, validators); err != nil {
+	case *metav1alpha1.Provider:
+		if err := s.validatorsForV1Alpha1Provider(rd, validators); err != nil {
 			return nil, err
 		}
 	default:
@@ -167,7 +167,7 @@ func validatorsFromV1XRD(x *xpextv1.CompositeResourceDefinition, acc map[schema.
 	return nil
 }
 
-func (s *Snapshot) validatorsForV1Configuration(c *v1.Configuration, acc map[schema.GroupVersionKind]validator.Validator) error {
+func (s *Snapshot) validatorsForV1Configuration(c *metav1.Configuration, acc map[schema.GroupVersionKind]validator.Validator) error {
 	v, err := DefaultMetaValidators(s)
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (s *Snapshot) validatorsForV1Configuration(c *v1.Configuration, acc map[sch
 	return nil
 }
 
-func (s *Snapshot) validatorsForV1Beta1Configuration(c *v1beta1.Configuration, acc map[schema.GroupVersionKind]validator.Validator) error {
+func (s *Snapshot) validatorsForV1Alpha1Configuration(c *metav1alpha1.Configuration, acc map[schema.GroupVersionKind]validator.Validator) error {
 	v, err := DefaultMetaValidators(s)
 	if err != nil {
 		return err
@@ -185,7 +185,7 @@ func (s *Snapshot) validatorsForV1Beta1Configuration(c *v1beta1.Configuration, a
 	return nil
 }
 
-func (s *Snapshot) validatorsForV1Provider(c *v1.Provider, acc map[schema.GroupVersionKind]validator.Validator) error {
+func (s *Snapshot) validatorsForV1Provider(c *metav1.Provider, acc map[schema.GroupVersionKind]validator.Validator) error {
 	v, err := DefaultMetaValidators(s)
 	if err != nil {
 		return err
@@ -194,7 +194,7 @@ func (s *Snapshot) validatorsForV1Provider(c *v1.Provider, acc map[schema.GroupV
 	return nil
 }
 
-func (s *Snapshot) validatorsForV1Beta1Provider(c *v1beta1.Provider, acc map[schema.GroupVersionKind]validator.Validator) error {
+func (s *Snapshot) validatorsForV1Alpha1Provider(c *metav1alpha1.Provider, acc map[schema.GroupVersionKind]validator.Validator) error {
 	v, err := DefaultMetaValidators(s)
 	if err != nil {
 		return err

--- a/internal/xpkg/snapshot/validator/validator.go
+++ b/internal/xpkg/snapshot/validator/validator.go
@@ -18,6 +18,20 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/validate"
 )
 
+// All code responses can be used to differentiate errors for different handling
+// by the consumer
+const (
+	// WarningTypeCode indicates a warning is being returned.
+	WarningTypeCode = 100
+	// ErrorTypeCode indicates an error is being returned.
+	ErrorTypeCode = 500
+
+	// NOTE(@tnthornton) api-server uses error code 422 and 600+ to indicate
+	// validation errors. As long as we're deferring to their logic for
+	// k8s type validations, we need to be sure to not overload those error
+	// codes.
+)
+
 // Nop is used for no-op validator results.
 var Nop = &validate.Result{}
 
@@ -26,19 +40,19 @@ type Validator interface {
 	Validate(data interface{}) *validate.Result
 }
 
-// MetaValidation represents a failure of a meta file condition.
-type MetaValidation struct {
-	code    int32
-	Message string
-	Name    string
+// Validation represents a failure of a file condition.
+type Validation struct {
+	TypeCode int32
+	Message  string
+	Name     string
 }
 
 // Code returns the code corresponding to the MetaValidation.
-func (e *MetaValidation) Code() int32 {
-	return e.code
+func (e *Validation) Code() int32 {
+	return e.TypeCode
 }
 
-func (e *MetaValidation) Error() string {
+func (e *Validation) Error() string {
 	return e.Message
 }
 


### PR DESCRIPTION
### Description of your changes
Prior to this changeset, when end users would attempt to use `xpls` with a package that was using v1alpha1 of the Configuration or Provider specs a panic would be returned.

Changes made that address this:
- checks were added for the older spec types
   - these changes include recognizing the type, updating the type, as well as performing validations on the type
- validationDiagnostics were updated to account for warnings instead of simply errors in order to communicate to the end user that they were using a deprecated version.   

Fixes #131 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
In addition to general functional testing of validations against the reported problematic repo https://github.com/upbound/platform-ref-azure, functional tests were performed to verify:
- the panic no longer is returned when using v1alpha1
- a warning diagnostic is returned when using v1alpha1 (see screenshot)
- updates to the dependency list from `up xpkg dep` worked with v1alpha1

<img width="934" alt="Screen Shot 2022-01-21 at 1 10 36 PM" src="https://user-images.githubusercontent.com/2375126/150601979-a8d51a7f-d2e6-4eda-81b8-c3cd6cb1fd97.png">

