### PR TITLE
Add --force option to destructive commands

### DIFF
--- a/cmd/up/organization/delete.go
+++ b/cmd/up/organization/delete.go
@@ -33,19 +33,21 @@ func (c *deleteCmd) BeforeApply() error {
 
 // AfterApply accepts user input by default to confirm the delete operation.
 func (c *deleteCmd) AfterApply(p pterm.TextPrinter) error {
-	if !c.Force {
-		confirm, err := c.prompter.Prompt("Are you sure you want to delete this organization? [y/n]", false)
-		if err != nil {
-			return err
-		}
-
-		if input.InputYes(confirm) {
-			p.Printfln("Deleting organization %s. This cannot be undone.", c.Name)
-		} else {
-			return fmt.Errorf("operation canceled")
-		}
+	if c.Force {
+		return nil
 	}
-	return nil
+
+	confirm, err := c.prompter.Prompt("Are you sure you want to delete this organization? [y/n]", false)
+	if err != nil {
+		return err
+	}
+
+	if input.InputYes(confirm) {
+		p.Printfln("Deleting organization %s. This cannot be undone.", c.Name)
+		return nil
+	}
+
+	return fmt.Errorf("operation canceled")
 }
 
 // deleteCmd deletes an organization on Upbound.
@@ -54,7 +56,7 @@ type deleteCmd struct {
 
 	Name string `arg:"" required:"" help:"Name of organization."`
 
-	Force bool `help:"Force deletion of the organization." default:"false" short:"f"`
+	Force bool `help:"Force deletion of the organization." default:"false"`
 }
 
 // Run executes the delete command.

--- a/cmd/up/repository/delete.go
+++ b/cmd/up/repository/delete.go
@@ -34,19 +34,21 @@ func (c *deleteCmd) BeforeApply() error {
 
 // AfterApply accepts user input by default to confirm the delete operation.
 func (c *deleteCmd) AfterApply(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if !c.Force {
-		confirm, err := c.prompter.Prompt("Are you sure you want to delete this repository? [y/n]", false)
-		if err != nil {
-			return err
-		}
-
-		if input.InputYes(confirm) {
-			p.Printfln("Deleting repository %s/%s. This cannot be undone.", upCtx.Account, c.Name)
-		} else {
-			return fmt.Errorf("operation canceled")
-		}
+	if c.Force {
+		return nil
 	}
-	return nil
+	confirm, err := c.prompter.Prompt("Are you sure you want to delete this repository? [y/n]", false)
+	if err != nil {
+		return err
+	}
+
+	if input.InputYes(confirm) {
+		p.Printfln("Deleting repository %s/%s. This cannot be undone.", upCtx.Account, c.Name)
+		return nil
+	}
+
+	return fmt.Errorf("operation canceled")
+
 }
 
 // deleteCmd deletes a repository on Upbound.
@@ -55,7 +57,7 @@ type deleteCmd struct {
 
 	Name string `arg:"" required:"" help:"Name of repository."`
 
-	Force bool `help:"Force deletion of repository." default:"false" short:"f"`
+	Force bool `help:"Force deletion of repository." default:"false"`
 }
 
 // Run executes the delete command.

--- a/cmd/up/robot/delete.go
+++ b/cmd/up/robot/delete.go
@@ -43,19 +43,21 @@ func (c *deleteCmd) BeforeApply() error {
 
 // AfterApply accepts user input by default to confirm the delete operation.
 func (c *deleteCmd) AfterApply(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if !c.Force {
-		confirm, err := c.prompter.Prompt("Are you sure you want to delete this robot? [y/n]", false)
-		if err != nil {
-			return err
-		}
-
-		if input.InputYes(confirm) {
-			p.Printfln("Deleting robot %s/%s. This cannot be undone.", upCtx.Account, c.Name)
-		} else {
-			return fmt.Errorf("operation canceled")
-		}
+	if c.Force {
+		return nil
 	}
-	return nil
+
+	confirm, err := c.prompter.Prompt("Are you sure you want to delete this robot? [y/n]", false)
+	if err != nil {
+		return err
+	}
+
+	if input.InputYes(confirm) {
+		p.Printfln("Deleting robot %s/%s. This cannot be undone.", upCtx.Account, c.Name)
+		return nil
+	}
+
+	return fmt.Errorf("operation canceled")
 }
 
 // deleteCmd deletes a robot on Upbound.
@@ -64,7 +66,7 @@ type deleteCmd struct {
 
 	Name string `arg:"" required:"" help:"Name of robot."`
 
-	Force bool `help:"Force delete robot even if conflicts exist." default:"false" short:"f"`
+	Force bool `help:"Force delete robot even if conflicts exist." default:"false"`
 }
 
 // Run executes the delete command.

--- a/cmd/up/robot/token/delete.go
+++ b/cmd/up/robot/token/delete.go
@@ -39,19 +39,21 @@ func (c *deleteCmd) BeforeApply() error {
 
 // AfterApply accepts user input by default to confirm the delete operation.
 func (c *deleteCmd) AfterApply(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if !c.Force {
-		confirm, err := c.prompter.Prompt("Are you sure you want to delete this robot token? [y/n]", false)
-		if err != nil {
-			return err
-		}
-
-		if input.InputYes(confirm) {
-			p.Printfln("Deleting robot token %s/%s/%s. This cannot be undone.", upCtx.Account, c.RobotName, c.TokenName)
-		} else {
-			return fmt.Errorf("operation canceled")
-		}
+	if c.Force {
+		return nil
 	}
-	return nil
+
+	confirm, err := c.prompter.Prompt("Are you sure you want to delete this robot token? [y/n]", false)
+	if err != nil {
+		return err
+	}
+
+	if input.InputYes(confirm) {
+		p.Printfln("Deleting robot token %s/%s/%s. This cannot be undone.", upCtx.Account, c.RobotName, c.TokenName)
+		return nil
+	}
+
+	return fmt.Errorf("operation canceled")
 }
 
 // deleteCmd deletes a robot token on Upbound.
@@ -61,7 +63,7 @@ type deleteCmd struct {
 	RobotName string `arg:"" required:"" help:"Name of robot."`
 	TokenName string `arg:"" required:"" help:"Name of token."`
 
-	Force bool `help:"Force delete token even if conflicts exist." default:"false" short:"f"`
+	Force bool `help:"Force delete token even if conflicts exist." default:"false"`
 }
 
 // Run executes the delete command.

--- a/cmd/up/xpkg/init.go
+++ b/cmd/up/xpkg/init.go
@@ -17,7 +17,6 @@ package xpkg
 import (
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	v1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
@@ -152,7 +151,7 @@ func (c *initCmd) initConfigPkg() error {
 		return err
 	}
 
-	if inputYes(include) {
+	if input.InputYes(include) {
 		for {
 			provider, err := c.prompter.Prompt("Provider URI [e.g. crossplane/provider-aws]", false)
 			if err != nil {
@@ -179,7 +178,7 @@ func (c *initCmd) initConfigPkg() error {
 			if err != nil {
 				return err
 			}
-			if inputYes(done) {
+			if input.InputYes(done) {
 				break
 			}
 		}
@@ -208,14 +207,4 @@ func (c *initCmd) metaFileInRoot() error {
 		return errors.New(errAlreadyExists)
 	}
 	return nil
-}
-
-// TODO(@tnthornton) this seems like the kind of thing we could build into
-// and expand in the prompt package if we find it useful elsewhere.
-// for example: reprompt if not given y/n (yes/no)
-func inputYes(include string) bool {
-	if len(include) > 0 {
-		return strings.ToLower(include)[0:1] == "y"
-	}
-	return false
 }

--- a/cmd/up/xpkg/init_test.go
+++ b/cmd/up/xpkg/init_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
+	"github.com/upbound/up/internal/input"
 	"github.com/upbound/up/internal/xpkg"
 )
 
@@ -83,7 +84,7 @@ func TestInputYes(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			y := inputYes(tc.args.input)
+			y := input.InputYes(tc.args.input)
 
 			if diff := cmp.Diff(tc.want.output, y); diff != "" {
 				t.Errorf("\n%s\nInputYes(...): -want, +got:\n%s", tc.reason, diff)

--- a/internal/input/prompt.go
+++ b/internal/input/prompt.go
@@ -54,6 +54,15 @@ func (defaultTTY) ReadPassword(fd int) ([]byte, error) {
 	return term.ReadPassword(fd)
 }
 
+// TODO(@tnthornton @jastang) there are possible enhancements to this.
+// for example: reprompt if not given y/n (yes/no)
+func InputYes(include string) bool {
+	if len(include) > 0 {
+		return strings.ToLower(include)[0:1] == "y"
+	}
+	return false
+}
+
 // Prompter prompts a user for input.
 type Prompter interface {
 	Prompt(label string, sensitive bool) (string, error)


### PR DESCRIPTION
Signed-off-by: Jason Tang <jason@upbound.io>

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
This PR adds a `--force` option to destructive commands, prompting the user by default to confirm the deletion of the entity (repository, robot, robot token, organization). If `--force` is supplied, no prompt is given.

If the user backs out of the delete, we will return an error, which will show the CLI usage by default.

I hope I know what I'm doing! ; )

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #232 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Tested commands with and without the `--force` option on dev, except the `org` as I cannot create additional orgs.