### PR TITLE
Include controlPlanes in proxy path

### DIFF
--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -74,9 +74,10 @@ func (c *getCmd) Run(experimental bool, upCtx *upbound.Context) error {
 	}
 
 	if experimental {
-		upCtx.ProxyEndpoint.Path = fmt.Sprintf("/v1/%s", upCtx.Account)
+		upCtx.ProxyEndpoint.Path = fmt.Sprintf("/v1/controlPlanes/%s", upCtx.Account)
 		return kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, c.ID, c.Token, c.File)
 	}
 
+	upCtx.ProxyEndpoint.Path = "/controlPlanes"
 	return kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, c.id.String(), c.Token, c.File)
 }


### PR DESCRIPTION



<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates proxy path to includes controlPlanes.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
$ KUBECONFIG=hello.txt up ctp kubeconfig get 8c9f2f45-4fe1-4f97-b687-88e4d0436696 --token=bye
$ UP_MCP_EXPERIMENTAL=true up ctp kubeconfig get hello --token=hi
$ cat hello.txt

apiVersion: v1
clusters:
- cluster:
    server: https://proxy.upbound.io/controlPlanes/8c9f2f45-4fe1-4f97-b687-88e4d0436696/k8s
  name: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
- cluster:
    server: http://proxy.local.upbound.io/v1/controlPlanes/my-org/hello/k8s
  name: upbound-hello
contexts:
- context:
    cluster: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
    user: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
  name: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
- context:
    cluster: upbound-hello
    user: upbound-hello
  name: upbound-hello
current-context: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
kind: Config
preferences: {}
users:
- name: upbound-8c9f2f45-4fe1-4f97-b687-88e4d0436696
  user:
    token: bye
- name: upbound-hello
  user:
    token: hi
```