### PR TITLE
Add `up xpkg xp-extract` command as EXPERIMENTAL

### DIFF
--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -1,0 +1,157 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xpkg
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"path/filepath"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/upbound/up/internal/xpkg"
+)
+
+const (
+	errInvalidTag              = "package tag is not a valid reference"
+	errFetchPackage            = "failed to fetch package from remote"
+	errGetManifest             = "failed to get package image manifest from remote"
+	errFetchLayer              = "failed to fetch annotated base layer from remote"
+	errGetUncompressed         = "failed to get uncompressed contents from layer"
+	errMultipleAnnotatedLayers = "package is invalid due to multiple annotated base layers"
+	errOpenPackageStream       = "failed to open package stream file"
+	errCreateOutputFile        = "failed to create output file"
+	errCreateGzipWriter        = "failed to create gzip writer"
+	errExtractPackageContents  = "failed to extract package contents"
+)
+
+const (
+	layerAnnotation     = "io.crossplane.xpkg"
+	baseAnnotationValue = "base"
+	cacheContentExt     = ".gz"
+)
+
+// AfterApply constructs and binds Upbound-specific context to any subcommands
+// that have Run() methods that receive it.
+func (c *xpExtractCmd) AfterApply() error {
+	c.fs = afero.NewOsFs()
+	return nil
+}
+
+// xpExtractCmd extracts package contents into a Crossplane cache compatible
+// format.
+type xpExtractCmd struct {
+	fs afero.Fs
+
+	Tag    string `arg:"" help:"Tag of the package to extract. Must be a valid OCI image tag."`
+	Output string `short:"o" help:"Package output file path. Extension must be .gz or will be replaced." default:"out.gz"`
+}
+
+// Run runs the xp extract cmd.
+func (c *xpExtractCmd) Run() error { //nolint:gocyclo
+	// NOTE(hasheddan): most of the logic in this method is from the machinery
+	// used in Crossplane's package cache and should be updated to use shared
+	// libraries if moved to crossplane-runtime.
+	tag, err := name.NewTag(c.Tag, name.WithDefaultRegistry(upboundRegistry))
+	if err != nil {
+		return errors.Wrap(err, errInvalidTag)
+	}
+
+	// Fetch package.
+	img, err := remote.Image(tag)
+	if err != nil {
+		return errors.Wrap(err, errFetchPackage)
+	}
+
+	// Get image manifest.
+	manifest, err := img.Manifest()
+	if err != nil {
+		return errors.Wrap(err, errGetManifest)
+	}
+
+	// Determine if the image is using annotated layers.
+	var tarc io.ReadCloser
+	foundAnnotated := false
+	for _, l := range manifest.Layers {
+		if a, ok := l.Annotations[layerAnnotation]; !ok || a != baseAnnotationValue {
+			continue
+		}
+		// NOTE(hasheddan): the xpkg specification dictates that only one layer
+		// descriptor may be annotated as xpkg base. Since iterating through all
+		// descriptors is relatively inexpensive, we opt to do so in order to
+		// verify that we aren't just using the first layer annotated as xpkg
+		// base.
+		if foundAnnotated {
+			return errors.New(errMultipleAnnotatedLayers)
+		}
+		foundAnnotated = true
+		layer, err := img.LayerByDigest(l.Digest)
+		if err != nil {
+			return errors.Wrap(err, errFetchLayer)
+		}
+		tarc, err = layer.Uncompressed()
+		if err != nil {
+			return errors.Wrap(err, errGetUncompressed)
+		}
+	}
+
+	// If we still don't have content then we need to flatten image filesystem.
+	if !foundAnnotated {
+		tarc = mutate.Extract(img)
+	}
+
+	// The ReadCloser is an uncompressed tarball, either consisting of annotated
+	// layer contents or flattened filesystem content. Either way, we only want
+	// the package YAML stream.
+	t := tar.NewReader(tarc)
+	var size int64
+	for {
+		h, err := t.Next()
+		if err != nil {
+			return errors.Wrap(err, errOpenPackageStream)
+		}
+		if h.Name == xpkg.StreamFile {
+			size = h.Size
+			break
+		}
+	}
+
+	out := xpkg.ReplaceExt(filepath.Clean(c.Output), cacheContentExt)
+	cf, err := c.fs.Create(out)
+	if err != nil {
+		return errors.Wrap(err, errCreateOutputFile)
+	}
+	// NOTE(hasheddan): we don't check error on deferred file close as Close()
+	// is explicitly called in the happy path.
+	defer cf.Close() //nolint:errcheck
+	w, err := gzip.NewWriterLevel(cf, gzip.BestSpeed)
+	if err != nil {
+		return errors.Wrap(err, errCreateGzipWriter)
+	}
+	if _, err = io.CopyN(w, t, size); err != nil {
+		return errors.Wrap(err, errExtractPackageContents)
+	}
+	// NOTE(hasheddan): gzip writer must be closed to ensure all data is flushed
+	// to file.
+	if err := w.Close(); err != nil {
+		return errors.Wrap(err, errExtractPackageContents)
+	}
+	return cf.Close()
+}

