### PR TITLE
Add support for pushing multiple xpkg and an index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.3.0
 	github.com/upbound/up-sdk-go v0.1.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	helm.sh/helm/v3 v3.7.0
 	k8s.io/api v0.23.3
@@ -191,7 +192,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds support for pushing multiple xpkg and an index such that multi-arch
providers can be pushed as single images.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #185 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

1. Built two controller images and loaded into daemon with `docker buildx build --load`.
2. Built two `xpkg`'s by referencing controllers with `up xpkg build --controller`.
3. Pushed as multi-arch image with `up xpkg push xpkg.upbound.io/dan/test-xpkg:v0.1.0 -f "amd64.xpkg,arm64.xpkg"`.
4. Verified manifest was an index with `crane manifest and that pulling either arch worked correctly.