### PR TITLE
Only add /k8s to kubeconfig server if experimental

### DIFF
--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -15,9 +15,9 @@
 package kubeconfig
 
 import (
-	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/google/uuid"
@@ -74,10 +74,10 @@ func (c *getCmd) Run(experimental bool, upCtx *upbound.Context) error {
 	}
 
 	if experimental {
-		upCtx.ProxyEndpoint.Path = fmt.Sprintf("/v1/controlPlanes/%s", upCtx.Account)
-		return kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, c.ID, c.Token, c.File)
+		upCtx.ProxyEndpoint.Path = "/v1/controlPlanes"
+		return kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, path.Join(upCtx.Account, c.ID), c.Token, c.File, true)
 	}
 
 	upCtx.ProxyEndpoint.Path = "/controlPlanes"
-	return kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, c.id.String(), c.Token, c.File)
+	return kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, c.id.String(), c.Token, c.File, false)
 }


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes an issue where /k8s was incorrectly being appended to proxy URL
when not using MCP experimental mode.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up) KUBECONFIG=test.yaml up ctp kubeconfig get --mcp-experimental exp-test --token=something
🤖 (up) KUBECONFIG=test.yaml up ctp kubeconfig get e50b0bb0-48e9-4f1a-811b-f6a265c2afa9 --token=something
🤖 (up) cat test.yaml 
apiVersion: v1
clusters:
- cluster:
    server: https://proxy.upbound.io/controlPlanes/e50b0bb0-48e9-4f1a-811b-f6a265c2afa9
  name: upbound-e50b0bb0-48e9-4f1a-811b-f6a265c2afa9
- cluster:
    server: https://proxy.upbound.io/v1/controlPlanes/hasheddan/exp-test/k8s
  name: upbound-hasheddan-exp-test
contexts:
- context:
    cluster: upbound-e50b0bb0-48e9-4f1a-811b-f6a265c2afa9
    user: upbound-e50b0bb0-48e9-4f1a-811b-f6a265c2afa9
  name: upbound-e50b0bb0-48e9-4f1a-811b-f6a265c2afa9
- context:
    cluster: upbound-hasheddan-exp-test
    user: upbound-hasheddan-exp-test
  name: upbound-hasheddan-exp-test
current-context: upbound-e50b0bb0-48e9-4f1a-811b-f6a265c2afa9
kind: Config
preferences: {}
users:
- name: upbound-e50b0bb0-48e9-4f1a-811b-f6a265c2afa9
  user:
    token: something
- name: upbound-hasheddan-exp-test
  user:
    token: something


```