--- a/cmd/up/xpkg/xpextract_test.go
+++ b/cmd/up/xpkg/xpextract_test.go
@@ -1,0 +1,111 @@
+package xpkg
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/upbound/up/internal/xpkg"
+	"github.com/upbound/up/internal/xpkg/dep/resolver/image"
+)
+
+func TestXPExtractRun(t *testing.T) {
+	errBoom := errors.New("boom")
+	randLayer, _ := random.Layer(int64(1000), types.DockerLayer)
+	randImg, _ := mutate.Append(empty.Image, mutate.Addendum{
+		Layer: randLayer,
+		Annotations: map[string]string{
+			layerAnnotation: baseAnnotationValue,
+		},
+	})
+
+	randImgDup, _ := mutate.Append(randImg, mutate.Addendum{
+		Layer: randLayer,
+		Annotations: map[string]string{
+			layerAnnotation: baseAnnotationValue,
+		},
+	})
+
+	streamCont := "somestreamofyaml"
+	tarBuf := new(bytes.Buffer)
+	tw := tar.NewWriter(tarBuf)
+	hdr := &tar.Header{
+		Name: xpkg.StreamFile,
+		Mode: int64(xpkg.StreamFileMode),
+		Size: int64(len(streamCont)),
+	}
+	_ = tw.WriteHeader(hdr)
+	_, _ = io.Copy(tw, strings.NewReader(streamCont))
+	_ = tw.Close()
+
+	packLayer, _ := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		// NOTE(hasheddan): we must construct a new reader each time as we
+		// ingest packImg in multiple tests below.
+		return io.NopCloser(bytes.NewReader(tarBuf.Bytes())), nil
+	})
+	packImg, _ := mutate.AppendLayers(empty.Image, packLayer)
+	cases := map[string]struct {
+		reason string
+		fs     afero.Fs
+		img    image.Fetcher
+		tag    string
+		out    string
+		want   error
+	}{
+		"ErrorInvalidTag": {
+			reason: "Should return error if we fail to parse package name.",
+			tag:    "++++",
+			want:   errors.Wrap(errors.New("could not parse reference: ++++"), errInvalidTag),
+		},
+		"ErrorFetchPackage": {
+			reason: "Should return error if we fail to fetch package.",
+			tag:    "crossplane/provider-aws:v0.24.1",
+			img:    image.NewMockFetcher(image.WithError(errBoom)),
+			want:   errors.Wrap(errBoom, errFetchPackage),
+		},
+		"ErrorMultipleAnnotatedLayers": {
+			reason: "Should return error if manifest contains multiple annotated layers.",
+			tag:    "crossplane/provider-aws:v0.24.1",
+			img:    image.NewMockFetcher(image.WithImage(randImgDup)),
+			want:   errors.New(errMultipleAnnotatedLayers),
+		},
+		"ErrorFetchBadPackage": {
+			reason: "Should return error if image with contents does not have package.yaml.",
+			tag:    "crossplane/provider-aws:v0.24.1",
+			img:    image.NewMockFetcher(image.WithImage(randImg)),
+			want:   errors.Wrap(io.EOF, errOpenPackageStream),
+		},
+		"Success": {
+			reason: "Should not return error if we successfully fetch package and extract contents.",
+			tag:    "crossplane/provider-aws:v0.24.1",
+			img:    image.NewMockFetcher(image.WithImage(packImg)),
+			fs:     afero.NewMemMapFs(),
+			out:    "out.gz",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := (&xpExtractCmd{
+				fs:      tc.fs,
+				img:     tc.img,
+				Package: tc.tag,
+				Output:  tc.out,
+			}).Run()
+			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRun(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/up/xpkg/xpextract_test.go
+++ b/cmd/up/xpkg/xpextract_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package xpkg
 
 import (

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -16,8 +16,9 @@ package xpkg
 
 // Cmd contains commands for interacting with xpkgs.
 type Cmd struct {
-	Build buildCmd `cmd:"" group:"xpkg" help:"Build a package."`
-	Init  initCmd  `cmd:"" group:"xpkg" help:"Initialize a package."`
-	Dep   depCmd   `cmd:"" group:"xpkg" help:"Manage package dependencies."`
-	Push  pushCmd  `cmd:"" group:"xpkg" help:"Push a package."`
+	Build     buildCmd     `cmd:"" group:"xpkg" help:"Build a package."`
+	XPExtract xpExtractCmd `cmd:"" group:"xpkg" help:"[EXPERIMENTAL] Extract package contents into a Crossplane cache compatible format."`
+	Init      initCmd      `cmd:"" group:"xpkg" help:"Initialize a package."`
+	Dep       depCmd       `cmd:"" group:"xpkg" help:"Manage package dependencies."`
+	Push      pushCmd      `cmd:"" group:"xpkg" help:"Push a package."`
 }

--- a/internal/xpkg/dep/resolver/image/mock_fetcher.go
+++ b/internal/xpkg/dep/resolver/image/mock_fetcher.go
@@ -1,0 +1,71 @@
+package image
+
+import (
+	"context"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// MockFetcher is an image fetcher that returns its configured values.
+type MockFetcher struct {
+	tags []string
+	img  v1.Image
+	dsc  *v1.Descriptor
+	err  error
+}
+
+// NewMockFetcher constructs a new mock fetcher.
+func NewMockFetcher(opts ...MockOption) *MockFetcher {
+	f := &MockFetcher{}
+	for _, o := range opts {
+		o(f)
+	}
+	return f
+}
+
+// MockOption modifies the mock fetcher.
+type MockOption func(*MockFetcher)
+
+// WithTags sets the tags for the mock fetcher.
+func WithTags(tags []string) MockOption {
+	return func(m *MockFetcher) {
+		m.tags = tags
+	}
+}
+
+// WithError sets the error for the mock fetcher.
+func WithError(err error) MockOption {
+	return func(m *MockFetcher) {
+		m.err = err
+	}
+}
+
+// WithImage sets the image for the mock fetcher.
+func WithImage(img v1.Image) MockOption {
+	return func(m *MockFetcher) {
+		m.img = img
+	}
+}
+
+// WithDescriptor sets the descriptor for the mock fetcher.
+func WithDescriptor(dsc *v1.Descriptor) MockOption {
+	return func(m *MockFetcher) {
+		m.dsc = dsc
+	}
+}
+
+// Fetch returns the configured error.
+func (m *MockFetcher) Fetch(ctx context.Context, ref name.Reference, secrets ...string) (v1.Image, error) {
+	return m.img, m.err
+}
+
+// Head returns the configured error.
+func (m *MockFetcher) Head(ctx context.Context, ref name.Reference, secrets ...string) (*v1.Descriptor, error) {
+	return m.dsc, m.err
+}
+
+// Tags returns the configured tags or if none exist then error.
+func (m *MockFetcher) Tags(ctx context.Context, ref name.Reference, secrets ...string) ([]string, error) {
+	return m.tags, m.err
+}

--- a/internal/xpkg/dep/resolver/image/mock_fetcher.go
+++ b/internal/xpkg/dep/resolver/image/mock_fetcher.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package image
 
 import (

--- a/internal/xpkg/dep/resolver/image/resolver_test.go
+++ b/internal/xpkg/dep/resolver/image/resolver_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 )
 
@@ -152,45 +150,4 @@ func TestResolveTag(t *testing.T) {
 			}
 		})
 	}
-}
-
-type MockFetcher struct {
-	tags []string
-	err  error
-}
-
-func NewMockFetcher(opts ...MockOption) *MockFetcher {
-	f := &MockFetcher{}
-	for _, o := range opts {
-		o(f)
-	}
-	return f
-}
-
-// MockOption modifies the mock resolver.
-type MockOption func(*MockFetcher)
-
-func WithTags(tags []string) MockOption {
-	return func(m *MockFetcher) {
-		m.tags = tags
-	}
-}
-
-func WithError(err error) MockOption {
-	return func(m *MockFetcher) {
-		m.err = err
-	}
-}
-
-func (m *MockFetcher) Fetch(ctx context.Context, ref name.Reference, secrets ...string) (v1.Image, error) {
-	return nil, nil
-}
-func (m *MockFetcher) Head(ctx context.Context, ref name.Reference, secrets ...string) (*v1.Descriptor, error) {
-	return nil, nil
-}
-func (m *MockFetcher) Tags(ctx context.Context, ref name.Reference, secrets ...string) ([]string, error) {
-	if m.tags != nil {
-		return m.tags, nil
-	}
-	return nil, m.err
 }

--- a/internal/xpkg/name.go
+++ b/internal/xpkg/name.go
@@ -78,6 +78,11 @@ func ToDNSLabel(s string) string { // nolint:gocyclo
 // extension it will be replaced.
 func BuildPath(path, name string) string {
 	full := filepath.Join(path, name)
-	ext := filepath.Ext(full)
-	return full[0:len(full)-len(ext)] + XpkgExtension
+	return ReplaceExt(full, XpkgExtension)
+}
+
+// ReplaceExt replaces the file extension of the given path.
+func ReplaceExt(path, ext string) string {
+	old := filepath.Ext(path)
+	return path[0:len(path)-len(old)] + ext
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds an xp-extract command that extracts xpkg contents and saves them to
a Crossplane cache compatible format. The logic in this command is
almost identical to that in the Crossplane package manager.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

> NOTE: this enables folks who want to pre-populate the Crossplane package cache to have a similar experience as prior to Crossplane v1.7. However, we add this command as EXPERIMENTAL because Crossplane does not make any promises about backwards compatibility for its package cache format.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

`up xpkg xp-extract crossplane/provider-aws:v0.24.1` and verified that `out.gz` contained the correct package contents (decompressed using `gunzip`). Then started Crossplane `v1.7.0` with it in the package cache and used it as a [`Provider` package source](https://doc.crds.dev/github.com/crossplane/crossplane/pkg.crossplane.io/Provider/v1@v1.7.0#spec-package) with `packagePullPolicy: Never`. Verified that `provider-aws:v0.24.1` was successfully installed.
