### PR TITLE
Allow skipping TLS verification on commands

### DIFF
--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -15,6 +15,7 @@
 package upbound
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -45,6 +46,10 @@ type Flags struct {
 	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command."`
 	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
 
+	// Insecure
+	InsecureSkipTLSVerify bool `env:"UP_INSECURE_SKIP_TLS_VERIFY" help:"[INSECURE] Skip verifying TLS certificates."`
+
+	// Hidden
 	APIEndpoint      *url.URL `env:"OVERRIDE_API_ENDPOINT" hidden:"" name:"override-api-endpoint" help:"Overrides the default API endpoint."`
 	ProxyEndpoint    *url.URL `env:"OVERRIDE_PROXY_ENDPOINT" hidden:"" name:"override-proxy-endpoint" help:"Overrides the default proxy endpoint."`
 	RegistryEndpoint *url.URL `env:"OVERRIDE_REGISTRY_ENDPOINT" hidden:"" name:"override-registry-endpoint" help:"Overrides the default registry endpoint."`
@@ -52,10 +57,13 @@ type Flags struct {
 
 // Context includes common data that Upbound consumers may utilize.
 type Context struct {
-	Profile          config.Profile
-	Token            string
-	Account          string
-	Domain           *url.URL
+	Profile config.Profile
+	Token   string
+	Account string
+	Domain  *url.URL
+
+	InsecureSkipTLSVerify bool
+
 	APIEndpoint      *url.URL
 	ProxyEndpoint    *url.URL
 	RegistryEndpoint *url.URL
@@ -120,6 +128,8 @@ func NewFromFlags(f Flags) (*Context, error) {
 		c.Account = c.Profile.Account
 	}
 
+	c.InsecureSkipTLSVerify = f.InsecureSkipTLSVerify
+
 	return c, nil
 }
 
@@ -135,10 +145,16 @@ func (c *Context) BuildSDKConfig(session string) (*up.Config, error) {
 		Value: session,
 	},
 	})
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: c.InsecureSkipTLSVerify,
+		},
+	}
 	client := up.NewClient(func(u *up.HTTPClient) {
 		u.BaseURL = c.APIEndpoint
 		u.HTTP = &http.Client{
-			Jar: cj,
+			Jar:       cj,
+			Transport: tr,
 		}
 		u.UserAgent = UserAgent
 	})


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds support for skipping TLS verification on all commands by passing
--insecure-skip-tls-verify or setting UP_INSECURE_SKIP_TLS_VERIFY.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up) go run ./cmd/up/ ctp -h
Usage: up controlplane <command>

Interact with control planes.

Flags:
  -h, --help                         Show context-sensitive help.
  -v, --version                      Print version and exit.

      --mcp-experimental             Use experimental managed control planes API ($UP_MCP_EXPERIMENTAL).
      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

controlplane
  controlplane create <name>
    Create a hosted control plane.

  controlplane delete <id>
    Delete a control plane.

  controlplane list
    List control planes for the account.

  controlplane kubeconfig get --token=STRING <control-plane-ID>
    Get a kubeconfig for a control plane.
🤖 (up) go run ./cmd/up/ ctp list
up: error: Get "https://api.local.upbound.io/v1/controlPlanes/my-org": x509: certificate signed by unknown authority (possibly because of "x509: invalid signature: parent certificate cannot sign this kind of certificate" while trying to verify candidate authority certificate "local.upbound.io")
exit status 1
🤖 (up) export UP_INSECURE_SKIP_TLS_VERIFY=true
🤖 (up) go run ./cmd/up/ ctp list
NAME           ID                                     STATUS
hasan-test-2   bf2c1509-932d-4034-8c40-02f02f397c48   ready
```