### PR TITLE
Move to pterm, emit success message for all operations, and support `--quiet` and `--pretty` global output config

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package controlplane
 
 import (
 	"github.com/alecthomas/kong"
@@ -21,14 +21,13 @@ import (
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 	op "github.com/upbound/up-sdk-go/service/oldplanes"
 
-	"github.com/upbound/up/cmd/up/controlplane"
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
 	"github.com/upbound/up/internal/upbound"
 )
 
 // AfterApply constructs and binds a control plane client to any subcommands
 // that have Run() methods that receive it.
-func (c *controlPlaneCmd) AfterApply(kongCtx *kong.Context) error {
+func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	upCtx, err := upbound.NewFromFlags(c.Flags)
 	if err != nil {
 		return err
@@ -46,11 +45,11 @@ func (c *controlPlaneCmd) AfterApply(kongCtx *kong.Context) error {
 	return nil
 }
 
-// controlPlaneCmd contains commands for interacting with control planes.
-type controlPlaneCmd struct {
-	Create controlplane.CreateCmd `cmd:"" help:"Create a hosted control plane."`
-	Delete controlplane.DeleteCmd `cmd:"" help:"Delete a control plane."`
-	List   controlplane.ListCmd   `cmd:"" help:"List control planes for the account."`
+// Cmd contains commands for interacting with control planes.
+type Cmd struct {
+	Create createCmd `cmd:"" group:"controlplane" help:"Create a hosted control plane."`
+	Delete deleteCmd `cmd:"" group:"controlplane" help:"Delete a control plane."`
+	List   listCmd   `cmd:"" group:"controlplane" help:"List control planes for the account."`
 
 	Kubeconfig kubeconfig.Cmd `cmd:"" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
 

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -50,6 +50,6 @@ func (c *CreateCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, o
 		}
 	}
 
-	p.Printfln("%s created.", c.Name)
+	p.Printfln("%s created", c.Name)
 	return nil
 }

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/pterm/pterm"
+
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 	op "github.com/upbound/up-sdk-go/service/oldplanes"
 	"github.com/upbound/up/internal/upbound"

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 
+	"github.com/pterm/pterm"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 	op "github.com/upbound/up-sdk-go/service/oldplanes"
 	"github.com/upbound/up/internal/upbound"
@@ -30,18 +31,24 @@ type CreateCmd struct {
 }
 
 // Run executes the create command.
-func (c *CreateCmd) Run(experimental bool, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
+func (c *CreateCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
 	if experimental {
-		_, err := cc.Create(context.Background(), upCtx.Account, &cp.ControlPlaneCreateParameters{
+		if _, err := cc.Create(context.Background(), upCtx.Account, &cp.ControlPlaneCreateParameters{
 			Name:        c.Name,
 			Description: c.Description,
-		})
-		return err
+		}); err != nil {
+			return err
+		}
+	} else {
+		if _, err := oc.Create(context.Background(), &op.ControlPlaneCreateParameters{
+			Account:     upCtx.Account,
+			Name:        c.Name,
+			Description: c.Description,
+		}); err != nil {
+			return err
+		}
 	}
-	_, err := oc.Create(context.Background(), &op.ControlPlaneCreateParameters{
-		Account:     upCtx.Account,
-		Name:        c.Name,
-		Description: c.Description,
-	})
-	return err
+
+	p.Printfln("%s created.", c.Name)
+	return nil
 }

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -24,15 +24,15 @@ import (
 	"github.com/upbound/up/internal/upbound"
 )
 
-// CreateCmd creates a control plane on Upbound.
-type CreateCmd struct {
+// createCmd creates a control plane on Upbound.
+type createCmd struct {
 	Name string `arg:"" required:"" help:"Name of control plane."`
 
 	Description string `short:"d" help:"Description for control plane."`
 }
 
 // Run executes the create command.
-func (c *CreateCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
+func (c *createCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
 	if experimental {
 		if _, err := cc.Create(context.Background(), upCtx.Account, &cp.ControlPlaneCreateParameters{
 			Name:        c.Name,

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/pterm/pterm"
 
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 	op "github.com/upbound/up-sdk-go/service/oldplanes"
@@ -44,9 +45,16 @@ type DeleteCmd struct {
 }
 
 // Run executes the delete command.
-func (c *DeleteCmd) Run(experimental bool, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
+func (c *DeleteCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
 	if experimental {
-		return cc.Delete(context.Background(), upCtx.Account, c.ID)
+		if err := cc.Delete(context.Background(), upCtx.Account, c.ID); err != nil {
+			return err
+		}
+	} else {
+		if err := oc.Delete(context.Background(), c.id); err != nil {
+			return err
+		}
 	}
-	return oc.Delete(context.Background(), c.id)
+	p.Printfln("%s deleted.", c.ID)
+	return nil
 }

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -55,6 +55,6 @@ func (c *DeleteCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, o
 			return err
 		}
 	}
-	p.Printfln("%s deleted.", c.ID)
+	p.Printfln("%s deleted", c.ID)
 	return nil
 }

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -26,7 +26,7 @@ import (
 )
 
 // AfterApply sets values in command after assignment and validation.
-func (c *DeleteCmd) AfterApply(experimental bool) error {
+func (c *deleteCmd) AfterApply(experimental bool) error {
 	if !experimental {
 		u, err := uuid.Parse(c.ID)
 		if err != nil {
@@ -37,15 +37,15 @@ func (c *DeleteCmd) AfterApply(experimental bool) error {
 	return nil
 }
 
-// DeleteCmd deletes a control plane on Upbound.
-type DeleteCmd struct {
+// deleteCmd deletes a control plane on Upbound.
+type deleteCmd struct {
 	id uuid.UUID
 
 	ID string `arg:"" help:"ID of control plane. ID is name if using experimental MCP API."`
 }
 
 // Run executes the delete command.
-func (c *DeleteCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
+func (c *deleteCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
 	if experimental {
 		if err := cc.Delete(context.Background(), upCtx.Account, c.ID); err != nil {
 			return err

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -90,6 +90,6 @@ func (c *getCmd) Run(experimental bool, p pterm.TextPrinter, upCtx *upbound.Cont
 		}
 	}
 
-	p.Printfln("Current context set to %s.", kubeCurCtx)
+	p.Printfln("Current context set to %s", kubeCurCtx)
 	return nil
 }

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -90,6 +90,6 @@ func (c *getCmd) Run(experimental bool, p pterm.TextPrinter, upCtx *upbound.Cont
 		}
 	}
 
-	p.Printfln("Current context set to %s", kubeCurCtx)
+	p.Printfln("Current context set to %s.", kubeCurCtx)
 	return nil
 }

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -53,7 +53,7 @@ func (c *ListCmd) Run(experimental bool, p pterm.TextPrinter, pt *pterm.TablePri
 		}
 	}
 	if len(cps) == 0 {
-		p.Printfln("No control planes found in %s.", upCtx.Account)
+		p.Printfln("No control planes found in %s", upCtx.Account)
 		return nil
 	}
 	data := make([][]string, len(cps)+1)
@@ -61,5 +61,5 @@ func (c *ListCmd) Run(experimental bool, p pterm.TextPrinter, pt *pterm.TablePri
 	for i, cp := range cps {
 		data[i+1] = []string{cp.ControlPlane.Name, cp.ControlPlane.ID.String(), string(cp.Status)}
 	}
-	return pt.WithHasHeader().WithHeaderStyle(&pterm.Style{}).WithData(data).Render()
+	return pt.WithHasHeader().WithData(data).Render()
 }

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 
+	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 
 	"github.com/upbound/up-sdk-go/service/accounts"
@@ -30,11 +31,17 @@ const (
 	maxItems = 100
 )
 
-// ListCmd list control planes in an account on Upbound.
-type ListCmd struct{}
+// AfterApply sets default values in command after assignment and validation.
+func (c *listCmd) AfterApply(experimental bool, kongCtx *kong.Context, upCtx *upbound.Context) error {
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+	return nil
+}
+
+// listCmd list control planes in an account on Upbound.
+type listCmd struct{}
 
 // Run executes the list command.
-func (c *ListCmd) Run(experimental bool, p pterm.TextPrinter, pt *pterm.TablePrinter, ac *accounts.Client, cc *cp.Client, upCtx *upbound.Context) error {
+func (c *listCmd) Run(experimental bool, p pterm.TextPrinter, pt *pterm.TablePrinter, ac *accounts.Client, cc *cp.Client, upCtx *upbound.Context) error {
 	var cps []cp.ControlPlaneResponse
 	var err error
 	if experimental {

--- a/cmd/up/license.go
+++ b/cmd/up/license.go
@@ -23,6 +23,6 @@ type licenseCmd struct{}
 
 // Run executes the license command.
 func (c *licenseCmd) Run(p pterm.TextPrinter) error { //nolint:unparam
-	p.Println("By using Up, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.html")
+	p.Printfln("By using Up, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.html")
 	return nil
 }

--- a/cmd/up/license.go
+++ b/cmd/up/license.go
@@ -15,16 +15,14 @@
 package main
 
 import (
-	"fmt"
-
-	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
 )
 
 // licenseCmd prints license information for using Up.
 type licenseCmd struct{}
 
 // Run executes the license command.
-func (c *licenseCmd) Run(kongCtx *kong.Context) error {
-	_, err := fmt.Fprintln(kongCtx.Stdout, "By using Up, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.html")
-	return err
+func (c *licenseCmd) Run(p pterm.TextPrinter) error {
+	p.Println("By using Up, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.html")
+	return nil
 }

--- a/cmd/up/license.go
+++ b/cmd/up/license.go
@@ -22,7 +22,7 @@ import (
 type licenseCmd struct{}
 
 // Run executes the license command.
-func (c *licenseCmd) Run(p pterm.TextPrinter) error {
+func (c *licenseCmd) Run(p pterm.TextPrinter) error { //nolint:unparam
 	p.Println("By using Up, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.html")
 	return nil
 }

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -28,6 +28,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 
 	"github.com/upbound/up/internal/config"
 	uphttp "github.com/upbound/up/internal/http"
@@ -108,7 +109,7 @@ type loginCmd struct {
 }
 
 // Run executes the login command.
-func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
+func (c *loginCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { // nolint:gocyclo
 	if c.Token == "-" {
 		b, err := io.ReadAll(c.stdin)
 		if err != nil {
@@ -172,7 +173,11 @@ func (c *loginCmd) Run(upCtx *upbound.Context) error { // nolint:gocyclo
 			return errors.Wrap(err, errLoginFailed)
 		}
 	}
-	return errors.Wrap(upCtx.CfgSrc.UpdateConfig(upCtx.Cfg), errUpdateConfig)
+	if err := upCtx.CfgSrc.UpdateConfig(upCtx.Cfg); err != nil {
+		return errors.Wrap(err, errUpdateConfig)
+	}
+	p.Printfln("%s logged in.", auth.ID)
+	return nil
 }
 
 // auth is the request body sent to authenticate a user or token.

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -176,7 +176,7 @@ func (c *loginCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { // n
 	if err := upCtx.CfgSrc.UpdateConfig(upCtx.Cfg); err != nil {
 		return errors.Wrap(err, errUpdateConfig)
 	}
-	p.Printfln("%s logged in.", auth.ID)
+	p.Printfln("%s logged in", auth.ID)
 	return nil
 }
 

--- a/cmd/up/login_test.go
+++ b/cmd/up/login_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 
 	"github.com/upbound/up/internal/config"
 	"github.com/upbound/up/internal/http/mocks"
@@ -66,7 +67,7 @@ func TestRun(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.err, tc.cmd.Run(tc.ctx), test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.err, tc.cmd.Run(pterm.DefaultBasicText.WithWriter(io.Discard), tc.ctx), test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nRun(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})

--- a/cmd/up/logout.go
+++ b/cmd/up/logout.go
@@ -83,6 +83,6 @@ func (c *logoutCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 		return errors.Wrap(err, errUpdateConfig)
 	}
 
-	p.Printfln("%s logged out.", profile.ID)
+	p.Printfln("%s logged out", profile.ID)
 	return nil
 }

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 
+	"github.com/upbound/up/cmd/up/controlplane"
 	"github.com/upbound/up/cmd/up/upbound"
 	"github.com/upbound/up/cmd/up/uxp"
 	"github.com/upbound/up/cmd/up/xpkg"
@@ -51,7 +52,6 @@ func (c *cli) AfterApply(ctx *kong.Context) error { //nolint:unparam
 		ctx.Stdout, ctx.Stderr = io.Discard, io.Discard
 	}
 	ctx.BindTo(pterm.DefaultBasicText.WithWriter(ctx.Stdout), (*pterm.TextPrinter)(nil))
-	ctx.Bind(pterm.DefaultTable.WithWriter(ctx.Stdout).WithSeparator("   "))
 	// TODO(hasheddan): configure pretty print styling to match Upbound
 	// branding.
 	if !c.Pretty {
@@ -69,14 +69,14 @@ type cli struct {
 
 	License licenseCmd `cmd:"" help:"Print Up license information."`
 
-	Login        loginCmd        `cmd:"" help:"Login to Upbound."`
-	Logout       logoutCmd       `cmd:"" help:"Logout of Upbound."`
-	ControlPlane controlPlaneCmd `cmd:"" name:"controlplane" aliases:"ctp" group:"controlplane" help:"Interact with control planes."`
+	Login  loginCmd  `cmd:"" help:"Login to Upbound."`
+	Logout logoutCmd `cmd:"" help:"Logout of Upbound."`
 
-	Upbound upbound.Cmd `cmd:"" help:"Interact with Upbound."`
-	UXP     uxp.Cmd     `cmd:"" help:"Interact with UXP."`
-	XPKG    xpkg.Cmd    `cmd:"" help:"Interact with UXP packages."`
-	XPLS    xpls.Cmd    `cmd:"" help:"Start xpls language server."`
+	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
+	Upbound      upbound.Cmd      `cmd:"" help:"Interact with Upbound."`
+	UXP          uxp.Cmd          `cmd:"" help:"Interact with UXP."`
+	XPKG         xpkg.Cmd         `cmd:"" help:"Interact with UXP packages."`
+	XPLS         xpls.Cmd         `cmd:"" help:"Start xpls language server."`
 }
 
 func main() {

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -46,7 +46,7 @@ func (v versionFlag) BeforeApply(ctx *kong.Context) error { // nolint:unparam
 }
 
 // AfterApply configures global settings before executing commands.
-func (c *cli) AfterApply(ctx *kong.Context) error {
+func (c *cli) AfterApply(ctx *kong.Context) error { //nolint:unparam
 	if c.Quiet {
 		ctx.Stdout, ctx.Stderr = io.Discard, io.Discard
 	}

--- a/cmd/up/uxp/install.go
+++ b/cmd/up/uxp/install.go
@@ -109,6 +109,6 @@ func (c *installCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
 	if err != nil {
 		return err
 	}
-	p.Printfln("UXP %s installed.", curVer)
+	p.Printfln("UXP %s installed", curVer)
 	return nil
 }

--- a/cmd/up/uxp/install.go
+++ b/cmd/up/uxp/install.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,7 +87,7 @@ type installCmd struct {
 }
 
 // Run executes the install command.
-func (c *installCmd) Run(insCtx *install.Context) error {
+func (c *installCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
 	// Create namespace if it does not exist.
 	_, err := c.kClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -100,9 +101,14 @@ func (c *installCmd) Run(insCtx *install.Context) error {
 	if err != nil {
 		return errors.Wrap(err, errParseInstallParameters)
 	}
-	err = c.mgr.Install(c.Version, params)
+	if err = c.mgr.Install(c.Version, params); err != nil {
+		return err
+	}
+
+	curVer, err := c.mgr.GetCurrentVersion()
 	if err != nil {
 		return err
 	}
+	p.Printfln("UXP %s installed.", curVer)
 	return nil
 }

--- a/cmd/up/uxp/uninstall.go
+++ b/cmd/up/uxp/uninstall.go
@@ -17,6 +17,7 @@ package uxp
 import (
 	"net/url"
 
+	"github.com/pterm/pterm"
 	"github.com/upbound/up/internal/install"
 	"github.com/upbound/up/internal/install/helm"
 )
@@ -42,6 +43,10 @@ type uninstallCmd struct {
 }
 
 // Run executes the uninstall command.
-func (c *uninstallCmd) Run(insCtx *install.Context) error {
-	return c.mgr.Uninstall()
+func (c *uninstallCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
+	if err := c.mgr.Uninstall(); err != nil {
+		return err
+	}
+	p.Println("UXP uninstalled.")
+	return nil
 }

--- a/cmd/up/uxp/uninstall.go
+++ b/cmd/up/uxp/uninstall.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 
 	"github.com/pterm/pterm"
+
 	"github.com/upbound/up/internal/install"
 	"github.com/upbound/up/internal/install/helm"
 )

--- a/cmd/up/uxp/uninstall.go
+++ b/cmd/up/uxp/uninstall.go
@@ -48,6 +48,6 @@ func (c *uninstallCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
 	if err := c.mgr.Uninstall(); err != nil {
 		return err
 	}
-	p.Println("UXP uninstalled.")
+	p.Println("UXP uninstalled")
 	return nil
 }

--- a/cmd/up/uxp/uninstall.go
+++ b/cmd/up/uxp/uninstall.go
@@ -48,6 +48,6 @@ func (c *uninstallCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
 	if err := c.mgr.Uninstall(); err != nil {
 		return err
 	}
-	p.Println("UXP uninstalled")
+	p.Printfln("UXP uninstalled")
 	return nil
 }

--- a/cmd/up/uxp/upgrade.go
+++ b/cmd/up/uxp/upgrade.go
@@ -92,6 +92,6 @@ func (c *upgradeCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
 	if err != nil {
 		return err
 	}
-	p.Printfln("UXP upgraded to %s.", curVer)
+	p.Printfln("UXP upgraded to %s", curVer)
 	return nil
 }

--- a/cmd/up/uxp/upgrade.go
+++ b/cmd/up/uxp/upgrade.go
@@ -18,6 +18,7 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 	"sigs.k8s.io/yaml"
 
 	"github.com/upbound/up/internal/install"
@@ -79,10 +80,18 @@ type upgradeCmd struct {
 }
 
 // Run executes the upgrade command.
-func (c *upgradeCmd) Run(insCtx *install.Context) error {
+func (c *upgradeCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
 	params, err := c.parser.Parse()
 	if err != nil {
 		return errors.Wrap(err, errParseUpgradeParameters)
 	}
-	return c.mgr.Upgrade(c.Version, params)
+	if err := c.mgr.Upgrade(c.Version, params); err != nil {
+		return err
+	}
+	curVer, err := c.mgr.GetCurrentVersion()
+	if err != nil {
+		return err
+	}
+	p.Printfln("UXP upgraded to %s.", curVer)
+	return nil
 }

--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -102,7 +103,7 @@ type buildCmd struct {
 }
 
 // Run executes the build command.
-func (c *buildCmd) Run() error { //nolint:gocyclo
+func (c *buildCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
 	var buildOpts []xpkg.BuildOpt
 	if c.Controller != "" {
 		ref, err := name.ParseReference(c.Controller)
@@ -147,6 +148,7 @@ func (c *buildCmd) Run() error { //nolint:gocyclo
 	if err := tarball.Write(nil, img, f); err != nil {
 		return err
 	}
+	p.Printfln("xpkg saved to %s", output)
 	return nil
 }
 

--- a/cmd/up/xpkg/dep.go
+++ b/cmd/up/xpkg/dep.go
@@ -129,6 +129,7 @@ func (c *depCmd) Run(ctx context.Context, p pterm.TextPrinter) error {
 	}
 	if len(deps) == 0 {
 		p.Println("xpkg cache up to date.")
+		return nil
 	}
 	p.Println("Dependencies added to xpkg cache:")
 	for _, d := range deps {

--- a/cmd/up/xpkg/dep.go
+++ b/cmd/up/xpkg/dep.go
@@ -119,7 +119,7 @@ func (c *depCmd) Run(ctx context.Context, p pterm.TextPrinter) error {
 		if err := c.userSuppliedDep(ctx); err != nil {
 			return err
 		}
-		p.Printfln("%s added to xpkg cache.", c.Package)
+		p.Printfln("%s added to xpkg cache", c.Package)
 		return nil
 	}
 
@@ -128,7 +128,7 @@ func (c *depCmd) Run(ctx context.Context, p pterm.TextPrinter) error {
 		return err
 	}
 	if len(deps) == 0 {
-		p.Println("xpkg cache up to date.")
+		p.Println("xpkg cache up to date")
 		return nil
 	}
 	p.Println("Dependencies added to xpkg cache:")

--- a/cmd/up/xpkg/init.go
+++ b/cmd/up/xpkg/init.go
@@ -15,12 +15,14 @@
 package xpkg
 
 import (
+	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	v1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 
 	"github.com/upbound/up/internal/input"
@@ -90,7 +92,7 @@ type initCmd struct {
 }
 
 // Run executes the init command.
-func (c *initCmd) Run() error {
+func (c *initCmd) Run(p pterm.TextPrinter) error {
 	fileBody := []byte{}
 	var err error
 
@@ -114,7 +116,12 @@ func (c *initCmd) Run() error {
 	)
 
 	// write out file named crossplane.yaml to the configured location
-	return writer.NewMetaFile()
+	if err := writer.NewMetaFile(); err != nil {
+		return err
+	}
+
+	p.Printfln("xpkg initialized at %s", path.Join(c.root, xpkg.MetaFile))
+	return nil
 }
 
 func (c *initCmd) initCommon() error {

--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
 
@@ -62,7 +63,7 @@ type pushCmd struct {
 }
 
 // Run runs the push cmd.
-func (c *pushCmd) Run() error { //nolint:gocyclo
+func (c *pushCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
 	tag, err := name.NewTag(c.Tag, name.WithDefaultRegistry(upboundRegistry))
 	if err != nil {
 		return err
@@ -163,6 +164,8 @@ func (c *pushCmd) Run() error { //nolint:gocyclo
 			return err
 		}
 	}
+
+	p.Printfln("xpkg pushed to %s", tag.String())
 	return nil
 }
 

--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 
 	"github.com/upbound/up/internal/xpkg"
@@ -124,7 +125,7 @@ type xpExtractCmd struct {
 }
 
 // Run runs the xp extract cmd.
-func (c *xpExtractCmd) Run() error { //nolint:gocyclo
+func (c *xpExtractCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
 	// NOTE(hasheddan): most of the logic in this method is from the machinery
 	// used in Crossplane's package cache and should be updated to use shared
 	// libraries if moved to crossplane-runtime.
@@ -193,8 +194,6 @@ func (c *xpExtractCmd) Run() error { //nolint:gocyclo
 	if err != nil {
 		return errors.Wrap(err, errCreateOutputFile)
 	}
-	// NOTE(hasheddan): we don't check error on deferred file close as Close()
-	// is explicitly called in the happy path.
 	defer cf.Close() //nolint:errcheck
 	w, err := gzip.NewWriterLevel(cf, gzip.BestSpeed)
 	if err != nil {
@@ -208,5 +207,7 @@ func (c *xpExtractCmd) Run() error { //nolint:gocyclo
 	if err := w.Close(); err != nil {
 		return errors.Wrap(err, errExtractPackageContents)
 	}
-	return cf.Close()
+
+	p.Printfln("xpkg contents extracted to %s", out)
+	return nil
 }

--- a/cmd/up/xpkg/xpextract_test.go
+++ b/cmd/up/xpkg/xpextract_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 
 	"github.com/upbound/up/internal/xpkg"
@@ -122,7 +123,7 @@ func TestXPExtractRun(t *testing.T) {
 				fetch:  tc.fetch,
 				name:   tc.name,
 				Output: tc.out,
-			}).Run()
+			}).Run(pterm.DefaultBasicText.WithWriter(io.Discard))
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nRun(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/goreleaser/nfpm/v2 v2.5.1
 	github.com/pkg/errors v0.9.1
+	github.com/pterm/pterm v0.12.45
 	github.com/radovskyb/watcher v1.0.7
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.1.0
@@ -32,7 +33,6 @@ require (
 	k8s.io/api v0.24.3
 	k8s.io/apiextensions-apiserver v0.24.3
 	k8s.io/apimachinery v0.24.3
-	k8s.io/cli-runtime v0.24.3
 	k8s.io/client-go v0.24.3
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42
 	k8s.io/kubectl v0.24.3
@@ -42,6 +42,8 @@ require (
 )
 
 require (
+	atomicgo.dev/cursor v0.1.1 // indirect
+	atomicgo.dev/keyboard v0.2.8 // indirect
 	cloud.google.com/go v0.99.0 // indirect
 	github.com/AlekSi/pointer v1.1.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -71,6 +73,7 @@ require (
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 // indirect
+	github.com/containerd/console v1.0.3 // indirect
 	github.com/containerd/containerd v1.6.3 // indirect
 	github.com/containerd/continuity v0.2.2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.10.1 // indirect
@@ -113,6 +116,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/rpmpack v0.0.0-20210410105602-e20c988a6f5a // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/gookit/color v1.5.0 // indirect
 	github.com/goreleaser/chglog v0.1.2 // indirect
 	github.com/goreleaser/fileglob v1.2.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
@@ -132,6 +136,7 @@ require (
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.4 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/lithammer/fuzzysearch v1.1.5 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -179,6 +184,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	go.opentelemetry.io/contrib v0.20.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0 // indirect
 	go.opentelemetry.io/otel v1.8.0 // indirect
@@ -196,7 +202,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
+	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
@@ -210,6 +216,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiserver v0.24.3 // indirect
+	k8s.io/cli-runtime v0.24.3 // indirect
 	k8s.io/component-base v0.24.3 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	oras.land/oras-go v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+atomicgo.dev/cursor v0.1.1 h1:0t9sxQomCTRh5ug+hAMCs59x/UmC9QL6Ci5uosINKD4=
+atomicgo.dev/cursor v0.1.1/go.mod h1:Lr4ZJB3U7DfPPOkbH7/6TOtJ4vFGHlgj1nc+n900IpU=
+atomicgo.dev/keyboard v0.2.8 h1:Di09BitwZgdTV1hPyX/b9Cqxi8HVuJQwWivnZUEqlj4=
+atomicgo.dev/keyboard v0.2.8/go.mod h1:BC4w9g00XkxH/f1HXhW2sXmJFOCWbKn9xrOunSFtExQ=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 bazil.org/fuse v0.0.0-20200407214033-5883e5a4b512/go.mod h1:FbcW6z/2VytnFDhZfumh8Ss8zxHE6qpMP5sHTRe0EaM=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -105,6 +109,14 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20200415212048-7901bc822317/go.mod h1:DF8FZRxMHMGv/vP2lQP6h+dYzzjpuRn24VeRiYn3qjQ=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/MarvinJWendt/testza v0.1.0/go.mod h1:7AxNvlfeHP7Z/hDQ5JtE3OKYT3XFUeLCDE2DQninSqs=
+github.com/MarvinJWendt/testza v0.2.1/go.mod h1:God7bhG8n6uQxwdScay+gjm9/LnO4D3kkcZX4hv9Rp8=
+github.com/MarvinJWendt/testza v0.2.8/go.mod h1:nwIcjmr0Zz+Rcwfh3/4UhBp7ePKVhuBExvZqnKYWlII=
+github.com/MarvinJWendt/testza v0.2.10/go.mod h1:pd+VWsoGUiFtq+hRKSU1Bktnn+DMCSrDrXDpX2bG66k=
+github.com/MarvinJWendt/testza v0.2.12/go.mod h1:JOIegYyV7rX+7VZ9r77L/eH6CfJHHzXjB69adAhzZkI=
+github.com/MarvinJWendt/testza v0.3.0/go.mod h1:eFcL4I0idjtIx8P9C6KkAuLgATNKpX4/2oUqKc6bF2c=
+github.com/MarvinJWendt/testza v0.4.2 h1:Vbw9GkSB5erJI2BPnBL9SVGV9myE+XmUSFahBGUhW2Q=
+github.com/MarvinJWendt/testza v0.4.2/go.mod h1:mSdhXiKH8sg/gQehJ63bINcCKp7RtYewEjXsvsVUPbE=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -189,6 +201,7 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.28.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -291,6 +304,7 @@ github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
+github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/containerd v1.2.10/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -742,6 +756,9 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
+github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
+github.com/gookit/color v1.5.0 h1:1Opow3+BWDwqor78DcJkJCIwnkviFi+rrOANki9BUFw=
+github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/goreleaser/chglog v0.1.2 h1:tdzAb/ILeMnphzI9zQ7Nkq+T8R9qyXli8GydD8plFRY=
@@ -878,6 +895,10 @@ github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
+github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
+github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -907,6 +928,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
+github.com/lithammer/fuzzysearch v1.1.5 h1:Ag7aKU08wp0R9QCfF4GoGST9HbmAIeLP7xwMrOBEp1c=
+github.com/lithammer/fuzzysearch v1.1.5/go.mod h1:1R1LRNk7yKid1BaQkmuLQaHruxcC4HmAH30Dh61Ih1Q=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1158,6 +1181,15 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pterm/pterm v0.12.27/go.mod h1:PhQ89w4i95rhgE+xedAoqous6K9X+r6aSOI2eFF7DZI=
+github.com/pterm/pterm v0.12.29/go.mod h1:WI3qxgvoQFFGKGjGnJR849gU0TsEOvKn5Q8LlY1U7lg=
+github.com/pterm/pterm v0.12.30/go.mod h1:MOqLIyMOgmTDz9yorcYbcw+HsgoZo3BQfg2wtl3HEFE=
+github.com/pterm/pterm v0.12.31/go.mod h1:32ZAWZVXD7ZfG0s8qqHXePte42kdz8ECtRyEejaWgXU=
+github.com/pterm/pterm v0.12.33/go.mod h1:x+h2uL+n7CP/rel9+bImHD5lF3nM9vJj80k9ybiiTTE=
+github.com/pterm/pterm v0.12.36/go.mod h1:NjiL09hFhT/vWjQHSj1athJpx6H8cjpHXNAK5bUw8T8=
+github.com/pterm/pterm v0.12.40/go.mod h1:ffwPLwlbXxP+rxT0GsgDTzS3y3rmpAO1NMjUkGTYf8s=
+github.com/pterm/pterm v0.12.45 h1:5HATKLTDjl9D74b0x7yiHzFI7OADlSXK3yHrJNhRwZE=
+github.com/pterm/pterm v0.12.45/go.mod h1:hJgLlBafm45w/Hr0dKXxY//POD7CgowhePaG1sdPNBg=
 github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
 github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
@@ -1314,6 +1346,8 @@ github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -1696,6 +1730,7 @@ golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1703,11 +1738,13 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -49,12 +49,12 @@ func GetKubeConfig(path string) (*rest.Config, error) {
 // BuildControlPlaneKubeconfig builds a kubeconfig entry for a control plane.
 // TODO(hasheddan): consider refactoring this function to be less specific to
 // the one command that consumes it.
-func BuildControlPlaneKubeconfig(proxy *url.URL, id string, token, kube string, experimental bool) error { //nolint:interfacer
+func BuildControlPlaneKubeconfig(proxy *url.URL, id string, token, kube string, experimental bool) (string, error) { //nolint:interfacer
 	po := clientcmd.NewDefaultPathOptions()
 	po.LoadingRules.ExplicitPath = kube
 	conf, err := po.GetStartingConfig()
 	if err != nil {
-		return err
+		return "", err
 	}
 	key := fmt.Sprintf(UpboundKubeconfigKeyFmt, strings.ReplaceAll(id, "/", "-"))
 	proxy.Path = path.Join(proxy.Path, id)
@@ -72,5 +72,5 @@ func BuildControlPlaneKubeconfig(proxy *url.URL, id string, token, kube string, 
 		AuthInfo: key,
 	}
 	conf.CurrentContext = key
-	return clientcmd.ModifyConfig(po, *conf, true)
+	return key, clientcmd.ModifyConfig(po, *conf, true)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Supports the -q,--quiet and --pretty flags to allow configuring whether
and how output is emitted globally. Also binds pterm text and table
printers to context for commands to consume as needed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Moves all commands other than up upbound and xpls to use bound pterm
writers and emit output on success unless supressed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Tested commands with updated output:

```
🤖 (up) up ctp list
NAME          ID                                     STATUS
tt-test-001   3fa92104-bfbc-40f0-ac46-81c84579cb34   ready 
tt-test-003   6bc0d6aa-7eb0-4723-b26e-1dc50a70c232   ready 
🤖 (up) up -h
Usage: up <command>

The Upbound CLI

Flags:
  -h, --help       Show context-sensitive help.
  -v, --version    Print version and exit.
  -q, --quiet      Suppress all output.
      --pretty     Pretty print output.

Commands:
  license
    Print Up license information.

  login
    Login to Upbound.

  logout
    Logout of Upbound.

controlplane
  controlplane create <name>
    Create a hosted control plane.

  controlplane delete <id>
    Delete a control plane.

  controlplane list
    List control planes for the account.

  controlplane kubeconfig get --token=STRING <control-plane-ID>
    Get a kubeconfig for a control plane.

upbound
  upbound install <version>
    Install Upbound.

  upbound mail
    [EXPERIMENTAL] Run a local mail portal.

  upbound uninstall [<name>]
    Uninstall Upbound.

  upbound upgrade <version>
    Upgrade Upbound.

uxp
  uxp install [<version>]
    Install UXP.

  uxp uninstall
    Uninstall UXP.

  uxp upgrade [<version>]
    Upgrade UXP.

xpkg
  xpkg build
    Build a package.

  xpkg xp-extract [<package>]
    [EXPERIMENTAL] Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default.

  xpkg init
    Initialize a package.

  xpkg dep [<package>]
    Manage package dependencies.

  xpkg push <tag>
    Push a package.

xpls
  xpls serve
    run a server for Crossplane definitions using the Language Server Protocol.

Run "up <command> --help" for more information on a command.
🤖 (up) up ctp kubeconfig get --token=blah tt-test-001 -f out.kube
Current context set to upbound-my-org-tt-test-001.
🤖 (up) cat out.kube 
apiVersion: v1
clusters:
- cluster:
    server: https://proxy.local.upbound.io/v1/controlPlanes/my-org/tt-test-001/k8s
  name: upbound-my-org-tt-test-001
contexts:
- context:
    cluster: upbound-my-org-tt-test-001
    user: upbound-my-org-tt-test-001
  name: upbound-my-org-tt-test-001
current-context: upbound-my-org-tt-test-001
kind: Config
preferences: {}
users:
- name: upbound-my-org-tt-test-001
  user:
    token: blah
🤖 (up) up login
Username: orgadmin
Password: 
orgadmin logged in.
🤖 (up) up logout
orgadmin logged out.
🤖 (up) up xpkg init -p ./blah
Package name: testing
What version contraints of Crossplane will this package be compatible with? [e.g. v1.0.0, >=v1.0.0-0, etc.]: v1.0.0
Add dependencies? [y/n]: n
xpkg initialized at /home/dan/code/github.com/upbound/up/blah/crossplane.yaml
```