### PR TITLE
Add support for repository management and create on push

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -32,7 +32,6 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
-	kongCtx.Bind(upCtx)
 	cfg, err := upCtx.BuildSDKConfig(upCtx.Profile.Session)
 	if err != nil {
 		return err

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -74,7 +74,7 @@ type cli struct {
 	Logout logoutCmd `cmd:"" help:"Logout of Upbound."`
 
 	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
-	Repository   repository.Cmd   `cmd:"" name:"repository" aliases:"r" help:"Interact with repositories."`
+	Repository   repository.Cmd   `cmd:"" name:"repository" aliases:"repo" help:"Interact with repositories."`
 	Upbound      upbound.Cmd      `cmd:"" help:"Interact with Upbound."`
 	UXP          uxp.Cmd          `cmd:"" help:"Interact with UXP."`
 	XPKG         xpkg.Cmd         `cmd:"" help:"Interact with UXP packages."`

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pterm/pterm"
 
 	"github.com/upbound/up/cmd/up/controlplane"
+	"github.com/upbound/up/cmd/up/repository"
 	"github.com/upbound/up/cmd/up/upbound"
 	"github.com/upbound/up/cmd/up/uxp"
 	"github.com/upbound/up/cmd/up/xpkg"
@@ -73,6 +74,7 @@ type cli struct {
 	Logout logoutCmd `cmd:"" help:"Logout of Upbound."`
 
 	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
+	Repository   repository.Cmd   `cmd:"" name:"repository" aliases:"r" help:"Interact with repositories."`
 	Upbound      upbound.Cmd      `cmd:"" help:"Interact with Upbound."`
 	UXP          uxp.Cmd          `cmd:"" help:"Interact with UXP."`
 	XPKG         xpkg.Cmd         `cmd:"" help:"Interact with UXP packages."`

--- a/cmd/up/repository/create.go
+++ b/cmd/up/repository/create.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"context"
+
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up-sdk-go/service/repositories"
+
+	"github.com/upbound/up/internal/upbound"
+)
+
+// createCmd creates a repository on Upbound.
+type createCmd struct {
+	Name string `arg:"" required:"" help:"Name of repository."`
+}
+
+// Run executes the create command.
+func (c *createCmd) Run(p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
+	if err := rc.CreateOrUpdate(context.Background(), upCtx.Account, c.Name); err != nil {
+		return err
+	}
+	p.Printfln("%s/%s created", upCtx.Account, c.Name)
+	return nil
+}

--- a/cmd/up/repository/delete.go
+++ b/cmd/up/repository/delete.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"context"
+
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up-sdk-go/service/repositories"
+
+	"github.com/upbound/up/internal/upbound"
+)
+
+// deleteCmd deletes a repository on Upbound.
+type deleteCmd struct {
+	Name string `arg:"" required:"" help:"Name of repository."`
+}
+
+// Run executes the delete command.
+func (c *deleteCmd) Run(p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
+	if err := rc.Delete(context.Background(), upCtx.Account, c.Name); err != nil {
+		return err
+	}
+	p.Printfln("%s/%s deleted", upCtx.Account, c.Name)
+	return nil
+}

--- a/cmd/up/repository/list.go
+++ b/cmd/up/repository/list.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/upbound/up-sdk-go/service/common"
+	"github.com/upbound/up-sdk-go/service/repositories"
+
+	"github.com/upbound/up/internal/upbound"
+)
+
+const (
+	maxItems = 100
+)
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+	return nil
+}
+
+// listCmd lists repositories in an account on Upbound.
+type listCmd struct{}
+
+// Run executes the list command.
+func (c *listCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, rc *repositories.Client, upCtx *upbound.Context) error {
+	rList, err := rc.List(context.Background(), upCtx.Account, common.WithSize(maxItems))
+	if err != nil {
+		return err
+	}
+	if len(rList.Repositories) == 0 {
+		p.Printfln("No repositories found in %s", upCtx.Account)
+		return nil
+	}
+	data := make([][]string, len(rList.Repositories)+1)
+	data[0] = []string{"NAME", "TYPE", "PUBLIC", "UPDATED"}
+	for i, r := range rList.Repositories {
+		rt := "unknown"
+		if r.Type != nil {
+			rt = string(*r.Type)
+		}
+		u := "n/a"
+		if r.UpdatedAt != nil {
+			u = duration.HumanDuration(time.Since(*r.UpdatedAt))
+		}
+		data[i+1] = []string{r.Name, rt, strconv.FormatBool(r.Public), u}
+	}
+	return pt.WithHasHeader().WithData(data).Render()
+}

