### PR TITLE
Add up enterprise mail command

### DIFF
--- a/cmd/up/enterprise/enterprise.go
+++ b/cmd/up/enterprise/enterprise.go
@@ -51,6 +51,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 // Cmd contains commands for managing enterprise.
 type Cmd struct {
 	Install   installCmd   `cmd:"" group:"enterprise" help:"Install enterprise."`
+	Mail      mailCmd      `cmd:"" group:"enterprise" help:"[EXPERIMENTAL] Run a local mail portal."`
 	Uninstall uninstallCmd `cmd:"" group:"enterprise" help:"Uninstall enterprise."`
 	Upgrade   upgradeCmd   `cmd:"" group:"enterprise" help:"Upgrade enterprise."`
 

--- a/cmd/up/enterprise/mail.go
+++ b/cmd/up/enterprise/mail.go
@@ -1,0 +1,190 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"html/template"
+	"io"
+	"net/http"
+	"net/mail"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/upbound/up/internal/install"
+)
+
+const (
+	mailSecretType = "type=upbound.io/email"
+	mailMessageKey = "message"
+	mailTmplPath   = "templates/mail.html"
+
+	errGetMessages = "failed to get messages"
+	errBadMessage  = "skipping incorrectly formatted message"
+
+	errGetMessage   = "failed to get message"
+	errParseMessage = "failed to parse message"
+	errReadBody     = "failed to read message body"
+
+	errWriteResponse = "failed to write response"
+
+	failedGetMessages  = "Could not find messages."
+	failedGetMessage   = "Could not get message."
+	failedParseMessage = "Could not parse message."
+)
+
+var reqTimeout = 10 * time.Second
+
+// MailItem is metadata for an email message.
+type MailItem struct {
+	Recipient string
+	Subject   string
+}
+
+//go:embed templates/mail.html
+var f embed.FS
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *mailCmd) AfterApply(insCtx *install.Context) error {
+	c.log = logging.NewLogrLogger(zap.New(zap.UseDevMode(c.Verbose)))
+	client, err := kubernetes.NewForConfig(insCtx.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	c.kClient = client
+	c.ns = insCtx.Namespace
+	b, err := f.ReadFile(mailTmplPath)
+	if err != nil {
+		return err
+	}
+	t, err := template.New("mail").Parse(string(b))
+	if err != nil {
+		return err
+	}
+	c.tmpl = t
+	return nil
+}
+
+// mailCmd runs the Upbound Enterprise Mail Portal.
+type mailCmd struct {
+	log     logging.Logger
+	kClient kubernetes.Interface
+	ns      string
+	tmpl    *template.Template
+
+	Port    int  `default:"8085" short:"p" help:"Port used for mail portal."`
+	Verbose bool `help:"Run server with verbose logging."`
+}
+
+// Run executes the mail command.
+func (c *mailCmd) Run(kCtx *kong.Context) error {
+	s := &http.Server{
+		Handler:      http.HandlerFunc(c.handler),
+		Addr:         fmt.Sprintf("127.0.0.1:%d", c.Port),
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	fmt.Printf("Running Mail Portal on port: %d\n", c.Port)
+	go func() {
+		if err := s.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			kCtx.FatalIfErrorf(err)
+		}
+	}()
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+	<-done
+	c.log.Debug("Shutting down Mail server.")
+	to, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return s.Shutdown(to)
+}
+
+func (c *mailCmd) handler(rw http.ResponseWriter, r *http.Request) { //nolint:gocyclo
+	ctx, cancel := context.WithTimeout(r.Context(), reqTimeout)
+	defer cancel()
+	if r.URL.Path == "/" {
+		l, err := c.kClient.CoreV1().Secrets(c.ns).List(ctx, v1.ListOptions{
+			FieldSelector: mailSecretType,
+		})
+		if err != nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			if _, err := rw.Write([]byte(failedGetMessages)); err != nil {
+				c.log.WithValues("Error", err).Info(errWriteResponse)
+			}
+			c.log.WithValues("Error", err).Debug(errGetMessages)
+			return
+		}
+		msgs := make(map[string]MailItem, len(l.Items))
+		for _, s := range l.Items {
+			msg, err := mail.ReadMessage(bytes.NewBuffer(s.Data[mailMessageKey]))
+			if err != nil {
+				c.log.WithValues("Message", s.Name, "Error", err).Debug(errBadMessage)
+				continue
+			}
+			msgs[s.Name] = MailItem{
+				Recipient: msg.Header.Get("To"),
+				Subject:   msg.Header.Get("Subject"),
+			}
+		}
+
+		if err := c.tmpl.Execute(rw, msgs); err != nil {
+			c.log.WithValues("Error", err).Info(errWriteResponse)
+		}
+		return
+	}
+	s, err := c.kClient.CoreV1().Secrets(c.ns).Get(ctx, strings.TrimLeft(r.URL.Path, "/"), v1.GetOptions{})
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		if _, err := rw.Write([]byte(failedGetMessage)); err != nil {
+			c.log.WithValues("Error", err).Info(errWriteResponse)
+		}
+		c.log.WithValues("Error", err).Debug(errGetMessage)
+		return
+	}
+	msg, err := mail.ReadMessage(bytes.NewBuffer(s.Data[mailMessageKey]))
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		if _, err := rw.Write([]byte(failedParseMessage)); err != nil {
+			c.log.WithValues("Error", err).Info(errWriteResponse)
+		}
+		c.log.WithValues("Error", err).Debug(errParseMessage)
+		return
+	}
+	b, err := io.ReadAll(msg.Body)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		if _, err := rw.Write([]byte(failedParseMessage)); err != nil {
+			c.log.WithValues("Error", err).Info(errWriteResponse)
+		}
+		c.log.WithValues("Error", err).Debug(errReadBody)
+		return
+	}
+	if _, err := rw.Write(b); err != nil {
+		c.log.WithValues("Error", err).Info(errWriteResponse)
+	}
+}

