### PR TITLE
Do not prompt for username / password if token is provided

### DIFF
--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -72,6 +72,9 @@ func (c *loginCmd) AfterApply(kongCtx *kong.Context) error {
 		},
 	}
 	kongCtx.Bind(upCtx)
+	if c.Token != "" {
+		return nil
+	}
 	if c.Username == "" {
 		username, err := c.prompter.Prompt("Username", false)
 		if err != nil {


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes regression in up login where user was prompted for username and
password even if a token was provided. These two login methods should be
mutually exclusive.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #207 

> Note: requires backport to `release-0.12` and patch release.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

`make build` and `up login --token=<user-token>` with a valid user token and verified that I am not prompted for username / password and login is successful.