### PR TITLE
Do not use absolute path for .up dir in xpkg

### DIFF
--- a/internal/xpkg/name.go
+++ b/internal/xpkg/name.go
@@ -44,7 +44,7 @@ const (
 
 	// XpkgExamplesFile is the name of the file in a Crossplane package image
 	// that contains the examples YAML stream.
-	XpkgExamplesFile string = "/.up/examples.yaml"
+	XpkgExamplesFile string = ".up/examples.yaml"
 
 	// AnnotationKey is the key value for xpkg annotations.
 	AnnotationKey string = "io.crossplane.xpkg"


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the .up dir to not be absolute to avoid security concerns when
extracting from an archive.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Built a package with examples and pushed it, verified that they were extracted correctly:
```
🤖 (xpkg-luop) up xpkg build
🤖 (xpkg-luop) ls
composition.yaml  crossplane.yaml  definition.yaml  examples  luop-171d7f5d3a2a.xpkg
🤖 (xpkg-luop) up xpkg push xpkg.upbound.io/dan/luop:v0.0.2
```