### PR TITLE
Fix up logout and hint when session is missing

### DIFF
--- a/cmd/up/logout.go
+++ b/cmd/up/logout.go
@@ -31,7 +31,6 @@ const (
 	logoutPath = "/v1/logout"
 
 	errLogoutFailed      = "unable to logout"
-	errGetProfile        = "failed to get profile"
 	errRemoveTokenFailed = "failed to remove token"
 )
 
@@ -69,20 +68,15 @@ func (c *logoutCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	if err := c.client.Do(req, nil); err != nil {
 		return errors.Wrap(err, errLogoutFailed)
 	}
-
 	// Logout is successful, remove token from config and update.
-	profile, err := upCtx.Cfg.GetUpboundProfile(c.Flags.Profile)
-	if err != nil {
-		return errors.Wrap(err, errGetProfile)
-	}
-	profile.Session = ""
-	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.Profile.ID, profile); err != nil {
+	upCtx.Profile.Session = ""
+	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.ProfileName, upCtx.Profile); err != nil {
 		return errors.Wrap(err, errRemoveTokenFailed)
 	}
 	if err := upCtx.CfgSrc.UpdateConfig(upCtx.Cfg); err != nil {
 		return errors.Wrap(err, errUpdateConfig)
 	}
 
-	p.Printfln("%s logged out", profile.ID)
+	p.Printfln("%s logged out", upCtx.Profile.ID)
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,10 @@ type RedactedProfile struct {
 func (p RedactedProfile) MarshalJSON() ([]byte, error) {
 	type profile RedactedProfile
 	pc := profile(p)
+	if pc.Session == "" {
+		pc.Session = "NONE"
+		return json.Marshal(&pc)
+	}
 	pc.Session = "REDACTED"
 	return json.Marshal(&pc)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,11 +118,11 @@ type RedactedProfile struct {
 func (p RedactedProfile) MarshalJSON() ([]byte, error) {
 	type profile RedactedProfile
 	pc := profile(p)
-	if pc.Session == "" {
-		pc.Session = "NONE"
-		return json.Marshal(&pc)
+	s := "NONE"
+	if pc.Session != "" {
+		s = "REDACTED"
 	}
-	pc.Session = "REDACTED"
+	pc.Session = s
 	return json.Marshal(&pc)
 }
 

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -65,10 +65,11 @@ type Flags struct {
 
 // Context includes common data that Upbound consumers may utilize.
 type Context struct {
-	Profile config.Profile
-	Token   string
-	Account string
-	Domain  *url.URL
+	ProfileName string
+	Profile     config.Profile
+	Token       string
+	Account     string
+	Domain      *url.URL
 
 	InsecureSkipTLSVerify bool
 	MCPExperimental       bool
@@ -120,20 +121,19 @@ func NewFromFlags(f Flags, opts ...Option) (*Context, error) { //nolint:gocyclo
 	// If profile identifier is not provided, use the default, or empty if the
 	// default cannot be obtained.
 	c.Profile = config.Profile{}
-	profileToUse := ""
 	if f.Profile == "" {
 		if name, p, err := c.Cfg.GetDefaultUpboundProfile(); err == nil {
 			c.Profile = p
-			profileToUse = name
+			c.ProfileName = name
 		}
 	} else {
 		if p, err := c.Cfg.GetUpboundProfile(f.Profile); err == nil {
 			c.Profile = p
-			profileToUse = f.Profile
+			c.ProfileName = f.Profile
 		}
 	}
 
-	of, err := c.applyOverrides(f, profileToUse)
+	of, err := c.applyOverrides(f, c.ProfileName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/upbound/context_test.go
+++ b/internal/upbound/context_test.go
@@ -140,6 +140,7 @@ func TestNewFromFlags(t *testing.T) {
 			},
 			want: want{
 				c: &Context{
+					ProfileName:           "default",
 					Account:               "",
 					APIEndpoint:           withURL("https://api.upbound.io"),
 					Domain:                withURL("https://upbound.io"),
@@ -167,6 +168,7 @@ func TestNewFromFlags(t *testing.T) {
 			},
 			want: want{
 				c: &Context{
+					ProfileName:           "default",
 					Account:               "my-org",
 					APIEndpoint:           withURL("https://api.local.upbound.io"),
 					Domain:                withURL("https://local.upbound.io"),
@@ -205,6 +207,7 @@ func TestNewFromFlags(t *testing.T) {
 			},
 			want: want{
 				c: &Context{
+					ProfileName:           "default",
 					Account:               "not-my-org",
 					APIEndpoint:           withURL("http://not.a.url"),
 					Domain:                withURL("http://a.domain.org"),


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the Upbound Context to include ProfileName such that commands
can specify profile when fetching or updating.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates the logout command to correctly identify profile by name rather
than the ID it currently contains.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates profile marshaling to emit NONE for session if not present in
order to help users identify whether they shouldn't expect to be
authenticated.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up) up login
Username: hasheddan
Password: 
hasheddan logged in
🤖 (up) up profile view
{
    "default": {
        "id": "hasheddan",
        "type": "user",
        "session": "REDACTED",
        "account": "hasheddan"
    }
}
🤖 (up) up logout
hasheddan logged out
🤖 (up) up profile view
{
    "default": {
        "id": "hasheddan",
        "type": "user",
        "session": "NONE",
        "account": "hasheddan"
    }
}
```