### PR TITLE
Remove stale reference to up cloud commands

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,12 +14,12 @@ installations.
 ### Format
 
 `up` allows users to define profiles that contain sets of preferences and
-credentials for interacting with Upbound. This enables easily executing
-commands as different users, or in different accounts. In the example below,
-five profiles are defined: `default`, `dev`, `staging`, `prod`, and `ci`. Any
-`up cloud` commands will use the specified profile when pass `--profile` or
-`UP_PROFILE` is set to its name. If a profile is not set, `up` will use the
-profile specified as `default`, which in this case is actually named `default`.
+credentials for interacting with Upbound. This enables easily executing commands
+as different users, or in different accounts. In the example below, five
+profiles are defined: `default`, `dev`, `staging`, `prod`, and `ci`. Commands
+will use the specified profile when set via the `--profile` flag or `UP_PROFILE`
+environment variable. If a profile is not set, `up` will use the profile
+specified as `default`, which in this case is actually named `default`.
 
 ```json
 {


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Removes a stale reference to an up cloud command and fixes wording of
sentence.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

n/a -- docs