### PR TITLE
Cleanup command structure and allow creating new named profile on login

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -90,8 +90,8 @@ type cli struct {
 	Login        loginCmd         `cmd:"" help:"Login to Upbound."`
 	Logout       logoutCmd        `cmd:"" help:"Logout of Upbound."`
 	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
-	Profile      profile.Cmd      `cmd:"" help:"Interact with Upbound profiles."`
 	Organization organization.Cmd `cmd:"" name:"organization" aliases:"org" help:"Interact with organizations."`
+	Profile      profile.Cmd      `cmd:"" help:"Interact with Upbound profiles."`
 	Repository   repository.Cmd   `cmd:"" name:"repository" aliases:"repo" help:"Interact with repositories."`
 	Robot        robot.Cmd        `cmd:"" name:"robot" help:"Interact with robots."`
 	Upbound      upbound.Cmd      `cmd:"" maturity:"alpha" help:"Interact with Upbound."`

--- a/cmd/up/profile/config/config.go
+++ b/cmd/up/profile/config/config.go
@@ -14,28 +14,8 @@
 
 package config
 
-import (
-	"github.com/alecthomas/kong"
-
-	"github.com/upbound/up/internal/upbound"
-)
-
-// Cmd contains commands for Upbound Profiles.
+// Cmd contains commands for configuring Upbound Profiles.
 type Cmd struct {
 	Set   setCmd   `cmd:"" help:"Set base configuration key, value pair in the Upbound Profile."`
 	UnSet unsetCmd `cmd:"" name:"unset" help:"Unset base configuration key, value pair in the Upbound Profile."`
-
-	Flags upbound.Flags `embed:""`
-}
-
-// AfterApply constructs and binds Upbound-specific context to any subcommands
-// that have Run() methods that receive it.
-func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
-	upCtx, err := upbound.NewFromFlags(c.Flags)
-	if err != nil {
-		return err
-	}
-
-	kongCtx.Bind(upCtx)
-	return nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Update the Context building to error if a profile is supplied but does
not exist, unless the AllowMissingProfile option is also supplied. This
is primarily to accommodate logging in and creating a new profile with
name that matches flag.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds two new unit test cases to cover when a profile name is supplied
and it does not exist, and when a profile name is supplied and it does
not exist but AllowMissingProfile is also supplied. The former should
error while the latter should not.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates the login command to specify that logging in with a supplied
profile that is missing should be allowed. This is the case in which a
user wants to create a new named profile on login.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Removes duplicate Upbound flags inclusion from up profile config. It
already consumes the flags as they are supplied by up profile.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
🤖 (up) rm ~/.up/config.json 
# creates a new profile
🤖 (up) up login --profile=stream
Username: hasheddan
Password: 
hasheddan logged in
🤖 (up) up profile list
CURRENT   NAME     TYPE   ACCOUNT  
*         stream   user   hasheddan
🤖 (up) up profile view
{
    "stream": {
        "id": "hasheddan",
        "type": "user",
        "session": "REDACTED",
        "account": "hasheddan"
    }
}
# login default to the profile specified as default
🤖 (up) up login
Username: hasheddan
Password: 
hasheddan logged in
🤖 (up) up profile view
{
    "stream": {
        "id": "hasheddan",
        "type": "user",
        "session": "REDACTED",
        "account": "hasheddan"
    }
}
🤖 (up) up profile list
CURRENT   NAME     TYPE   ACCOUNT  
*         stream   user   hasheddan
# login default to the profile specified as default and updates it
🤖 (up) up login --account=dan
Username: hasheddan
Password: 
hasheddan logged in
🤖 (up) up profile view
{
    "stream": {
        "id": "hasheddan",
        "type": "user",
        "session": "REDACTED",
        "account": "dan"
    }
}
# login with profile named default, it is added and set as the default profile
🤖 (up) up login --profile=default
Username: hasheddan
Password: 
hasheddan logged in
🤖 (up) up profile list
CURRENT   NAME      TYPE   ACCOUNT  
*         default   user   hasheddan
          stream    user   dan      
🤖 (up) up profile view
{
    "default": {
        "id": "hasheddan",
        "type": "user",
        "session": "REDACTED",
        "account": "hasheddan"
    },
    "stream": {
        "id": "hasheddan",
        "type": "user",
        "session": "REDACTED",
        "account": "dan"
    }
}
```