### PR TITLE
Support `--controller` in up xpkg build

### DIFF
--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -108,13 +108,10 @@ func (c *pushCmd) Run() error {
 // layers with their corresponding annotations, returning a new v1.Image
 // containing the annotation details.
 func annotate(i v1.Image) (v1.Image, error) { //nolint:gocyclo
-
 	cfgFile, err := i.ConfigFile()
 	if err != nil {
 		return nil, err
 	}
-
-	cfg := cfgFile.Config
 
 	layers, err := i.Layers()
 	if err != nil {
@@ -128,14 +125,18 @@ func annotate(i v1.Image) (v1.Image, error) { //nolint:gocyclo
 		if err != nil {
 			return nil, err
 		}
-		if annotation, ok := cfg.Labels[xpkg.Label(d.String())]; ok {
+		if annotation, ok := cfgFile.Config.Labels[xpkg.Label(d.String())]; ok {
 			addendums = append(addendums, mutate.Addendum{
 				Layer: l,
 				Annotations: map[string]string{
 					xpkg.AnnotationKey: annotation,
 				},
 			})
+			continue
 		}
+		addendums = append(addendums, mutate.Addendum{
+			Layer: l,
+		})
 	}
 
 	// we didn't find any annotations, return original image
@@ -151,5 +152,5 @@ func annotate(i v1.Image) (v1.Image, error) { //nolint:gocyclo
 		}
 	}
 
-	return mutate.Config(img, cfg)
+	return mutate.ConfigFile(img, cfgFile)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates xpkg build to support setting a base image, typically a
controller, other than the empty image.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds support for a --controller flag to up xpkg build such that provider
packages can be constructed as a single image. This change only supports
fetching the controller image from the local docker daemon, and can only
support building an image for a single architecture at a time. Options
may be expanded based on feedback from incorporating this functionality
into package building workflows.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Modifies up xpkg push to persist non-package layers and modify rather
than replace the existing config file. This ensures that information
such as os/arch are preserved when building provider packages from a
controller image.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #176 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified by building a "fat package" for `crossplane/provider-aws:v0.24.1` with the following commands:

```
$ docker pull crossplane/provider-aws-controller:v0.24.1
$ cd package
$ up xpkg build --controller crossplane/provider-aws-controller:v0.24.1
$ up xpkg push index.docker.io/hasheddan/from-controller:v0.0.3
```

Resulting package image contents can be viewed here: https://explore.ggcr.dev/?image=hasheddan%2Ffrom-controller%3Av0.0.3

Config File:
```json
{
   "config":{
      "Entrypoint":[
         "crossplane-aws-provider"
      ],
      "Env":[
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
      ],
      "ExposedPorts":{
         "8080/tcp":{
            
         }
      },
      "Labels":{
         "io.crossplane.xpkg:sha256:2130b0dd6e962fcd7ff51f45615149fea400c5d8cc9c45b234a429a5f2541e5e":"base"
      },
      "User":"1001"
   },
   "architecture":"amd64",
   "created":"2022-02-12T00:21:15.522134471Z",
   "history":[
      {
         "created":"2021-11-12T17:19:58.698676655Z",
         "created_by":"/bin/sh -c #(nop) ADD file:5a707b9d6cb5fff532e4c2141bc35707593f21da5528c9e71ae2ddb6ba4a4eb6 in / "
      },
      {
         "created":"2021-11-12T17:19:58.948920855Z",
         "created_by":"/bin/sh -c #(nop) CMD [\"/bin/sh\"]",
         "empty_layer":true
      },
      {
         "comment":"buildkit.dockerfile.v0",
         "created":"2022-02-12T00:21:14.315430496Z",
         "created_by":"RUN /bin/sh -c apk --no-cache add ca-certificates bash # buildkit"
      },
      {
         "comment":"buildkit.dockerfile.v0",
         "created":"2022-02-12T00:21:15.522134471Z",
         "created_by":"ARG ARCH",
         "empty_layer":true
      },
      {
         "comment":"buildkit.dockerfile.v0",
         "created":"2022-02-12T00:21:15.522134471Z",
         "created_by":"ARG TINI_VERSION",
         "empty_layer":true
      },
      {
         "comment":"buildkit.dockerfile.v0",
         "created":"2022-02-12T00:21:15.522134471Z",
         "created_by":"ADD provider /usr/local/bin/crossplane-aws-provider # buildkit"
      },
      {
         "comment":"buildkit.dockerfile.v0",
         "created":"2022-02-12T00:21:15.522134471Z",
         "created_by":"EXPOSE map[8080/tcp:{}]",
         "empty_layer":true
      },
      {
         "comment":"buildkit.dockerfile.v0",
         "created":"2022-02-12T00:21:15.522134471Z",
         "created_by":"USER 1001",
         "empty_layer":true
      },
      {
         "comment":"buildkit.dockerfile.v0",
         "created":"2022-02-12T00:21:15.522134471Z",
         "created_by":"ENTRYPOINT [\"crossplane-aws-provider\"]",
         "empty_layer":true
      },
      {
         "created":"0001-01-01T00:00:00Z"
      }
   ],
   "os":"linux",
   "rootfs":{
      "diff_ids":[
         "sha256:7fcb75871b2101082203959c83514ac8a9f4ecfee77a0fe9aa73bbe56afdf1b4",
         "sha256:5a2718191b06665faa84b8c6b7884d03544e04c0054677f51b4264d8cfd784d4",
         "sha256:b4a9a36571ccfe1cf856d990a727c4e16c3ccadea6d3ee9d535c5ed3e54fa7bd",
         "sha256:dad289fa4752e3e510f6756469e6281ff6aa9ab027cebd8c9b0d131bad921293"
      ],
      "type":"layers"
   }
}
```

Manifest:
```json
{
   "schemaVersion":2,
   "mediaType":"application/vnd.docker.distribution.manifest.v2+json",
   "config":{
      "mediaType":"application/vnd.docker.container.image.v1+json",
      "size":2011,
      "digest":"sha256:76385dc71e3b1371e837cea85dbf93d1ea7ebc87f86c155a80ae178f57876ee4"
   },
   "layers":[
      {
         "mediaType":"application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size":3064029,
         "digest":"sha256:e04db65a8fdafe46c2b16e29b45b11ef90b8b801eafb9f7677fb407b19339fac"
      },
      {
         "mediaType":"application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size":1175760,
         "digest":"sha256:936df6f369ba9b46ab678a546e1a689ef4e7c8ee718da49b2e6a8f79a4b51342"
      },
      {
         "mediaType":"application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size":33107181,
         "digest":"sha256:7b59fd4d4e002071af51078e8c12e95de6b80e76a8aa2b57cba3c92160aa7ed9"
      },
      {
         "mediaType":"application/vnd.docker.image.rootfs.diff.tar.gzip",
         "size":392104,
         "digest":"sha256:2130b0dd6e962fcd7ff51f45615149fea400c5d8cc9c45b234a429a5f2541e5e",
         "annotations":{
            "io.crossplane.xpkg":"base"
         }
      }
   ]
}
```