### PR TITLE
Validate `crossplane.yaml` as part of initialization

### DIFF
--- a/internal/xpkg/workspace/workspace.go
+++ b/internal/xpkg/workspace/workspace.go
@@ -344,6 +344,11 @@ func (v *View) Meta() *meta.Meta {
 	return v.meta
 }
 
+// MetaLocation returns the meta file's location (on disk) in the current View.
+func (v *View) MetaLocation() string {
+	return v.metaLocation
+}
+
 // Nodes returns the View's Nodes.
 func (v *View) Nodes() map[NodeIdentifier]Node {
 	return v.nodes


### PR DESCRIPTION
### Description of your changes
Prior to this change, if an end user opened a package in VS Code and the following were true:
* the file that was opened was not the `crossplane.yaml`
* the end user did not have external dependencies loaded in their cache as defined by the crossplane.yaml

There would be no feedback given to the end user. Nothing.

With this change, we now validate the `crossplane.yaml` during the initialization stage and emit diagnostics async so that if the above occurs, the end user will see their `crossplane.yaml` file turn red and a notice will show up in the problems window.

Fixes #136 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Verified that the expected behavior occurred when working with an empty cache and the file that was open during initialization was not the `crossplane.yaml`.
