### PR TITLE
Update `ctp kubeconfig get` default Proxy URL

### DIFF
--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -37,7 +37,7 @@ type getCmd struct {
 	stdin io.Reader
 
 	File  string   `type:"path" short:"f" help:"File to merge kubeconfig."`
-	Proxy *url.URL `env:"UP_PROXY" default:"https://proxy.upbound.io/controlPlanes" help:"Endpoint used for Upbound Proxy."`
+	Proxy *url.URL `env:"UP_PROXY" default:"https://proxy.upbound.io/v1/controlPlanes" help:"Endpoint used for Upbound Proxy."`
 	Token string   `required:"" help:"API token used to authenticate."`
 
 	ID uuid.UUID `arg:"" name:"control-plane-ID" required:"" help:"ID of control plane."`

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -19,7 +19,6 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/google/uuid"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -46,15 +45,15 @@ func GetKubeConfig(path string) (*rest.Config, error) {
 }
 
 // BuildControlPlaneKubeconfig builds a kubeconfig entry for a control plane.
-func BuildControlPlaneKubeconfig(proxy *url.URL, id uuid.UUID, token, kube string) error { //nolint:interfacer
+func BuildControlPlaneKubeconfig(proxy *url.URL, id string, token, kube string) error { //nolint:interfacer
 	po := clientcmd.NewDefaultPathOptions()
 	po.LoadingRules.ExplicitPath = kube
 	conf, err := po.GetStartingConfig()
 	if err != nil {
 		return err
 	}
-	key := fmt.Sprintf(UpboundKubeconfigKeyFmt, id.String())
-	proxy.Path = path.Join(proxy.Path, id.String(), k8sResource)
+	key := fmt.Sprintf(UpboundKubeconfigKeyFmt, id)
+	proxy.Path = path.Join(proxy.Path, id, k8sResource)
 	conf.Clusters[key] = &api.Cluster{
 		Server: proxy.String(),
 	}

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -33,6 +33,8 @@ const (
 	// UpboundKubeconfigKeyFmt is the format for Upbound control plane entries
 	// in a kubeconfig file.
 	UpboundKubeconfigKeyFmt = "upbound-%s"
+
+	k8sResource = "k8s"
 )
 
 // GetKubeConfig constructs a Kubernetes REST config from the specified
@@ -52,7 +54,7 @@ func BuildControlPlaneKubeconfig(proxy *url.URL, id uuid.UUID, token, kube strin
 		return err
 	}
 	key := fmt.Sprintf(UpboundKubeconfigKeyFmt, id.String())
-	proxy.Path = path.Join(proxy.Path, id.String())
+	proxy.Path = path.Join(proxy.Path, id.String(), k8sResource)
 	conf.Clusters[key] = &api.Cluster{
 		Server: proxy.String(),
 	}


### PR DESCRIPTION
### Description of your changes
The control planes proxy API is getting updated to include:
- a version - i.e. `/v1/
- a trailing k8s resource path param - `k8s`

This change accounts for that by:
- updating the default Proxy URL to include the new version
- append the k8s resource path param when building the URL for the kubeconfig.

Fixes xref: #https://github.com/upbound/squad-orchestration/issues/13

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tested using the following steps:
1. Built a new `up`
2. created an empty kubeconfig file - `touch kubeconfig`
3. set the empty file as the kubeconfig for the terminal session - `export KUBECONFIG=kubeconfig`
4. ran the following command: `./_output/bin/darwin_arm64/up ctp kubeconfig get AE7FB077-C0E0-4F6D-B5C4-40844E6D6A4E --token=not-a-token`
5. verified the corresponding entry had the correct format:
```bash
apiVersion: v1
clusters:
- cluster:
    server: https://proxy.upbound.io/v1/controlPlanes/ae7fb077-c0e0-4f6d-b5c4-40844e6d6a4e/k8s
  name: upbound-ae7fb077-c0e0-4f6d-b5c4-40844e6d6a4e
contexts:
- context:
    cluster: upbound-ae7fb077-c0e0-4f6d-b5c4-40844e6d6a4e
    user: upbound-ae7fb077-c0e0-4f6d-b5c4-40844e6d6a4e
  name: upbound-ae7fb077-c0e0-4f6d-b5c4-40844e6d6a4e
current-context: upbound-ae7fb077-c0e0-4f6d-b5c4-40844e6d6a4e
kind: Config
preferences: {}
users:
- name: upbound-ae7fb077-c0e0-4f6d-b5c4-40844e6d6a4e
  user:
    token: not-a-token
```
