### PR TITLE
Replace `UP_ENDPOINT` with `UP_DOMAIN`

### DIFF
--- a/cmd/docker-credential-up/main.go
+++ b/cmd/docker-credential-up/main.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	profile = "UP_PROFILE"
+	profileEnv = "UP_PROFILE"
+	domainEnv  = "UP_DOMAIN"
 )
 
 func main() {
@@ -41,7 +42,8 @@ func main() {
 
 	// Build credential helper and defer execution to Docker.
 	h := credhelper.New(
-		credhelper.WithProfile(os.Getenv(profile)),
+		credhelper.WithDomain(os.Getenv(domainEnv)),
+		credhelper.WithProfile(os.Getenv(profileEnv)),
 	)
 	credentials.Serve(h)
 }

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -136,8 +136,9 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 		return errors.Wrap(err, errLoginFailed)
 	}
 	// If no profile is specified, a new profile named `default` is used.
-	if upCtx.Profile.ID == "" {
-		upCtx.Profile.ID = defaultProfileName
+	profileName := c.Flags.Profile
+	if profileName == "" {
+		profileName = defaultProfileName
 	}
 	// If no account is specified and profile type is user, set profile account
 	// to user ID if not an email address. This is for convenience if a user is
@@ -145,7 +146,7 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 	if upCtx.Account == "" && profType == config.UserProfileType && !isEmail(auth.ID) {
 		upCtx.Account = auth.ID
 	}
-	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.Profile.ID, config.Profile{
+	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(profileName, config.Profile{
 		ID:      auth.ID,
 		Type:    profType,
 		Session: session,
@@ -154,7 +155,7 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 		return errors.Wrap(err, errLoginFailed)
 	}
 	if len(upCtx.Cfg.Upbound.Profiles) == 1 {
-		if err := upCtx.Cfg.SetDefaultUpboundProfile(upCtx.Profile.ID); err != nil {
+		if err := upCtx.Cfg.SetDefaultUpboundProfile(profileName); err != nil {
 			return errors.Wrap(err, errLoginFailed)
 		}
 	}

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -58,24 +57,11 @@ func (c *loginCmd) BeforeApply() error { //nolint:unparam
 }
 
 func (c *loginCmd) AfterApply(kongCtx *kong.Context) error {
-	src := config.NewFSSource()
-	if err := src.Initialize(); err != nil {
-		return err
-	}
-	conf, err := config.Extract(src)
+	upCtx, err := upbound.NewFromFlags(c.Flags)
 	if err != nil {
 		return err
 	}
-	kongCtx.Bind(&upbound.Context{
-		Profile:  c.Profile,
-		Account:  c.Account,
-		Endpoint: c.Endpoint,
-		Cfg:      conf,
-		CfgSrc:   src,
-	})
-	if c.Token != "" {
-		return nil
-	}
+	kongCtx.Bind(upCtx)
 	if c.Username == "" {
 		username, err := c.prompter.Prompt("Username", false)
 		if err != nil {
@@ -105,9 +91,7 @@ type loginCmd struct {
 	Token    string `short:"t" env:"UP_TOKEN" xor:"identifier" help:"Token used to execute command. '-' to read from stdin."`
 
 	// Common Upbound API configuration
-	Endpoint *url.URL `env:"UP_ENDPOINT" default:"https://api.upbound.io" help:"Endpoint used for Upbound API."`
-	Profile  string   `env:"UP_PROFILE" help:"Profile used to execute command."`
-	Account  string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
+	Flags upbound.Flags `embed:""`
 }
 
 // Run executes the login command.
@@ -136,8 +120,8 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 	if err != nil {
 		return errors.Wrap(err, errLoginFailed)
 	}
-	upCtx.Endpoint.Path = loginPath
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upCtx.Endpoint.String(), bytes.NewReader(jsonStr))
+	upCtx.APIEndpoint.Path = loginPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upCtx.APIEndpoint.String(), bytes.NewReader(jsonStr))
 	if err != nil {
 		return errors.Wrap(err, errLoginFailed)
 	}
@@ -151,14 +135,9 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 	if err != nil {
 		return errors.Wrap(err, errLoginFailed)
 	}
-	// If profile is not set, we assume operation on profile designated as
-	// default in config.
-	if upCtx.Profile == "" {
-		upCtx.Profile = upCtx.Cfg.Upbound.Default
-	}
-	// If no default profile is specified, the profile is named `default`.
-	if upCtx.Profile == "" {
-		upCtx.Profile = defaultProfileName
+	// If no profile is specified, a new profile named `default` is used.
+	if upCtx.Profile.ID == "" {
+		upCtx.Profile.ID = defaultProfileName
 	}
 	// If no account is specified and profile type is user, set profile account
 	// to user ID if not an email address. This is for convenience if a user is
@@ -166,7 +145,7 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 	if upCtx.Account == "" && profType == config.UserProfileType && !isEmail(auth.ID) {
 		upCtx.Account = auth.ID
 	}
-	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.Profile, config.Profile{
+	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.Profile.ID, config.Profile{
 		ID:      auth.ID,
 		Type:    profType,
 		Session: session,
@@ -175,7 +154,7 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 		return errors.Wrap(err, errLoginFailed)
 	}
 	if len(upCtx.Cfg.Upbound.Profiles) == 1 {
-		if err := upCtx.Cfg.SetDefaultUpboundProfile(upCtx.Profile); err != nil {
+		if err := upCtx.Cfg.SetDefaultUpboundProfile(upCtx.Profile.ID); err != nil {
 			return errors.Wrap(err, errLoginFailed)
 		}
 	}

--- a/cmd/up/login_test.go
+++ b/cmd/up/login_test.go
@@ -59,7 +59,7 @@ func TestRun(t *testing.T) {
 				Password: "cool-pass",
 			},
 			ctx: &upbound.Context{
-				Domain: defaultURL,
+				APIEndpoint: defaultURL,
 			},
 			err: errors.Wrap(errBoom, errLoginFailed),
 		},

--- a/cmd/up/login_test.go
+++ b/cmd/up/login_test.go
@@ -59,7 +59,7 @@ func TestRun(t *testing.T) {
 				Password: "cool-pass",
 			},
 			ctx: &upbound.Context{
-				Endpoint: defaultURL,
+				Domain: defaultURL,
 			},
 			err: errors.Wrap(errBoom, errLoginFailed),
 		},

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -45,10 +45,6 @@ var cli struct {
 
 	License licenseCmd `cmd:"" help:"Print Up license information."`
 
-	// TODO(hasheddan): the following commands interact with the Upbound API,
-	// but handle building upboundCtx individually in order to avoid reading the
-	// configuration file for all commands that are nested under the root. We
-	// should investigate refactoring structure to allow deduplicating logic.
 	Login        loginCmd        `cmd:"" help:"Login to Upbound."`
 	Logout       logoutCmd       `cmd:"" help:"Logout of Upbound."`
 	ControlPlane controlPlaneCmd `cmd:"" name:"controlplane" aliases:"ctp" group:"controlplane" help:"Interact with control planes."`

--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -53,7 +53,7 @@ type pushCmd struct {
 
 	Tag      string   `arg:"" help:"Tag of the package to be pushed. Must be a valid OCI image tag."`
 	Package  string   `short:"f" help:"Path to package. If not specified and only one package exists in current directory it will be used."`
-	Endpoint *url.URL `env:"UP_ENDPOINT" default:"https://api.upbound.io" help:"Registry endpoint used to execute command."`
+	Endpoint *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain."`
 	Profile  string   `env:"UP_PROFILE" help:"Profile used to execute command."`
 }
 

--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -51,10 +51,10 @@ func (c *pushCmd) AfterApply() error {
 type pushCmd struct {
 	fs afero.Fs
 
-	Tag      string   `arg:"" help:"Tag of the package to be pushed. Must be a valid OCI image tag."`
-	Package  string   `short:"f" help:"Path to package. If not specified and only one package exists in current directory it will be used."`
-	Endpoint *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain."`
-	Profile  string   `env:"UP_PROFILE" help:"Profile used to execute command."`
+	Tag     string   `arg:"" help:"Tag of the package to be pushed. Must be a valid OCI image tag."`
+	Package string   `short:"f" help:"Path to package. If not specified and only one package exists in current directory it will be used."`
+	Domain  *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain."`
+	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command."`
 }
 
 // Run runs the push cmd.
@@ -92,6 +92,7 @@ func (c *pushCmd) Run() error {
 		authn.NewMultiKeychain(
 			authn.NewKeychainFromHelper(
 				credhelper.New(
+					credhelper.WithDomain(c.Domain.Hostname()),
 					credhelper.WithProfile(c.Profile),
 				),
 			),

--- a/internal/credhelper/credhelper_test.go
+++ b/internal/credhelper/credhelper_test.go
@@ -50,6 +50,18 @@ func TestGet(t *testing.T) {
 		opts   []Opt
 		want   want
 	}{
+		"ErrorUnsupportedDomain": {
+			reason: "Should return error if domain is not supported.",
+			args: args{
+				server: testServer,
+			},
+			opts: []Opt{
+				WithDomain("registry.upbound.io"),
+			},
+			want: want{
+				err: errors.New(errUnsupportedDomain),
+			},
+		},
 		"ErrorInitializeSource": {
 			reason: "Should return error if we fail to initialize source.",
 			args: args{

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -29,40 +29,109 @@ const (
 	UserAgent = "up-cli"
 	// CookieName is the default cookie name used to identify a session token.
 	CookieName = "SID"
+
+	// Default API subdomain.
+	apiSubdomain = "api."
+	// Default registry subdomain.
+	xpkgSubdomain = "xpkg."
 )
+
+// Flags are common flags used by commands that interact with Upbound.
+type Flags struct {
+	// Optional
+	Domain  *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain."`
+	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command."`
+	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
+
+	APIEndpoint      *url.URL `env:"OVERRIDE_API_ENDPOINT" hidden:"" name:"override-api-endpoint" help:"Overrides the default API endpoint."`
+	RegistryEndpoint *url.URL `env:"OVERRIDE_REGISTRY_ENDPOINT" hidden:"" name:"override-registry-endpoint" help:"Overrides the default registry endpoint."`
+}
 
 // Context includes common data that Upbound consumers may utilize.
 type Context struct {
-	Profile  string
-	ID       string
-	Token    string
-	Type     config.ProfileType
-	Account  string
-	Endpoint *url.URL
-	Cfg      *config.Config
-	CfgSrc   config.Source
+	Profile          config.Profile
+	Token            string
+	Account          string
+	Domain           *url.URL
+	APIEndpoint      *url.URL
+	RegistryEndpoint *url.URL
+	Cfg              *config.Config
+	CfgSrc           config.Source
+}
+
+// NewFromFlags constructs a new context from flags.
+func NewFromFlags(f Flags) (*Context, error) {
+	src := config.NewFSSource()
+	if err := src.Initialize(); err != nil {
+		return nil, err
+	}
+	conf, err := config.Extract(src)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Context{
+		Account: f.Account,
+		Domain:  f.Domain,
+		Cfg:     conf,
+		CfgSrc:  src,
+	}
+
+	c.APIEndpoint = f.APIEndpoint
+	if c.APIEndpoint == nil {
+		u := *c.Domain
+		u.Host = apiSubdomain + u.Host
+		c.APIEndpoint = &u
+	}
+
+	c.RegistryEndpoint = f.RegistryEndpoint
+	if c.RegistryEndpoint == nil {
+		u := *c.Domain
+		u.Host = xpkgSubdomain + u.Host
+		c.RegistryEndpoint = &u
+	}
+
+	// If profile identifier is not provided, use the default, or empty if the
+	// default cannot be obtained.
+	c.Profile = config.Profile{}
+	if f.Profile == "" {
+		if _, p, err := c.Cfg.GetDefaultUpboundProfile(); err == nil {
+			c.Profile = p
+		}
+	} else {
+		if p, err := c.Cfg.GetUpboundProfile(f.Profile); err == nil {
+			c.Profile = p
+		}
+	}
+
+	// If account has not already been set, use the profile default.
+	if c.Account == "" {
+		c.Account = c.Profile.Account
+	}
+
+	return c, nil
 }
 
 // BuildSDKConfig builds an Upbound SDK config suitable for usage with any
 // service client.
-func BuildSDKConfig(session string, endpoint *url.URL) (*up.Config, error) {
+func (c *Context) BuildSDKConfig(session string) (*up.Config, error) {
 	cj, err := cookiejar.New(nil)
 	if err != nil {
 		return nil, err
 	}
-	cj.SetCookies(endpoint, []*http.Cookie{{
+	cj.SetCookies(c.APIEndpoint, []*http.Cookie{{
 		Name:  CookieName,
 		Value: session,
 	},
 	})
-	client := up.NewClient(func(c *up.HTTPClient) {
-		c.BaseURL = endpoint
-		c.HTTP = &http.Client{
+	client := up.NewClient(func(u *up.HTTPClient) {
+		u.BaseURL = c.APIEndpoint
+		u.HTTP = &http.Client{
 			Jar: cj,
 		}
-		c.UserAgent = UserAgent
+		u.UserAgent = UserAgent
 	})
-	return up.NewConfig(func(c *up.Config) {
-		c.Client = client
+	return up.NewConfig(func(conf *up.Config) {
+		conf.Client = client
 	}), nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Moves all commnon flags and context required to communicate with Upbound
to a common package to be consumed by relevant commands.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds support for restricting the domain that the Docker cred helper will
accept. Default behavior is to accept any.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates up xpkg push to use UP_DOMAIN with a default of upbound.io. This
means that any upbound.io domain will use the credential helper logic,
while pushing to a registry like dockerhub will fall back to whatever
exists in the Docker config file. Setting UP_DOMAIN will allow using
Upbound credentials to push to other domains, such as a local install of
Upbound.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #178 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified with `up login`:
```
🤖 (up) up login
Username: hasheddan
Password: 
🤖 (up) cat ~/.up/config.json | jq .
{
  "upbound": {
    "default": "default",
    "profiles": {
      "default": {
        "id": "hasheddan",
        "type": "user",
        "session": "<redacted>",
        "account": "hasheddan"
      }
    }
  }
}
🤖 (up) up login --profile=test -a upbound
Username: hasheddan
Password: 
🤖 (up) cat ~/.up/config.json | jq .
{
  "upbound": {
    "default": "default",
    "profiles": {
      "default": {
        "id": "hasheddan",
        "type": "user",
        "session": "<redacted>",
        "account": "hasheddan"
      },
      "test": {
        "id": "hasheddan",
        "type": "user",
        "session": "<redacted>",
        "account": "upbound"
      }
    }
  }
}
```

Ensured profiles being used correctly:
```
🤖 (up) up ctp list 
🤖 (up) up ctp list -a upbound
NAME                   ID                                     SELF-HOSTED   STATUS
hosted-piotr           b9c9c960-650b-4ac5-80aa-f681b6b48662   false         ready
kubecon-demos-backup   cbe794c9-5c77-4629-9999-163ea8b125da   false         ready
kubecon-demos          da93e2e2-21cf-4666-8130-65b4a60f53f2   false         ready
platform-aaron-e       dde5b6a3-a0fc-47a4-b515-d6d630dafdeb   false         ready
grant-platform-demo    ed312d5c-0eb0-46e7-8626-e69c75d747c9   false         ready
🤖 (up) up ctp list --profile=test
NAME                   ID                                     SELF-HOSTED   STATUS
hosted-piotr           b9c9c960-650b-4ac5-80aa-f681b6b48662   false         ready
kubecon-demos-backup   cbe794c9-5c77-4629-9999-163ea8b125da   false         ready
kubecon-demos          da93e2e2-21cf-4666-8130-65b4a60f53f2   false         ready
platform-aaron-e       dde5b6a3-a0fc-47a4-b515-d6d630dafdeb   false         ready
grant-platform-demo    ed312d5c-0eb0-46e7-8626-e69c75d747c9   false         ready
```

Verified docker creds used correctly with `up xpkg push`:
```
🤖 (up) up xpkg push index.docker.io/hasheddan/auth-test:v0.0.1
```

ref: https://hub.docker.com/layers/auth-test/hasheddan/auth-test/v0.0.1/images/sha256-5463ccde371186125078569cf21836d7239270eef219a9bf5bce68f85a3b79c7?context=repo