--- a/cmd/up/repository/repository.go
+++ b/cmd/up/repository/repository.go
@@ -16,6 +16,7 @@ package repository
 
 import (
 	"github.com/alecthomas/kong"
+
 	"github.com/upbound/up-sdk-go/service/repositories"
 
 	"github.com/upbound/up/internal/upbound"

--- a/cmd/up/repository/repository.go
+++ b/cmd/up/repository/repository.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"github.com/alecthomas/kong"
+	"github.com/upbound/up-sdk-go/service/repositories"
+
+	"github.com/upbound/up/internal/upbound"
+)
+
+// AfterApply constructs and binds a repositories client to any subcommands
+// that have Run() methods that receive it.
+func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
+	upCtx, err := upbound.NewFromFlags(c.Flags)
+	if err != nil {
+		return err
+	}
+	cfg, err := upCtx.BuildSDKConfig(upCtx.Profile.Session)
+	if err != nil {
+		return err
+	}
+	kongCtx.Bind(upCtx)
+	kongCtx.Bind(repositories.NewClient(cfg))
+	return nil
+}
+
+// Cmd contains commands for interacting with repositories.
+type Cmd struct {
+	Create createCmd `cmd:"" group:"repository" help:"Create a repository."`
+	Delete deleteCmd `cmd:"" group:"repository" help:"Delete a repository."`
+	List   listCmd   `cmd:"" group:"repository" help:"List repositories for the account."`
+
+	// Common Upbound API configuration
+	Flags upbound.Flags `embed:""`
+}

--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 
+	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/xpkg"
 )
 
@@ -102,7 +103,11 @@ func (c *xpExtractCmd) AfterApply() error {
 		if c.Package == "" {
 			return errors.New(errMustProvideTag)
 		}
-		name, err := name.ParseReference(c.Package, name.WithDefaultRegistry(upboundRegistry))
+		upCtx, err := upbound.NewFromFlags(c.Flags)
+		if err != nil {
+			return err
+		}
+		name, err := name.ParseReference(c.Package, name.WithDefaultRegistry(upCtx.RegistryEndpoint.Hostname()))
 		if err != nil {
 			return errors.Wrap(err, errInvalidTag)
 		}
@@ -122,6 +127,9 @@ type xpExtractCmd struct {
 	FromDaemon bool   `xor:"xp-extract-from" help:"Indicates that the image should be fetched from the Docker daemon."`
 	FromXpkg   bool   `xor:"xp-extract-from" help:"Indicates that the image should be fetched from a local xpkg. If package is not specified and only one exists in current directory it will be used."`
 	Output     string `short:"o" help:"Package output file path. Extension must be .gz or will be replaced." default:"out.gz"`
+
+	// Common Upbound API configuration
+	Flags upbound.Flags `embed:""`
 }
 
 // Run runs the xp extract cmd.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds repository commands for create, list, and delete.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds an optional --create flag to up xpkg push to support creating a
repository on push if it does not exist.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #216 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up) up r list
No repositories found in hasheddan
🤖 (up) up xpkg push --create hasheddan/create-on-push:v0.0.1
xpkg pushed to hasheddan/create-on-push:v0.0.1
🤖 (up) up r list
NAME             TYPE            PUBLIC   UPDATED
create-on-push   configuration   false    6s     
🤖 (up) up r delete create-on-push
hasheddan/create-on-push deleted
🤖 (up) up r list
No repositories found in hasheddan
```