### PR TITLE
Capture validators for XRD if schema def is broken

### DIFF
--- a/internal/xpkg/snapshot/validators.go
+++ b/internal/xpkg/snapshot/validators.go
@@ -39,9 +39,10 @@ import (
 )
 
 const (
-	errFmtGetProps        = "cannot get %q properties from validation schema"
-	errObjectNotKnownType = "object is not a known type"
-	errParseValidation    = "cannot parse validation schema"
+	errFailedToGetValidatorsXRD = "failed to get validators from XRD"
+	errFmtGetProps              = "cannot get %q properties from validation schema"
+	errObjectNotKnownType       = "object is not a known type"
+	errParseValidation          = "cannot parse validation schema"
 )
 
 // ValidatorsForObj returns a mapping of GVK -> validator for the given runtime.Object.
@@ -63,7 +64,8 @@ func ValidatorsForObj(o runtime.Object, s *Snapshot) (map[schema.GroupVersionKin
 		}
 	case *xpextv1.CompositeResourceDefinition:
 		if err := validatorsFromV1XRD(rd, validators); err != nil {
-			return nil, err
+			// XR validators failed we should log this and move on
+			s.log.Debug(errFailedToGetValidatorsXRD, "info", err)
 		}
 		if err := validatorsForV1XRD(rd, validators); err != nil {
 			return nil, err


### PR DESCRIPTION
### Description of your changes
The previous error handling in validators.go would result in the validator for the XRD not being registered if the `openAPIV3Schema` object was invalid. Instead the desired behavior is to note that it happened (log it) and move on to trying to register the XRD's validator.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Verified that diagnostics would render again for a given XRD when an invalid schema definition was presented.
Verified that a warn diagnostic was not returned for the given XRD when an invalid schema definition was presented.
