### PR TITLE
Only pass domain to docker-credential-up

### DIFF
--- a/cmd/docker-credential-up/main.go
+++ b/cmd/docker-credential-up/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/docker/docker-credential-helpers/credentials"
@@ -30,6 +31,10 @@ const (
 	domainEnv  = "UP_DOMAIN"
 )
 
+const (
+	errInvalidDomain = "invalid value for UP_DOMAIN"
+)
+
 func main() {
 	var v bool
 	flag.BoolVar(&v, "v", false, "Print CLI version and exit.")
@@ -40,9 +45,19 @@ func main() {
 		os.Exit(0)
 	}
 
+	domain := ""
+	if de, ok := os.LookupEnv(domainEnv); ok {
+		u, err := url.Parse(de)
+		if err != nil {
+			fmt.Fprintln(os.Stdout, errInvalidDomain)
+			os.Exit(1)
+		}
+		domain = u.Hostname()
+	}
+
 	// Build credential helper and defer execution to Docker.
 	h := credhelper.New(
-		credhelper.WithDomain(os.Getenv(domainEnv)),
+		credhelper.WithDomain(domain),
 		credhelper.WithProfile(os.Getenv(profileEnv)),
 	)
 	credentials.Serve(h)


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

up requires that commands provide a scheme in the UP_DOMAIN, but doing
so causes a failure to match to registry domain in docker-credential-up,
meaning that a separate UP_DOMAIN value must be used for up and
docker-credential-up. This corrects that behavior to parse the hostname
from UP_DOMAIN in docker-credential-up and only pass it along as the
domain for matching.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #191 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified by setting `UP_DOMAIN-https://upbound.io` and pushing successfully using `docker push` with `docker-credential-up` configured in `~/.docker/config.json`.