### PR TITLE
Supporting extracting contents from local xpkg

### DIFF
--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -53,7 +53,7 @@ type pushCmd struct {
 
 	Tag      string   `arg:"" help:"Tag of the package to be pushed. Must be a valid OCI image tag."`
 	Package  string   `short:"f" help:"Path to package. If not specified and only one package exists in current directory it will be used."`
-	Endpoint *url.URL `env:"UP_ENDPOINT" default:"https://api.upbound.io " help:"Registry endpoint used to execute command."`
+	Endpoint *url.URL `env:"UP_ENDPOINT" default:"https://api.upbound.io" help:"Registry endpoint used to execute command."`
 	Profile  string   `env:"UP_PROFILE" help:"Profile used to execute command."`
 }
 

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -17,7 +17,7 @@ package xpkg
 // Cmd contains commands for interacting with xpkgs.
 type Cmd struct {
 	Build     buildCmd     `cmd:"" group:"xpkg" help:"Build a package."`
-	XPExtract xpExtractCmd `cmd:"" group:"xpkg" help:"[EXPERIMENTAL] Extract package contents into a Crossplane cache compatible format."`
+	XPExtract xpExtractCmd `cmd:"" group:"xpkg" help:"[EXPERIMENTAL] Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
 	Init      initCmd      `cmd:"" group:"xpkg" help:"Initialize a package."`
 	Dep       depCmd       `cmd:"" group:"xpkg" help:"Manage package dependencies."`
 	Push      pushCmd      `cmd:"" group:"xpkg" help:"Push a package."`


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the experimental up xpkg xp-extract command to support fetching
from a local xpkg file.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified the following commands:

1. Extract from local xpkg implicitly:
```
🤖 (z) ls
package.xpkg
🤖 (z) up xpkg xp-extract --from-xpkg
🤖 (z) ls
out.gz  package.xpkg
```
2. Extract from local xpkg by name:
```
🤖 (z) ls
package.xpkg
🤖 (z) up xpkg xp-extract --from-xpkg package.xpkg 
🤖 (z) ls
out.gz  package.xpkg
```

3. Fail to extract with multiple `--from-*`:
```
🤖 (z) up xpkg xp-extract --from-xpkg --from-daemon package.xpkg 
Usage: up xpkg xp-extract [<package>]

[EXPERIMENTAL] Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default.

Arguments:
  [<package>]    Name of the package to extract. Must be a valid OCI image tag or a path if using --from-xpkg.

Flags:
  -h, --help               Show context-sensitive help.
  -v, --version            Print version and exit.

      --from-daemon        Indicates that the image should be fetched from the Docker daemon.
      --from-xpkg          Indicates that the image should be fetched from a local xpkg. If package is not specified and only one exists in current directory it will be used.
  -o, --output="out.gz"    Package output file path. Extension must be .gz or will be replaced.

up: error: --from-daemon and --from-xpkg can't be used together
```

4. Extract from remote registry by default
```
🤖 (z) ls
🤖 (z) up xpkg xp-extract crossplane/provider-aws:v0.24.1
🤖 (z) ls
out.gz
```

5. Fail to extract from daemon if not exist:
```
🤖 (z) ls
🤖 (z) up xpkg xp-extract --from-daemon crossplane/provider-aws:v0.24.1
up: error: failed to get package image manifest from remote: Error response from daemon: reference does not exist
```

6. Successful extract from daemon if exists:
```
🤖 (z) ls
🤖 (z) up xpkg xp-extract --from-daemon index.docker.io/crossplane/provider-aws:v0.24.1
🤖 (z) ls
out.gz
```