--- a/cmd/up/enterprise/mail_test.go
+++ b/cmd/up/enterprise/mail_test.go
@@ -1,0 +1,152 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func withSecretReactor(verb string, fRet runtime.Object, fErr error) *fake.Clientset {
+	c := fake.NewSimpleClientset()
+	c.CoreV1().(*fakecorev1.FakeCoreV1).PrependReactor(verb, "secrets", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, fRet, fErr
+	})
+	return c
+}
+
+func TestHandler(t *testing.T) {
+	emptySec := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cool-secret-name",
+		},
+	}
+	validSec := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cool-secret-name",
+		},
+		Data: map[string][]byte{
+			mailMessageKey: []byte("MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\r\nFrom: me\r\nTo: you\r\nSubject: hello\r\n\r\nhello world\r\n"),
+		},
+	}
+	errBoom := errors.New("boom")
+	b, _ := f.ReadFile(mailTmplPath)
+	tmpl, _ := template.New("mail").Parse(string(b))
+	type want struct {
+		status int
+	}
+
+	cases := map[string]struct {
+		reason   string
+		m        *mailCmd
+		endpoint string
+		want     want
+	}{
+		"ErrorListSecrets": {
+			reason: "Should return an error if unable to list secrets.",
+			m: &mailCmd{
+				log:     logging.NewNopLogger(),
+				kClient: withSecretReactor("list", &v1.SecretList{}, errBoom),
+			},
+			endpoint: "/",
+			want: want{
+				status: http.StatusInternalServerError,
+			},
+		},
+		"SuccessInvalidMessage": {
+			reason: "Should not return an error if invalid message encountered in list.",
+			m: &mailCmd{
+				log: logging.NewNopLogger(),
+				kClient: withSecretReactor("list", &v1.SecretList{
+					Items: []v1.Secret{
+						emptySec,
+					},
+				}, nil),
+				tmpl: tmpl,
+			},
+			endpoint: "/",
+			want: want{
+				status: http.StatusOK,
+			},
+		},
+		"SuccessValidMessages": {
+			reason: "Should not return an error if messages are valid.",
+			m: &mailCmd{
+				log: logging.NewNopLogger(),
+				kClient: withSecretReactor("list", &v1.SecretList{
+					Items: []v1.Secret{
+						validSec,
+					},
+				}, nil),
+				tmpl: tmpl,
+			},
+			endpoint: "/",
+			want: want{
+				status: http.StatusOK,
+			},
+		},
+		"ErrorGetSecret": {
+			reason: "Should return an error if unable to get secret.",
+			m: &mailCmd{
+				log:     logging.NewNopLogger(),
+				kClient: withSecretReactor("get", &v1.Secret{}, errBoom),
+			},
+			endpoint: "/cool-secret-name",
+			want: want{
+				status: http.StatusInternalServerError,
+			},
+		},
+		"SuccessValidMessage": {
+			reason: "Should not return an error if message is valid.",
+			m: &mailCmd{
+				log:     logging.NewNopLogger(),
+				kClient: withSecretReactor("get", &validSec, nil),
+			},
+			endpoint: "/cool-secret-name",
+			want: want{
+				status: http.StatusOK,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequestWithContext(context.Background(), "GET", tc.endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			http.HandlerFunc(tc.m.handler).ServeHTTP(rr, req)
+			if diff := cmp.Diff(tc.want.status, rr.Code, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nhandle(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/up/enterprise/templates/mail.html
+++ b/cmd/up/enterprise/templates/mail.html
@@ -1,0 +1,35 @@
+<!--
+ Copyright 2022 Upbound Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Upbound Mail Portal</h1>
+    <h3>Messages:</h3>
+    <table>
+      <tr>
+        <th>Recipient</th>
+        <th>Subject</th>
+      </tr>
+      {{ range $key, $value := . }}
+      <tr>
+        <td>{{ $value.Recipient }}</td>
+        <td><a href="/{{ $key }}">{{ $value.Subject }}</a></td>
+      </tr>
+      {{ end }}
+    </table>
+  </body>
+</html>

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build generate
 // +build generate
 
 // NOTE(negz): See the below link for details on what is happening here.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds `up enterprise mail` **EXPERIMENTAL** command for viewing emails that are stored as `Secret`s in a Kubernetes cluster using a small mail portal provided by a local server.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Tested this out with a cluster with valid emails as `Secret`s.

![Screenshot from 2022-02-14 12-18-22](https://user-images.githubusercontent.com/31777345/153956321-79f86a73-362b-4364-b827-d36675172845.png)
![Screenshot from 2022-02-14 12-17-26](https://user-images.githubusercontent.com/31777345/153956324-7796b081-83a4-4165-8ac9-51588fdc3d95.png)
