### PR TITLE
Move experimental and preview commands to `alpha` group 

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -46,9 +46,9 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for interacting with control planes.
 type Cmd struct {
-	Create createCmd `cmd:"" group:"controlplane" help:"Create a hosted control plane."`
-	Delete deleteCmd `cmd:"" group:"controlplane" help:"Delete a control plane."`
-	List   listCmd   `cmd:"" group:"controlplane" help:"List control planes for the account."`
+	Create createCmd `cmd:"" help:"Create a hosted control plane."`
+	Delete deleteCmd `cmd:"" help:"Delete a control plane."`
+	List   listCmd   `cmd:"" help:"List control planes for the account."`
 
 	Kubeconfig kubeconfig.Cmd `cmd:"" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
 

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -78,15 +78,19 @@ type cli struct {
 
 	Login        loginCmd         `cmd:"" help:"Login to Upbound."`
 	Logout       logoutCmd        `cmd:"" help:"Logout of Upbound."`
-	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
+	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" hidden:"" help:"Interact with control planes."`
 	Profile      profile.Cmd      `cmd:"" help:"Interact with Upbound Profiles"`
 	Organization organization.Cmd `cmd:"" name:"organization" aliases:"org" help:"Interact with organizations."`
 	Repository   repository.Cmd   `cmd:"" name:"repository" aliases:"repo" help:"Interact with repositories."`
 	Robot        robot.Cmd        `cmd:"" name:"robot" help:"Interact with robots."`
-	Upbound      upbound.Cmd      `cmd:"" help:"Interact with Upbound."`
+	Upbound      upbound.Cmd      `cmd:"" hidden:"" help:"Interact with Upbound."`
 	UXP          uxp.Cmd          `cmd:"" help:"Interact with UXP."`
 	XPKG         xpkg.Cmd         `cmd:"" help:"Interact with UXP packages."`
 	XPLS         xpls.Cmd         `cmd:"" help:"Start xpls language server."`
+	Alpha        struct {
+		ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" group:"alpha" help:"Interact with control planes."`
+		Upbound      upbound.Cmd      `cmd:"" group:"alpha" help:"Interact with Upbound."`
+	} `cmd:"" help:"Alpha features. Commands may be removed in future releases."`
 }
 
 func main() {

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -90,6 +90,9 @@ type cli struct {
 	Alpha        struct {
 		ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" group:"alpha" help:"Interact with control planes."`
 		Upbound      upbound.Cmd      `cmd:"" group:"alpha" help:"Interact with Upbound."`
+		XPKG         struct {
+			XPExtract xpkg.XPExtractCmd `cmd:"" group:"alpha" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
+		} `cmd:"" help:"Interact with UXP packages."`
 	} `cmd:"" help:"Alpha features. Commands may be removed in future releases."`
 }
 

--- a/cmd/up/robot/robot.go
+++ b/cmd/up/robot/robot.go
@@ -49,10 +49,10 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for interacting with robots.
 type Cmd struct {
-	Create createCmd `cmd:"" group:"robots" help:"Create a robot."`
-	Delete deleteCmd `cmd:"" group:"robots" help:"Delete a robot."`
-	List   listCmd   `cmd:"" group:"robots" help:"List robots for the account."`
-	Token  token.Cmd `cmd:"" group:"robots" help:"Interact with robot tokens."`
+	Create createCmd `cmd:"" group:"robot" help:"Create a robot."`
+	Delete deleteCmd `cmd:"" group:"robot" help:"Delete a robot."`
+	List   listCmd   `cmd:"" group:"robot" help:"List robots for the account."`
+	Token  token.Cmd `cmd:"" group:"robot" help:"Interact with robot tokens."`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/upbound/upbound.go
+++ b/cmd/up/upbound/upbound.go
@@ -50,10 +50,10 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for managing Upbound.
 type Cmd struct {
-	Install   installCmd   `cmd:"" group:"upbound" help:"Install Upbound."`
-	Mail      mailCmd      `cmd:"" group:"upbound" help:"[EXPERIMENTAL] Run a local mail portal."`
-	Uninstall uninstallCmd `cmd:"" group:"upbound" help:"Uninstall Upbound."`
-	Upgrade   upgradeCmd   `cmd:"" group:"upbound" help:"Upgrade Upbound."`
+	Install   installCmd   `cmd:"" help:"Install Upbound."`
+	Mail      mailCmd      `cmd:"" help:"[EXPERIMENTAL] Run a local mail portal."`
+	Uninstall uninstallCmd `cmd:"" help:"Uninstall Upbound."`
+	Upgrade   upgradeCmd   `cmd:"" help:"Upgrade Upbound."`
 
 	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
 	Namespace  string `short:"n" env:"UPBOUND_NAMESPACE" default:"upbound-system" help:"Kubernetes namespace for Upbound."`

--- a/cmd/up/upbound/upbound.go
+++ b/cmd/up/upbound/upbound.go
@@ -51,7 +51,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 // Cmd contains commands for managing Upbound.
 type Cmd struct {
 	Install   installCmd   `cmd:"" help:"Install Upbound."`
-	Mail      mailCmd      `cmd:"" help:"[EXPERIMENTAL] Run a local mail portal."`
+	Mail      mailCmd      `cmd:"" help:"Run a local mail portal."`
 	Uninstall uninstallCmd `cmd:"" help:"Uninstall Upbound."`
 	Upgrade   upgradeCmd   `cmd:"" help:"Upgrade Upbound."`
 

--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -77,7 +77,7 @@ func xpkgFetch(path string) fetchFn {
 
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
-func (c *xpExtractCmd) AfterApply() error {
+func (c *XPExtractCmd) AfterApply() error {
 	c.fs = afero.NewOsFs()
 	c.fetch = registryFetch
 	if c.FromDaemon {
@@ -116,9 +116,9 @@ func (c *xpExtractCmd) AfterApply() error {
 	return nil
 }
 
-// xpExtractCmd extracts package contents into a Crossplane cache compatible
+// XPExtractCmd extracts package contents into a Crossplane cache compatible
 // format.
-type xpExtractCmd struct {
+type XPExtractCmd struct {
 	fs    afero.Fs
 	name  name.Reference
 	fetch fetchFn
@@ -133,7 +133,7 @@ type xpExtractCmd struct {
 }
 
 // Run runs the xp extract cmd.
-func (c *xpExtractCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
+func (c *XPExtractCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
 	// NOTE(hasheddan): most of the logic in this method is from the machinery
 	// used in Crossplane's package cache and should be updated to use shared
 	// libraries if moved to crossplane-runtime.

--- a/cmd/up/xpkg/xpextract_test.go
+++ b/cmd/up/xpkg/xpextract_test.go
@@ -118,7 +118,7 @@ func TestXPExtractRun(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := (&xpExtractCmd{
+			err := (&XPExtractCmd{
 				fs:     tc.fs,
 				fetch:  tc.fetch,
 				name:   tc.name,

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -17,7 +17,7 @@ package xpkg
 // Cmd contains commands for interacting with xpkgs.
 type Cmd struct {
 	Build     buildCmd     `cmd:"" group:"xpkg" help:"Build a package."`
-	XPExtract xpExtractCmd `cmd:"" group:"xpkg" help:"[EXPERIMENTAL] Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
+	XPExtract XPExtractCmd `cmd:"" group:"xpkg" hidden:"" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
 	Init      initCmd      `cmd:"" group:"xpkg" help:"Initialize a package."`
 	Dep       depCmd       `cmd:"" group:"xpkg" help:"Manage package dependencies."`
 	Push      pushCmd      `cmd:"" group:"xpkg" help:"Push a package."`

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -52,7 +52,7 @@ type Flags struct {
 	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
 
 	// Experimental
-	MCPExperimental bool `env:"UP_MCP_EXPERIMENTAL" help:"Use experimental managed control planes API."`
+	MCPExperimental bool `env:"UP_MCP_EXPERIMENTAL" hidden:"" help:"Use experimental managed control planes API."`
 
 	// Insecure
 	InsecureSkipTLSVerify bool `env:"UP_INSECURE_SKIP_TLS_VERIFY" help:"[INSECURE] Skip verifying TLS certificates."`


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Moves controlplanes and upbound commands under the alpha distinction,
but also maintains hidden location at root in the tree. All
documentation and references will use the `up alpha` variants, but the
hidden commands serve to reserve a future location for these commands,
and, in this case, preserve backwards compatability with commands that
already existed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

up upbound has been moved to the alpha group of commands, signaling that
the entire group is experimental. Because of this, we can drop the
[EXPERIMENTAL] distinction from up upbound mail explicitly.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Moves the up xpkg xp-extract command to alpha group. The previous
location is preserved, but is hidden from the user.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified that commands work properly on both their previous location and the `up alpha` variants. Diff in usage shown below:

Previously:
```
🤖 (up) up -h
Usage: up <command>

The Upbound CLI

Flags:
  -h, --help       Show context-sensitive help.
  -v, --version    Print version and exit.
  -q, --quiet      Suppress all output.
      --pretty     Pretty print output.

Commands:
  license
    Print Up license information.

  login
    Login to Upbound.

  logout
    Logout of Upbound.

  controlplane (ctp) kubeconfig get --token=STRING <control-plane-ID>
    Get a kubeconfig for a control plane.

controlplane
  controlplane (ctp) create <name>
    Create a hosted control plane.

  controlplane (ctp) delete <id>
    Delete a control plane.

  controlplane (ctp) list
    List control planes for the account.

config
  profile config set [<key> [<value>]]
    Set base configuration key, value pair in the Upbound Profile.

  profile config unset [<key>]
    Unset base configuration key, value pair in the Upbound Profile.

profile
  profile current
    Get current Upbound Profile.

  profile list
    List Upbound Profiles.

  profile use <name>
    Set the default Upbound Profile to the given Profile.

  profile view
    View the Upbound Profile settings across profiles.

organizations
  organization (org) create <name>
    Create an organization.

  organization (org) delete <name>
    Delete an organization.

  organization (org) list
    List organizations.

repository
  repository (repo) create <name>
    Create a repository.

  repository (repo) delete <name>
    Delete a repository.

  repository (repo) list
    List repositories for the account.

robots
  robot create <name>
    Create a robot.

  robot delete <name>
    Delete a robot.

  robot list
    List robots for the account.

  robot token create <robot-name> <token-name>
    Create a token for the robot.

  robot token delete <robot-name> <token-name>
    Delete a token for the robot.

  robot token list <robot-name>
    List a token for the robot.

upbound
  upbound install <version>
    Install Upbound.

  upbound mail
    [EXPERIMENTAL] Run a local mail portal.

  upbound uninstall [<name>]
    Uninstall Upbound.

  upbound upgrade <version>
    Upgrade Upbound.

uxp
  uxp install [<version>]
    Install UXP.

  uxp uninstall
    Uninstall UXP.

  uxp upgrade [<version>]
    Upgrade UXP.

xpkg
  xpkg build
    Build a package.

  xpkg xp-extract [<package>]
    [EXPERIMENTAL] Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default.

  xpkg init
    Initialize a package.

  xpkg dep [<package>]
    Manage package dependencies.

  xpkg push <tag>
    Push a package.

xpls
  xpls serve
    run a server for Crossplane definitions using the Language Server Protocol.

Run "up <command> --help" for more information on a command.
```

Updated:
```
🤖 (up) go run ./cmd/up/ -h
Usage: up <command>

The Upbound CLI

Flags:
  -h, --help       Show context-sensitive help.
  -v, --version    Print version and exit.
  -q, --quiet      Suppress all output.
      --pretty     Pretty print output.

Commands:
  license
    Print Up license information.

  login
    Login to Upbound.

  logout
    Logout of Upbound.

config
  profile config set [<key> [<value>]]
    Set base configuration key, value pair in the Upbound Profile.

  profile config unset [<key>]
    Unset base configuration key, value pair in the Upbound Profile.

profile
  profile current
    Get current Upbound Profile.

  profile list
    List Upbound Profiles.

  profile use <name>
    Set the default Upbound Profile to the given Profile.

  profile view
    View the Upbound Profile settings across profiles.

organizations
  organization (org) create <name>
    Create an organization.

  organization (org) delete <name>
    Delete an organization.

  organization (org) list
    List organizations.

repository
  repository (repo) create <name>
    Create a repository.

  repository (repo) delete <name>
    Delete a repository.

  repository (repo) list
    List repositories for the account.

robots
  robot create <name>
    Create a robot.

  robot delete <name>
    Delete a robot.

  robot list
    List robots for the account.

  robot token create <robot-name> <token-name>
    Create a token for the robot.

  robot token delete <robot-name> <token-name>
    Delete a token for the robot.

  robot token list <robot-name>
    List a token for the robot.

uxp
  uxp install [<version>]
    Install UXP.

  uxp uninstall
    Uninstall UXP.

  uxp upgrade [<version>]
    Upgrade UXP.

xpkg
  xpkg build
    Build a package.

  xpkg init
    Initialize a package.

  xpkg dep [<package>]
    Manage package dependencies.

  xpkg push <tag>
    Push a package.

xpls
  xpls serve
    run a server for Crossplane definitions using the Language Server Protocol.

alpha
  alpha controlplane (ctp) create <name>
    Create a hosted control plane.

  alpha controlplane (ctp) delete <id>
    Delete a control plane.

  alpha controlplane (ctp) list
    List control planes for the account.

  alpha controlplane (ctp) kubeconfig get --token=STRING <control-plane-ID>
    Get a kubeconfig for a control plane.

  alpha upbound install <version>
    Install Upbound.

  alpha upbound mail
    Run a local mail portal.

  alpha upbound uninstall [<name>]
    Uninstall Upbound.

  alpha upbound upgrade <version>
    Upgrade Upbound.

  alpha xpkg xp-extract [<package>]
    Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default.

Run "up <command> --help" for more information on a command.
```