### PR TITLE
Construct proxy endpoint in up context

### DIFF
--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -32,6 +32,8 @@ const (
 
 	// Default API subdomain.
 	apiSubdomain = "api."
+	// Default proxy subdomain.
+	proxySubdomain = "proxy."
 	// Default registry subdomain.
 	xpkgSubdomain = "xpkg."
 )
@@ -44,6 +46,7 @@ type Flags struct {
 	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
 
 	APIEndpoint      *url.URL `env:"OVERRIDE_API_ENDPOINT" hidden:"" name:"override-api-endpoint" help:"Overrides the default API endpoint."`
+	ProxyEndpoint    *url.URL `env:"OVERRIDE_PROXY_ENDPOINT" hidden:"" name:"override-proxy-endpoint" help:"Overrides the default proxy endpoint."`
 	RegistryEndpoint *url.URL `env:"OVERRIDE_REGISTRY_ENDPOINT" hidden:"" name:"override-registry-endpoint" help:"Overrides the default registry endpoint."`
 }
 
@@ -54,6 +57,7 @@ type Context struct {
 	Account          string
 	Domain           *url.URL
 	APIEndpoint      *url.URL
+	ProxyEndpoint    *url.URL
 	RegistryEndpoint *url.URL
 	Cfg              *config.Config
 	CfgSrc           config.Source
@@ -82,6 +86,13 @@ func NewFromFlags(f Flags) (*Context, error) {
 		u := *c.Domain
 		u.Host = apiSubdomain + u.Host
 		c.APIEndpoint = &u
+	}
+
+	c.ProxyEndpoint = f.ProxyEndpoint
+	if c.ProxyEndpoint == nil {
+		u := *c.Domain
+		u.Host = proxySubdomain + u.Host
+		c.ProxyEndpoint = &u
 	}
 
 	c.RegistryEndpoint = f.RegistryEndpoint


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Construct proxy in the up context to match pattern used by API and
registry, and consume the UP_DOMAIN env var.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates to consume the up context proxy domain and sets the account in
the path for the UP_MCP_EXPERIMENTAL config.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
$ KUBECONFIG=hello.txt up ctp kubeconfig get 8c9f2f45-4fe1-4f97-b687-88e4d0436696 --token=bye
$ UP_MCP_EXPERIMENTAL=true up ctp kubeconfig get hello --token=hi
$ cat hello.txt

apiVersion: v1
clusters:
- cluster:
    server: https://proxy.upbound.io/8c9f2f45-4fe1-4f97-b687-88e4d0436696/k8s
  name: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
- cluster:
    server: http://proxy.local.upbound.io/v1/my-org/hello/k8s
  name: upbound-hello
contexts:
- context:
    cluster: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
    user: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
  name: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
- context:
    cluster: upbound-hello
    user: upbound-hello
  name: upbound-hello
current-context: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
kind: Config
preferences: {}
users:
- name: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
  user:
    token: bye
- name: upbound-hello
  user:
    token: hi
```