### PR TITLE
Add support for `up ctp pull-secret create` and require token create output

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -22,6 +22,7 @@ import (
 	op "github.com/upbound/up-sdk-go/service/oldplanes"
 
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
+	"github.com/upbound/up/cmd/up/controlplane/pullsecret"
 	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/upbound"
 )
@@ -52,10 +53,11 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for interacting with control planes.
 type Cmd struct {
-	Create     createCmd     `cmd:"" maturity:"alpha" help:"Create a hosted control plane."`
-	Delete     deleteCmd     `cmd:"" maturity:"alpha" help:"Delete a control plane."`
-	List       listCmd       `cmd:"" maturity:"alpha" help:"List control planes for the account."`
-	PullSecret pullSecretCmd `cmd:"" help:"Create a package pull secret."`
+	Create createCmd `cmd:"" maturity:"alpha" help:"Create a hosted control plane."`
+	Delete deleteCmd `cmd:"" maturity:"alpha" help:"Delete a control plane."`
+	List   listCmd   `cmd:"" maturity:"alpha" help:"List control planes for the account."`
+
+	PullSecret pullsecret.Cmd `cmd:"" help:"Manage package pull secrets."`
 
 	Kubeconfig kubeconfig.Cmd `cmd:"" maturity:"alpha" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
 

--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -22,8 +22,14 @@ import (
 	op "github.com/upbound/up-sdk-go/service/oldplanes"
 
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
+	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/upbound"
 )
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
 
 // AfterApply constructs and binds a control plane client to any subcommands
 // that have Run() methods that receive it.
@@ -46,11 +52,12 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for interacting with control planes.
 type Cmd struct {
-	Create createCmd `cmd:"" help:"Create a hosted control plane."`
-	Delete deleteCmd `cmd:"" help:"Delete a control plane."`
-	List   listCmd   `cmd:"" help:"List control planes for the account."`
+	Create     createCmd     `cmd:"" maturity:"alpha" help:"Create a hosted control plane."`
+	Delete     deleteCmd     `cmd:"" maturity:"alpha" help:"Delete a control plane."`
+	List       listCmd       `cmd:"" maturity:"alpha" help:"List control planes for the account."`
+	PullSecret pullSecretCmd `cmd:"" help:"Create a package pull secret."`
 
-	Kubeconfig kubeconfig.Cmd `cmd:"" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
+	Kubeconfig kubeconfig.Cmd `cmd:"" maturity:"alpha" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/controlplane/kubeconfig/kubeconfig.go
+++ b/cmd/up/controlplane/kubeconfig/kubeconfig.go
@@ -14,7 +14,17 @@
 
 package kubeconfig
 
+import (
+	"github.com/alecthomas/kong"
+	"github.com/upbound/up/internal/feature"
+)
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
+
 // Cmd contains commands for managing control plane kubeconfig data.
 type Cmd struct {
-	Get getCmd `cmd:"" help:"Get a kubeconfig for a control plane."`
+	Get getCmd `cmd:"" maturity:"alpha" help:"Get a kubeconfig for a control plane."`
 }

--- a/cmd/up/controlplane/kubeconfig/kubeconfig.go
+++ b/cmd/up/controlplane/kubeconfig/kubeconfig.go
@@ -16,6 +16,7 @@ package kubeconfig
 
 import (
 	"github.com/alecthomas/kong"
+
 	"github.com/upbound/up/internal/feature"
 )
 

--- a/cmd/up/controlplane/pullsecret.go
+++ b/cmd/up/controlplane/pullsecret.go
@@ -1,0 +1,94 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+
+	"github.com/alecthomas/kong"
+	"github.com/pkg/errors"
+	"github.com/pterm/pterm"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/upbound/up/internal/kube"
+	"github.com/upbound/up/internal/upbound"
+)
+
+const defaultUsername = "_token"
+
+const (
+	errMissingProfileCreds = "current profile does not contain credentials"
+	errCreatePullSecret    = "failed to create package pull secret"
+)
+
+// AfterApply constructs and binds Upbound-specific context to any subcommands
+// that have Run() methods that receive it.
+func (c *pullSecretCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	client, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	c.kClient = client
+	if c.File != "" {
+		tf, err := upbound.TokenFromPath(c.File)
+		if err != nil {
+			return err
+		}
+		c.user, c.pass = tf.AccessID, tf.Token
+	}
+	if c.user == "" || c.pass == "" {
+		if upCtx.Profile.Session == "" {
+			return errors.New(errMissingProfileCreds)
+		}
+		c.user, c.pass = defaultUsername, upCtx.Profile.Session
+		pterm.Warning.WithWriter(kongCtx.Stdout).Printfln("Using temporary user credentials that will expire within 30 days.")
+	}
+	return nil
+}
+
+// pullSecretCmd creates a package pull secret.
+type pullSecretCmd struct {
+	kClient kubernetes.Interface
+	user    string
+	pass    string
+
+	Name string `arg:"" default:"package-pull-secret" help:"Name of the pull secret."`
+
+	// NOTE(hasheddan): kong automatically cleans paths tagged with existingfile.
+	File       string `type:"existingfile" short:"f" help:"Path to credentials file. Credentials from profile are used if not specified."`
+	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
+	Namespace  string `short:"n" env:"UPBOUND_NAMESPACE" default:"upbound-system" help:"Kubernetes namespace for pull secret."`
+}
+
+// Run executes the pull secret command.
+func (c *pullSecretCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
+	if err := kube.NewImagePullApplicator(kube.NewSecretApplicator(c.kClient)).
+		Apply(context.Background(),
+			c.Name,
+			c.Namespace,
+			c.user,
+			c.pass,
+			upCtx.RegistryEndpoint.Hostname(),
+		); err != nil {
+		return errors.Wrap(err, errCreatePullSecret)
+	}
+
+	p.Printfln("%s/%s created", c.Namespace, c.Name)
+	return nil
+}

--- a/cmd/up/controlplane/pullsecret/create.go
+++ b/cmd/up/controlplane/pullsecret/create.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controlplane
+package pullsecret
 
 import (
 	"context"
@@ -35,7 +35,7 @@ const (
 
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
-func (c *pullSecretCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
 	if err != nil {
 		return err
@@ -62,8 +62,8 @@ func (c *pullSecretCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context
 	return nil
 }
 
-// pullSecretCmd creates a package pull secret.
-type pullSecretCmd struct {
+// createCmd creates a package pull secret.
+type createCmd struct {
 	kClient kubernetes.Interface
 	user    string
 	pass    string
@@ -77,7 +77,7 @@ type pullSecretCmd struct {
 }
 
 // Run executes the pull secret command.
-func (c *pullSecretCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
+func (c *createCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
 	if err := kube.NewImagePullApplicator(kube.NewSecretApplicator(c.kClient)).
 		Apply(context.Background(),
 			c.Name,

--- a/cmd/up/controlplane/pullsecret/pullsecret.go
+++ b/cmd/up/controlplane/pullsecret/pullsecret.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pullsecret
+
+import (
+	"github.com/alecthomas/kong"
+
+	"github.com/upbound/up/internal/feature"
+)
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
+
+// Cmd contains commands for managing pull secrets.
+type Cmd struct {
+	Create createCmd `cmd:"" help:"Create a package pull secret."`
+}

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -79,7 +79,7 @@ type cli struct {
 	Login        loginCmd         `cmd:"" help:"Login to Upbound."`
 	Logout       logoutCmd        `cmd:"" help:"Logout of Upbound."`
 	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" hidden:"" help:"Interact with control planes."`
-	Profile      profile.Cmd      `cmd:"" help:"Interact with Upbound Profiles"`
+	Profile      profile.Cmd      `cmd:"" help:"Interact with Upbound profiles."`
 	Organization organization.Cmd `cmd:"" name:"organization" aliases:"org" help:"Interact with organizations."`
 	Repository   repository.Cmd   `cmd:"" name:"repository" aliases:"repo" help:"Interact with repositories."`
 	Robot        robot.Cmd        `cmd:"" name:"robot" help:"Interact with robots."`
@@ -102,7 +102,10 @@ func main() {
 	ctx := kong.Parse(&c,
 		kong.Name("up"),
 		kong.Description("The Upbound CLI"),
-		kong.UsageOnError())
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			NoExpandSubcommands: true,
+		}))
 	err := ctx.Run()
 	ctx.FatalIfErrorf(err)
 }

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -103,7 +103,7 @@ type cli struct {
 
 // BeforeReset runs before all other hooks. If command has alpha as an ancestor,
 // maturity level will be set to alpha.
-func (a *alpha) BeforeReset(ctx *kong.Context) error {
+func (a *alpha) BeforeReset(ctx *kong.Context) error { //nolint:unparam
 	ctx.Bind(feature.Alpha)
 	return nil
 }

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/upbound/up/cmd/up/xpkg"
 	"github.com/upbound/up/cmd/up/xpls"
 	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/version"
 
 	// TODO(epk): Remove this once we upgrade kubernetes deps to 1.25
@@ -69,6 +70,16 @@ func (c *cli) AfterApply(ctx *kong.Context) error { //nolint:unparam
 	return nil
 }
 
+// BeforeReset runs before all other hooks. Default maturity level is stable.
+func (c *cli) BeforeReset(ctx *kong.Context, p *kong.Path) error {
+	ctx.Bind(feature.Stable)
+	// If no command is selected, we are emitting help and filter maturity.
+	if ctx.Selected() == nil {
+		return feature.HideMaturity(p, feature.Stable)
+	}
+	return nil
+}
+
 type cli struct {
 	Version versionFlag      `short:"v" name:"version" help:"Print version and exit."`
 	Quiet   config.QuietFlag `short:"q" name:"quiet" help:"Suppress all output."`
@@ -78,22 +89,29 @@ type cli struct {
 
 	Login        loginCmd         `cmd:"" help:"Login to Upbound."`
 	Logout       logoutCmd        `cmd:"" help:"Logout of Upbound."`
-	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" hidden:"" help:"Interact with control planes."`
+	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
 	Profile      profile.Cmd      `cmd:"" help:"Interact with Upbound profiles."`
 	Organization organization.Cmd `cmd:"" name:"organization" aliases:"org" help:"Interact with organizations."`
 	Repository   repository.Cmd   `cmd:"" name:"repository" aliases:"repo" help:"Interact with repositories."`
 	Robot        robot.Cmd        `cmd:"" name:"robot" help:"Interact with robots."`
-	Upbound      upbound.Cmd      `cmd:"" hidden:"" help:"Interact with Upbound."`
+	Upbound      upbound.Cmd      `cmd:"" maturity:"alpha" help:"Interact with Upbound."`
 	UXP          uxp.Cmd          `cmd:"" help:"Interact with UXP."`
 	XPKG         xpkg.Cmd         `cmd:"" help:"Interact with UXP packages."`
 	XPLS         xpls.Cmd         `cmd:"" help:"Start xpls language server."`
-	Alpha        struct {
-		ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" group:"alpha" help:"Interact with control planes."`
-		Upbound      upbound.Cmd      `cmd:"" group:"alpha" help:"Interact with Upbound."`
-		XPKG         struct {
-			XPExtract xpkg.XPExtractCmd `cmd:"" group:"alpha" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
-		} `cmd:"" help:"Interact with UXP packages."`
-	} `cmd:"" help:"Alpha features. Commands may be removed in future releases."`
+	Alpha        alpha            `cmd:"" help:"Alpha features. Commands may be removed in future releases."`
+}
+
+// BeforeReset runs before all other hooks. If command has alpha as an ancestor,
+// maturity level will be set to alpha.
+func (a *alpha) BeforeReset(ctx *kong.Context) error {
+	ctx.Bind(feature.Alpha)
+	return nil
+}
+
+type alpha struct {
+	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
+	Upbound      upbound.Cmd      `cmd:"" help:"Interact with Upbound."`
+	XPKG         xpkg.Cmd         `cmd:"" help:"Interact with UXP packages."`
 }
 
 func main() {
@@ -102,10 +120,16 @@ func main() {
 	ctx := kong.Parse(&c,
 		kong.Name("up"),
 		kong.Description("The Upbound CLI"),
-		kong.UsageOnError(),
+		kong.Help(func(options kong.HelpOptions, ctx *kong.Context) error {
+			// Do not emit help if command is hidden.
+			if ctx.Selected() != nil && ctx.Selected().Hidden {
+				fmt.Fprintf(ctx.Stdout, "Refusing to emit help for hidden command. See %s variant.\n", feature.GetMaturity(ctx.Selected()))
+				return nil
+			}
+			return kong.DefaultHelpPrinter(options, ctx)
+		}),
 		kong.ConfigureHelp(kong.HelpOptions{
 			NoExpandSubcommands: true,
 		}))
-	err := ctx.Run()
-	ctx.FatalIfErrorf(err)
+	ctx.FatalIfErrorf(ctx.Run())
 }

--- a/cmd/up/organization/organization.go
+++ b/cmd/up/organization/organization.go
@@ -40,9 +40,9 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for interacting with organizations.
 type Cmd struct {
-	Create createCmd `cmd:"" group:"organizations" help:"Create an organization."`
-	Delete deleteCmd `cmd:"" group:"organizations" help:"Delete an organization."`
-	List   listCmd   `cmd:"" group:"organizations" help:"List organizations."`
+	Create createCmd `cmd:"" help:"Create an organization."`
+	Delete deleteCmd `cmd:"" help:"Delete an organization."`
+	List   listCmd   `cmd:"" help:"List organizations."`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/profile/config/config.go
+++ b/cmd/up/profile/config/config.go
@@ -22,8 +22,8 @@ import (
 
 // Cmd contains commands for Upbound Profiles.
 type Cmd struct {
-	Set   setCmd   `cmd:"" group:"config" help:"Set base configuration key, value pair in the Upbound Profile."`
-	UnSet unsetCmd `cmd:"" group:"config" name:"unset" help:"Unset base configuration key, value pair in the Upbound Profile."`
+	Set   setCmd   `cmd:"" help:"Set base configuration key, value pair in the Upbound Profile."`
+	UnSet unsetCmd `cmd:"" name:"unset" help:"Unset base configuration key, value pair in the Upbound Profile."`
 
 	Flags upbound.Flags `embed:""`
 }

--- a/cmd/up/profile/profile.go
+++ b/cmd/up/profile/profile.go
@@ -23,11 +23,11 @@ import (
 
 // Cmd contains commands for Upbound Profiles.
 type Cmd struct {
-	Current currentCmd `cmd:"" group:"profile" help:"Get current Upbound Profile."`
-	List    listCmd    `cmd:"" group:"profile" help:"List Upbound Profiles."`
-	Use     useCmd     `cmd:"" group:"profile" help:"Set the default Upbound Profile to the given Profile."`
-	View    viewCmd    `cmd:"" group:"profile" help:"View the Upbound Profile settings across profiles."`
-	Config  config.Cmd `cmd:"" group:"profile" help:"Interact with the current Upbound Profile's config."`
+	Current currentCmd `cmd:"" help:"Get current Upbound Profile."`
+	List    listCmd    `cmd:"" help:"List Upbound Profiles."`
+	Use     useCmd     `cmd:"" help:"Set the default Upbound Profile to the given Profile."`
+	View    viewCmd    `cmd:"" help:"View the Upbound Profile settings across profiles."`
+	Config  config.Cmd `cmd:"" help:"Interact with the current Upbound Profile's config."`
 
 	Flags upbound.Flags `embed:""`
 }

--- a/cmd/up/profile/profile.go
+++ b/cmd/up/profile/profile.go
@@ -23,11 +23,11 @@ import (
 
 // Cmd contains commands for Upbound Profiles.
 type Cmd struct {
-	Config  config.Cmd `cmd:"" group:"profile" help:"Interact with the current Upbound Profile's config."`
 	Current currentCmd `cmd:"" group:"profile" help:"Get current Upbound Profile."`
 	List    listCmd    `cmd:"" group:"profile" help:"List Upbound Profiles."`
 	Use     useCmd     `cmd:"" group:"profile" help:"Set the default Upbound Profile to the given Profile."`
 	View    viewCmd    `cmd:"" group:"profile" help:"View the Upbound Profile settings across profiles."`
+	Config  config.Cmd `cmd:"" group:"profile" help:"Interact with the current Upbound Profile's config."`
 
 	Flags upbound.Flags `embed:""`
 }

--- a/cmd/up/repository/repository.go
+++ b/cmd/up/repository/repository.go
@@ -40,9 +40,9 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for interacting with repositories.
 type Cmd struct {
-	Create createCmd `cmd:"" group:"repository" help:"Create a repository."`
-	Delete deleteCmd `cmd:"" group:"repository" help:"Delete a repository."`
-	List   listCmd   `cmd:"" group:"repository" help:"List repositories for the account."`
+	Create createCmd `cmd:"" help:"Create a repository."`
+	Delete deleteCmd `cmd:"" help:"Delete a repository."`
+	List   listCmd   `cmd:"" help:"List repositories for the account."`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/robot/robot.go
+++ b/cmd/up/robot/robot.go
@@ -49,10 +49,10 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for interacting with robots.
 type Cmd struct {
-	Create createCmd `cmd:"" group:"robot" help:"Create a robot."`
-	Delete deleteCmd `cmd:"" group:"robot" help:"Delete a robot."`
-	List   listCmd   `cmd:"" group:"robot" help:"List robots for the account."`
-	Token  token.Cmd `cmd:"" group:"robot" help:"Interact with robot tokens."`
+	Create createCmd `cmd:"" help:"Create a robot."`
+	Delete deleteCmd `cmd:"" help:"Delete a robot."`
+	List   listCmd   `cmd:"" help:"List robots for the account."`
+	Token  token.Cmd `cmd:"" help:"Interact with robot tokens."`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/robot/token/create.go
+++ b/cmd/up/robot/token/create.go
@@ -38,7 +38,7 @@ type createCmd struct {
 	RobotName string `arg:"" required:"" help:"Name of robot."`
 	TokenName string `arg:"" required:"" help:"Name of token."`
 
-	Output string `type:"path" short:"o" help:"Path to write JSON file containing access ID and token."`
+	Output string `type:"path" short:"o" required:"" help:"Path to write JSON file containing access ID and token."`
 }
 
 // Run executes the create command.

--- a/cmd/up/robot/token/create.go
+++ b/cmd/up/robot/token/create.go
@@ -111,10 +111,7 @@ func (c *createCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizati
 		return err
 	}
 	defer f.Close() //nolint:errcheck,gosec
-	return json.NewEncoder(f).Encode(&struct {
-		AccessID string `json:"accessId"`
-		Token    string `json:"token"`
-	}{
+	return json.NewEncoder(f).Encode(&upbound.TokenFile{
 		AccessID: access,
 		Token:    token,
 	})

--- a/cmd/up/upbound/install.go
+++ b/cmd/up/upbound/install.go
@@ -102,7 +102,7 @@ func (c *installCmd) AfterApply(insCtx *install.Context, kongCtx *kong.Context, 
 	}
 	c.kClient = client
 	secret := kube.NewSecretApplicator(client)
-	c.pullSecret = newImagePullApplicator(secret)
+	c.pullSecret = kube.NewImagePullApplicator(secret)
 	auth := auth.NewProvider(
 		auth.WithBasicAuth(c.id, c.token),
 		auth.WithEndpoint(c.Registry),
@@ -152,7 +152,7 @@ type installCmd struct {
 	kClient    kubernetes.Interface
 	prompter   input.Prompter
 	access     *accessKeyApplicator
-	pullSecret *imagePullApplicator
+	pullSecret *kube.ImagePullApplicator
 	id         string
 	token      string
 	quiet      config.QuietFlag
@@ -218,7 +218,7 @@ func (c *installCmd) applySecrets(ctx context.Context, namespace string) error {
 		return nil
 	}
 	creatPullSecret := func() error {
-		if err := c.pullSecret.apply(
+		if err := c.pullSecret.Apply(
 			ctx,
 			defaultImagePullSecret,
 			namespace,

--- a/cmd/up/upbound/upbound.go
+++ b/cmd/up/upbound/upbound.go
@@ -24,12 +24,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/upbound/up/internal/auth"
+	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/install"
 	"github.com/upbound/up/internal/kube"
 	"github.com/upbound/up/internal/license"
 )
 
 const upboundChart = "upbound"
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
 
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
@@ -47,10 +53,10 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for managing Upbound.
 type Cmd struct {
-	Install   installCmd   `cmd:"" help:"Install Upbound."`
-	Mail      mailCmd      `cmd:"" help:"Run a local mail portal."`
-	Uninstall uninstallCmd `cmd:"" help:"Uninstall Upbound."`
-	Upgrade   upgradeCmd   `cmd:"" help:"Upgrade Upbound."`
+	Install   installCmd   `cmd:"" maturity:"alpha" help:"Install Upbound."`
+	Mail      mailCmd      `cmd:"" maturity:"alpha" help:"Run a local mail portal."`
+	Uninstall uninstallCmd `cmd:"" maturity:"alpha" help:"Uninstall Upbound."`
+	Upgrade   upgradeCmd   `cmd:"" maturity:"alpha" help:"Upgrade Upbound."`
 
 	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
 	Namespace  string `short:"n" env:"UPBOUND_NAMESPACE" default:"upbound-system" help:"Kubernetes namespace for Upbound."`

--- a/cmd/up/upbound/upgrade.go
+++ b/cmd/up/upbound/upgrade.go
@@ -62,7 +62,7 @@ func (c *upgradeCmd) AfterApply(insCtx *install.Context, quiet config.QuietFlag)
 	}
 	c.kClient = client
 	secret := kube.NewSecretApplicator(client)
-	c.pullSecret = newImagePullApplicator(secret)
+	c.pullSecret = kube.NewImagePullApplicator(secret)
 	auth := auth.NewProvider(
 		auth.WithBasicAuth(id, token),
 		auth.WithEndpoint(c.Registry),
@@ -112,7 +112,7 @@ type upgradeCmd struct {
 	parser     install.ParameterParser
 	prompter   input.Prompter
 	access     *accessKeyApplicator
-	pullSecret *imagePullApplicator
+	pullSecret *kube.ImagePullApplicator
 	id         string
 	token      string
 	kClient    kubernetes.Interface
@@ -139,7 +139,7 @@ func (c *upgradeCmd) Run(insCtx *install.Context) error {
 	}
 
 	// Create or update image pull secret.
-	if err := c.pullSecret.apply(ctx, defaultImagePullSecret, insCtx.Namespace, c.id, c.token, c.Registry.String()); err != nil {
+	if err := c.pullSecret.Apply(ctx, defaultImagePullSecret, insCtx.Namespace, c.id, c.token, c.Registry.String()); err != nil {
 		return errors.Wrap(err, errCreateImagePullSecret)
 	}
 

--- a/cmd/up/uxp/uxp.go
+++ b/cmd/up/uxp/uxp.go
@@ -49,9 +49,9 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 // Cmd contains commands for managing UXP.
 type Cmd struct {
-	Install   installCmd   `cmd:"" group:"uxp" help:"Install UXP."`
-	Uninstall uninstallCmd `cmd:"" group:"uxp" help:"Uninstall UXP."`
-	Upgrade   upgradeCmd   `cmd:"" group:"uxp" help:"Upgrade UXP."`
+	Install   installCmd   `cmd:"" help:"Install UXP."`
+	Uninstall uninstallCmd `cmd:"" help:"Uninstall UXP."`
+	Upgrade   upgradeCmd   `cmd:"" help:"Upgrade UXP."`
 
 	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
 	Namespace  string `short:"n" env:"UXP_NAMESPACE" default:"upbound-system" help:"Kubernetes namespace for UXP."`

--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -77,7 +77,7 @@ func xpkgFetch(path string) fetchFn {
 
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
-func (c *XPExtractCmd) AfterApply() error {
+func (c *xpExtractCmd) AfterApply() error {
 	c.fs = afero.NewOsFs()
 	c.fetch = registryFetch
 	if c.FromDaemon {
@@ -116,9 +116,9 @@ func (c *XPExtractCmd) AfterApply() error {
 	return nil
 }
 
-// XPExtractCmd extracts package contents into a Crossplane cache compatible
+// xpExtractCmd extracts package contents into a Crossplane cache compatible
 // format.
-type XPExtractCmd struct {
+type xpExtractCmd struct {
 	fs    afero.Fs
 	name  name.Reference
 	fetch fetchFn
@@ -133,7 +133,7 @@ type XPExtractCmd struct {
 }
 
 // Run runs the xp extract cmd.
-func (c *XPExtractCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
+func (c *xpExtractCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
 	// NOTE(hasheddan): most of the logic in this method is from the machinery
 	// used in Crossplane's package cache and should be updated to use shared
 	// libraries if moved to crossplane-runtime.

--- a/cmd/up/xpkg/xpextract_test.go
+++ b/cmd/up/xpkg/xpextract_test.go
@@ -118,7 +118,7 @@ func TestXPExtractRun(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			err := (&XPExtractCmd{
+			err := (&xpExtractCmd{
 				fs:     tc.fs,
 				fetch:  tc.fetch,
 				name:   tc.name,

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -16,6 +16,7 @@ package xpkg
 
 import (
 	"github.com/alecthomas/kong"
+
 	"github.com/upbound/up/internal/feature"
 )
 

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -17,7 +17,7 @@ package xpkg
 // Cmd contains commands for interacting with xpkgs.
 type Cmd struct {
 	Build     buildCmd     `cmd:"" group:"xpkg" help:"Build a package."`
-	XPExtract XPExtractCmd `cmd:"" group:"xpkg" hidden:"" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
+	XPExtract xpExtractCmd `cmd:"" group:"xpkg" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
 	Init      initCmd      `cmd:"" group:"xpkg" help:"Initialize a package."`
 	Dep       depCmd       `cmd:"" group:"xpkg" help:"Manage package dependencies."`
 	Push      pushCmd      `cmd:"" group:"xpkg" help:"Push a package."`

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -26,9 +26,9 @@ func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
 
 // Cmd contains commands for interacting with xpkgs.
 type Cmd struct {
-	Build     buildCmd     `cmd:"" group:"xpkg" help:"Build a package."`
-	XPExtract xpExtractCmd `cmd:"" maturity:"alpha" group:"xpkg" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
-	Init      initCmd      `cmd:"" group:"xpkg" help:"Initialize a package."`
-	Dep       depCmd       `cmd:"" group:"xpkg" help:"Manage package dependencies."`
-	Push      pushCmd      `cmd:"" group:"xpkg" help:"Push a package."`
+	Build     buildCmd     `cmd:"" help:"Build a package."`
+	XPExtract xpExtractCmd `cmd:"" maturity:"alpha" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
+	Init      initCmd      `cmd:"" help:"Initialize a package."`
+	Dep       depCmd       `cmd:"" help:"Manage package dependencies."`
+	Push      pushCmd      `cmd:"" help:"Push a package."`
 }

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -14,10 +14,20 @@
 
 package xpkg
 
+import (
+	"github.com/alecthomas/kong"
+	"github.com/upbound/up/internal/feature"
+)
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
+
 // Cmd contains commands for interacting with xpkgs.
 type Cmd struct {
 	Build     buildCmd     `cmd:"" group:"xpkg" help:"Build a package."`
-	XPExtract xpExtractCmd `cmd:"" group:"xpkg" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
+	XPExtract xpExtractCmd `cmd:"" maturity:"alpha" group:"xpkg" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
 	Init      initCmd      `cmd:"" group:"xpkg" help:"Initialize a package."`
 	Dep       depCmd       `cmd:"" group:"xpkg" help:"Manage package dependencies."`
 	Push      pushCmd      `cmd:"" group:"xpkg" help:"Push a package."`

--- a/cmd/up/xpls/xpls.go
+++ b/cmd/up/xpls/xpls.go
@@ -16,5 +16,5 @@ package xpls
 
 // Cmd --
 type Cmd struct {
-	Serve serveCmd `cmd:"" group:"xpls" help:"run a server for Crossplane definitions using the Language Server Protocol."`
+	Serve serveCmd `cmd:"" help:"run a server for Crossplane definitions using the Language Server Protocol."`
 }

--- a/internal/feature/maturity.go
+++ b/internal/feature/maturity.go
@@ -1,0 +1,40 @@
+package feature
+
+import (
+	"github.com/alecthomas/kong"
+)
+
+// maturityTag is the struct field tag used to specify maturity of a command.
+const maturityTag = "maturity"
+
+// Maturity is the maturity of a feature.
+type Maturity string
+
+// Currently supported maturity levels.
+const (
+	Alpha  Maturity = "alpha"
+	Stable Maturity = "stable"
+)
+
+// HideMaturity hides commands that are not at the specified level of maturity.
+func HideMaturity(p *kong.Path, maturity Maturity) error {
+	children := p.Node().Children
+	for _, c := range children {
+		mt := Maturity(c.Tag.Get(maturityTag))
+		if mt == "" {
+			mt = Stable
+		}
+		if mt != maturity {
+			c.Hidden = true
+		}
+	}
+	return nil
+}
+
+// GetMaturity gets the maturity of the node.
+func GetMaturity(n *kong.Node) Maturity {
+	if m := Maturity(n.Tag.Get(maturityTag)); m != "" {
+		return m
+	}
+	return Stable
+}

--- a/internal/feature/maturity.go
+++ b/internal/feature/maturity.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package feature
 
 import (

--- a/internal/upbound/token.go
+++ b/internal/upbound/token.go
@@ -1,0 +1,62 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upbound
+
+import (
+	"encoding/json"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+const errInvalidTokenFile = "token file is invalid"
+
+// TokenFile is the format in which Upbound tokens are stored on disk.
+type TokenFile struct {
+	AccessID string `json:"accessId"`
+	Token    string `json:"token"`
+}
+
+// tokenConf is the configuration for obtaining a token.
+type tokenConf struct {
+	fs afero.Fs
+}
+
+// TokenOption modifies how a token is obtained.
+type TokenOption func(conf *tokenConf)
+
+// TokenFromPath extracts a token from the provided path.
+func TokenFromPath(path string, opts ...TokenOption) (TokenFile, error) {
+	conf := &tokenConf{
+		fs: afero.NewOsFs(),
+	}
+	for _, o := range opts {
+		o(conf)
+	}
+	tf := TokenFile{}
+	f, err := conf.fs.Open(filepath.Clean(path))
+	if err != nil {
+		return tf, err
+	}
+	defer f.Close() //nolint:errcheck,gosec
+	if err := json.NewDecoder(f).Decode(&tf); err != nil {
+		return tf, err
+	}
+	if tf.AccessID == "" || tf.Token == "" {
+		return tf, errors.New(errInvalidTokenFile)
+	}
+	return tf, nil
+}

--- a/internal/upbound/token_test.go
+++ b/internal/upbound/token_test.go
@@ -1,0 +1,104 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upbound
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+)
+
+// withTokenFile sets the filesystem with a creds file.
+func withTokenFile(b []byte) TokenOption {
+	return func(conf *tokenConf) {
+		fs := afero.NewMemMapFs()
+		f, _ := fs.Create("creds.json")
+		f.Write(b)
+		conf.fs = fs
+	}
+}
+
+func TestTokenFromPath(t *testing.T) {
+	tf := TokenFile{
+		AccessID: "cool-access",
+		Token:    "cool-token",
+	}
+	validTF, _ := json.Marshal(tf)
+	type args struct {
+		path string
+		opts []TokenOption
+	}
+	type want struct {
+		tf  TokenFile
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NotExist": {
+			reason: "We should return error if token file does not exist.",
+			args: args{
+				path: "creds.json",
+			},
+			want: want{
+				err: &os.PathError{Op: "open", Path: "creds.json", Err: errors.New("no such file or directory")},
+			},
+		},
+		"InvalidTokenFile": {
+			reason: "We should return error if token file is invalid.",
+			args: args{
+				path: "creds.json",
+				opts: []TokenOption{
+					withTokenFile([]byte("{}")),
+				},
+			},
+			want: want{
+				err: errors.New(errInvalidTokenFile),
+			},
+		},
+		"ValidTokenFile": {
+			reason: "We should return token information if exists and is valid.",
+			args: args{
+				path: "creds.json",
+				opts: []TokenOption{
+					withTokenFile(validTF),
+				},
+			},
+			want: want{
+				tf: tf,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			token, err := TokenFromPath(tc.args.path, tc.args.opts...)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nTokenFromPath(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.tf, token); diff != "" {
+				t.Errorf("\n%s\nTokenFromPath(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Restructures alpha level command gating to dynamically hide commands
from help based on the branch they are accessed on. This allows for
tagging commands such that they can be accessible from multiple
branches, but are not shown in the help at maturity levels that differ
from their own.

Also updates to hide the usage help on hidden commands, instead
encouraging folks to use the variant at the specified maturity level. In
the future we will introduce alpha commands and not allow them to be
invoked on the main tree, but for now we want to keep existing commands
functioning properly even though they are not discoverable.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds a feature package that allows for specifying the maturity level of
a command.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds an up ctp pull-secret command which allows a user to create a
pull-secret using their profile credentials or a token file.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Nests the pull secret commands as a subcommand group under controlplane
so that they can be expanded in the future as needed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes https://github.com/upbound/up/issues/239
Fixes https://github.com/upbound/up/issues/240

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->


<details>
  <summary>Expand for testing</summary>

  ```
🤖 (up) up --version
v0.13.0-rc.0.92.g737bd4a
🤖 (up) up -h
Usage: up <command>

The Upbound CLI

Flags:
  -h, --help       Show context-sensitive help.
  -v, --version    Print version and exit.
  -q, --quiet      Suppress all output.
      --pretty     Pretty print output.

Commands:
  license
    Print Up license information.

  login
    Login to Upbound.

  logout
    Logout of Upbound.

  controlplane (ctp) <command>
    Interact with control planes.

  profile <command>
    Interact with Upbound profiles.

  organization (org) <command>
    Interact with organizations.

  repository (repo) <command>
    Interact with repositories.

  robot <command>
    Interact with robots.

  uxp <command>
    Interact with UXP.

  xpkg <command>
    Interact with UXP packages.

  xpls <command>
    Start xpls language server.

  alpha <command>
    Alpha features. Commands may be removed in future releases.

Run "up <command> --help" for more information on a command.
🤖 (up) up alpha -h
Usage: up alpha <command>

Alpha features. Commands may be removed in future releases.

Flags:
  -h, --help       Show context-sensitive help.
  -v, --version    Print version and exit.
  -q, --quiet      Suppress all output.
      --pretty     Pretty print output.

Commands:
  alpha controlplane (ctp) <command>
    Interact with control planes.

  alpha upbound <command>
    Interact with Upbound.

  alpha xpkg <command>
    Interact with UXP packages.
🤖 (up) up alpha upbound -h
Usage: up alpha upbound <command>

Interact with Upbound.

Flags:
  -h, --help                          Show context-sensitive help.
  -v, --version                       Print version and exit.
  -q, --quiet                         Suppress all output.
      --pretty                        Pretty print output.

      --kubeconfig=STRING             Override default kubeconfig path.
  -n, --namespace="upbound-system"    Kubernetes namespace for Upbound ($UPBOUND_NAMESPACE).

Commands:
  alpha upbound install <version>
    Install Upbound.

  alpha upbound mail
    Run a local mail portal.

  alpha upbound uninstall [<name>]
    Uninstall Upbound.

  alpha upbound upgrade <version>
    Upgrade Upbound.
🤖 (up) up ctp -h
Usage: up controlplane (ctp) <command>

Interact with control planes.

Flags:
  -h, --help                         Show context-sensitive help.
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io/    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

Commands:
  controlplane (ctp) pull-secret [<name>]
    Create a package pull secret.

🤖 (up) up ctp create -h
Refusing to emit help for hidden command. See alpha variant.
🤖 (up) up alpha ctp create -h
Usage: up alpha controlplane (ctp) create <name>

Create a hosted control plane.

Arguments:
  <name>    Name of control plane.

Flags:
  -h, --help                         Show context-sensitive help.
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io/    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

  -d, --description=STRING           Description for control plane.
🤖 (up) up robot list -a dan
NAME          ID                                     DESCRIPTION   CREATED
kube-access   69ef268a-2008-4b94-a202-606a39f42027                 29h    
up-test       d9386395-8bc0-4864-bcdd-37af69a02cdd                 9h     
🤖 (up) up robot create cli -a dan
dan/cli created
🤖 (up) up robot list -a dan
NAME          ID                                     DESCRIPTION   CREATED
kube-access   69ef268a-2008-4b94-a202-606a39f42027                 29h    
cli           b92efe20-fb7d-4287-a738-92539cbb2a62                 5s     
up-test       d9386395-8bc0-4864-bcdd-37af69a02cdd                 9h     
🤖 (up) up robot token create cli test -a dan
up: error: missing flags: --output=STRING
🤖 (up) up robot token create cli test -a dan -o creds.json
dan/cli/test created
🤖 (up) ls | grep creds.json
creds.json
🤖 (up) up --version
v0.13.0-rc.0.93.gb5b9bb4
🤖 (up) k get secrets -n upbound-system
NAME                                       TYPE                                  DATA   AGE
crossplane-token-nphsq                     kubernetes.io/service-account-token   3      31h
default-token-5jqpj                        kubernetes.io/service-account-token   3      31h
prometheus-token-qww8j                     kubernetes.io/service-account-token   3      31h
rbac-manager-token-2jrsc                   kubernetes.io/service-account-token   3      31h
sh.helm.release.v1.cc-policies-tenant.v1   helm.sh/release.v1                    1      31h
sh.helm.release.v1.crossplane-tenant.v1    helm.sh/release.v1                    1      31h
upbound-agent-tls                          Opaque                                3      31h
upbound-agent-token-nfd4r                  kubernetes.io/service-account-token   3      31h
upbound-bootstrapper-token-qwln9           kubernetes.io/service-account-token   3      31h
upbound-control-plane-token                Opaque                                1      31h
uxp-ca                                     Opaque                                3      31h
xgql-tls                                   Opaque                                3      31h
xgql-token-dmjmn                           kubernetes.io/service-account-token   3      31h
🤖 (up) up ctp pull-secret create
WARNING: Using temporary user credentials that will expire within 30 days.
upbound-system/package-pull-secret created
🤖 (up) k get secrets -n upbound-system
NAME                                       TYPE                                  DATA   AGE
crossplane-token-nphsq                     kubernetes.io/service-account-token   3      31h
default-token-5jqpj                        kubernetes.io/service-account-token   3      31h
package-pull-secret                        kubernetes.io/dockerconfigjson        1      3s
prometheus-token-qww8j                     kubernetes.io/service-account-token   3      31h
rbac-manager-token-2jrsc                   kubernetes.io/service-account-token   3      31h
sh.helm.release.v1.cc-policies-tenant.v1   helm.sh/release.v1                    1      31h
sh.helm.release.v1.crossplane-tenant.v1    helm.sh/release.v1                    1      31h
upbound-agent-tls                          Opaque                                3      31h
upbound-agent-token-nfd4r                  kubernetes.io/service-account-token   3      31h
upbound-bootstrapper-token-qwln9           kubernetes.io/service-account-token   3      31h
upbound-control-plane-token                Opaque                                1      31h
uxp-ca                                     Opaque                                3      31h
xgql-tls                                   Opaque                                3      31h
xgql-token-dmjmn                           kubernetes.io/service-account-token   3      31h
🤖 (up) k get secrets -n crossplane-system
NAME                                    TYPE                                  DATA   AGE
default-token-lrmlb                     kubernetes.io/service-account-token   3      31h
package-pull-secret                     kubernetes.io/dockerconfigjson        1      29h
provider-aws-6d0d7887a3e8-token-tc58j   kubernetes.io/service-account-token   3      28h
upbound-oidc                            Opaque                                1      24h
🤖 (up) up ctp pull-secret create cool-pull -n crossplane-system
WARNING: Using temporary user credentials that will expire within 30 days.
crossplane-system/cool-pull created
🤖 (up) up ctp pull-secret create cool-pull-token -f creds.json -n crossplane-system
crossplane-system/cool-pull-token created
🤖 (up) k get secrets -n crossplane-system
NAME                                    TYPE                                  DATA   AGE
cool-pull                               kubernetes.io/dockerconfigjson        1      18s
cool-pull-token                         kubernetes.io/dockerconfigjson        1      6s
default-token-lrmlb                     kubernetes.io/service-account-token   3      31h
package-pull-secret                     kubernetes.io/dockerconfigjson        1      29h
provider-aws-6d0d7887a3e8-token-tc58j   kubernetes.io/service-account-token   3      28h
  ```

</details>