### PR TITLE
Clean up commands doc after mcp experimental changes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,21 +69,12 @@ Top-level flags can be passed for any top-level or group-specific command.
 
 Format: `up controlplane <cmd> ...` Alias: `up ctp <cmd> ...`
 
-- `attach <name>`
-    - Flags:
-      - `-d,--description = STRING`: Control plane description.
-      - `--view-only`: creates the self-hosted control plane as view only.
-    - Behavior: Creates a self-hosted control plane in Upbound and returns token
-      to connect a UXP instance to it. The name of the token is randomly
-      generated.
 - `create <name>`
     - Flags:
         - `--description = STRING`: Control plane description.
     - Behavior: Creates a hosted control plane in Upbound.
 - `delete <id>`
-    - Behavior: Deletes a control plane in Upbound. If control plane is hosted,
-      the UXP cluster will be deleted. If the control plane is self-hosted, the
-      UXP cluster will begin failing to connect to Upbound.
+    - Behavior: Deletes a control plane in Upbound.
 - `list`
     - Behavior: Lists all control planes for the configured account.
 
@@ -96,6 +87,8 @@ commands may choose not to utilize the group flags when not relevant.
   specified command. Can be either an organization or a personal account.
 - `--endpoint = URL` (Env: `UP_ENDPOINT`) (Default: `https://api.upbound.io`):
   Endpoint to use when communicating with the Upbound API.
+- `--mcp-experimental = BOOL` (Env: `UP_MCP_EXPERIMENTAL`): Use experimental
+  control planes API.
 - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
   specified command.
 
@@ -117,21 +110,6 @@ Format: `up controlplane kubeconfig <cmd> ...` Alias: `up ctp kubeconfig
       `--token` flag must be provided and must be a valid Upbound API token. A
       new context will be created for the cluster and authentication data and it
       will be set as current.
-
-**Subgroup: Token**
-
-Format: `up controlplane token <cmd> ...` Alias: `up ctp token <cmd>...`
-
-- `create <control-plane-ID>`
-    - Flags:
-        - `--name = STRING`: Name of control plane token. Name is randomly
-          generated if not specified.
-    - Behavior: Creates a token for the specified self-hosted control plane ID
-      and prints it to stdout.
-- `delete <token-ID>`
-    - Behavior: Deletes the control plane token with the specified ID.
-- `list <control-plane-ID>`
-    - Behavior: Lists all tokens for the specified control plane.
 
 ## Enterprise
 


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Cleans up documentation for control planes commands after the changes to
the control planes API. Drops the attach and token commands, and adds
documentation for the --mcp-experimental flag.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up) up ctp -h
Usage: up controlplane <command>

Interact with control planes.

Flags:
  -h, --help                         Show context-sensitive help.
  -v, --version                      Print version and exit.

      --mcp-experimental             Use experimental managed control planes API ($UP_MCP_EXPERIMENTAL).
      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).

controlplane
  controlplane create <name>
    Create a hosted control plane.

  controlplane delete <id>
    Delete a control plane.

  controlplane list
    List control planes for the account.

  controlplane kubeconfig get --token=STRING <control-plane-ID>
    Get a kubeconfig for a control plane.

```