### PR TITLE
Add nil checks for `schema` when evaluating XRD schema field

### DIFF
--- a/internal/xpkg/snapshot/xrd_test.go
+++ b/internal/xpkg/snapshot/xrd_test.go
@@ -223,6 +223,41 @@ func TestValidateOpenAPIV3Schema(t *testing.T) {
 				},
 			},
 		},
+		"NoSchemaDefined": {
+			reason: "Not defining a schema is valid.",
+			args: args{
+				xrd: &xpextv1.CompositeResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apiextensions.crossplane.io/v1",
+						Kind:       "CompositeResourceDefinition",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "xpostgresqlinstances.database.example.org",
+					},
+					Spec: xpextv1.CompositeResourceDefinitionSpec{
+						Group: "database.example.org",
+						Names: v1.CustomResourceDefinitionNames{
+							Kind:   "XPostgreSQLInstance",
+							Plural: "xpostgresqlinstances",
+						},
+						ClaimNames: &v1.CustomResourceDefinitionNames{
+							Kind:   "PostgreSQLInstance",
+							Plural: "postgresqlinstances",
+						},
+						Versions: []xpextv1.CompositeResourceDefinitionVersion{
+							{
+								Name:          "v1alpha1",
+								Served:        true,
+								Referenceable: true,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				errs: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
### Description of your changes
XRDs do not have a hard requirement that a version has a schema. Given that, the previous implementation assumed that there would be a schema object on every version; which results in a panic when a schema does not exist.

This can also be seen if an end user is typing an XRD from scratch and has not yet defined the schema.


Fixes #160 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
1. Verified that a panic is no longer seen in `xpls` when using the https://github.com/danielinclouds/play_crossplane_plugin repo.
2. Verified that typing up the schema and partially supplying its definition does not result in a panic. Effectively mocking the authoring flow of typing everything individually.
