### PR TITLE
Fix top-level alpha command help output and updates docs for v0.13.0 release

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -109,9 +109,9 @@ func (a *alpha) BeforeReset(ctx *kong.Context) error { //nolint:unparam
 }
 
 type alpha struct {
-	ControlPlane controlplane.Cmd `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
-	Upbound      upbound.Cmd      `cmd:"" help:"Interact with Upbound."`
-	XPKG         xpkg.Cmd         `cmd:"" help:"Interact with UXP packages."`
+	ControlPlane controlplane.Cmd `cmd:"" maturity:"alpha" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
+	Upbound      upbound.Cmd      `cmd:"" maturity:"alpha" help:"Interact with Upbound."`
+	XPKG         xpkg.Cmd         `cmd:"" maturity:"alpha" help:"Interact with UXP packages."`
 }
 
 func main() {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -109,9 +109,15 @@ Format: `up controlplane pull-secret <cmd> ...` Alias: `up ctp pull-secret
       currently configured `kubeconfig`. If `-f` is not provided, the session
       token in the current profile is used. Session tokens expire within 30
       days. If `-f` is provided, it must point to a file with valid token
-      credentials in the following JSON format: `{"accessId": "<access-id>",
-      "token":"<token>"}`. This is the same format emitted by `up robot token
-      create`. Robot tokens do not expire.
+      credentials in the following JSON format:
+      ```json
+      {
+        "accessId": "<access-id>",
+        "token":"<token>"
+      }
+      ```
+      This is the same format emitted by `up robot token create`. Robot tokens
+      do not expire.
 
 ## Profile
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,10 +8,13 @@ interacts.
 Groups:
 - [Top-Level](#top-level)
 - [Control Plane](#control-plane)
-- [Upbound](#upbound)
+- [Organization](#organization)
+- [Repository](#repository)
+- [Robot](#robot)
 - [UXP](#uxp)
 - [XPKG](#xpkg)
 - [XPLS](#xpls)
+- [Alpha](#upbound)
 
 ## Top-Level
 
@@ -31,14 +34,13 @@ Format: `up <cmd> ...`
           perform the login. If `-` is given the value will be read from stdin.
         - `-u,--username = STRING` (Env: `UP_USER`): User with which to perform
           the login. Email can also be used as username.
+        - `--domain = URL` (Env: `UP_DOMAIN`) (Default: `https://upbound.io`):
+          Endpoint to use when communicating with the Upbound API.
+        - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to
+          perform the specified command.
         - `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to
           perform the specified command. Can be either an organization or a
           personal account.
-        - `--endpoint = URL` (Env: `UP_ENDPOINT`) (Default:
-          `https://api.upbound.io`): Endpoint to use when communicating with the
-          Upbound API.
-        - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to
-          perform the specified command.
     - Behavior: Acquires a session token based on the provided information. If
       only username is provided, the user will be prompted for a password. If
       neither username or password is provided, the user will be prompted for
@@ -47,14 +49,15 @@ Format: `up <cmd> ...`
       input is disabled if stdin is not an interactive terminal.
 - `logout`
     - Flags:
+        - `--domain = URL` (Env: `UP_DOMAIN`) (Default: `https://upbound.io`):
+          Endpoint to use when communicating with the Upbound API.
+        - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to
+          perform the specified command.
        - `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to
           perform the specified command. Can be either an organization or a
           personal account.
-        - `--endpoint = URL` (Env: `UP_ENDPOINT`) (Default:
-          `https://api.upbound.io`): Endpoint to use when communicating with the
-          Upbound API.
-        - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to
-          perform the specified command.
+        - `--insecure-skip-tls-verify = BOOL` (Env:
+          `UP_INSECURE_SKIP_TLS_VERIFY`): Skip verifying TLS certificates.
     - Behavior: Invalidates the session token for the default profile or one
       specified with `--profile`.
 
@@ -64,109 +67,214 @@ Top-level flags can be passed for any top-level or group-specific command.
 
 - `-h,--help`: Print help and exit.
 - `-v,--version`: Print current `up` version and exit.
+- `-q,--quiet`: Suppresses all output.
+- `--pretty`: Pretty prints output.
 
 ## Control Plane
 
 Format: `up controlplane <cmd> ...` Alias: `up ctp <cmd> ...`
 
-- `create <name>`
-    - Flags:
-        - `--description = STRING`: Control plane description.
-    - Behavior: Creates a hosted control plane in Upbound.
-- `delete <id>`
-    - Behavior: Deletes a control plane in Upbound.
-- `list`
-    - Behavior: Lists all control planes for the configured account.
+Commands in the **Control Plane** group are used to manage and interact with
+control planes.
 
 **Group Flags**
 
 Group flags can be passed for any command in the **Control Plane** group. Some
 commands may choose not to utilize the group flags when not relevant.
 
-- `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to perform the
-  specified command. Can be either an organization or a personal account.
-- `--endpoint = URL` (Env: `UP_ENDPOINT`) (Default: `https://api.upbound.io`):
-  Endpoint to use when communicating with the Upbound API.
-- `--mcp-experimental = BOOL` (Env: `UP_MCP_EXPERIMENTAL`): Use experimental
-  control planes API.
+- `--domain = URL` (Env: `UP_DOMAIN`) (Default: `https://upbound.io`): Endpoint
+  to use when communicating with the Upbound API.
 - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
   specified command.
+- `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to perform the
+  specified command. Can be either an organization or a personal account.
+- `--insecure-skip-tls-verify = BOOL` (Env: `UP_INSECURE_SKIP_TLS_VERIFY`): Skip
+  verifying TLS certificates.
 
-**Subgroup: Kubeconfig**
+**Subgroup: Pull Secret**
 
-Format: `up controlplane kubeconfig <cmd> ...` Alias: `up ctp kubeconfig
+Format: `up controlplane pull-secret <cmd> ...` Alias: `up ctp pull-secret
 <cmd>...`
 
-- `get <control-plane-ID>`
+- `create <control-plane-ID>`
     - Flags:
-        - `--token = STRING` (*Required*): API token for authenticating to
-          control plane. If `-` is given the value will be read from stdin.
-        - `-f,--file = FILE`: File to merge `kubeconfig`.
-        - `--proxy = URL` (Env: `UP_PROXY`) (Default:
-          `https://proxy.upbound.io/env`): Endpoint for Upbound control plane
-          proxy.
-    - Behavior: Merges control plane cluster and authentication data into
-      currently configured `kubeconfig`, or one specified by `--file`. The
-      `--token` flag must be provided and must be a valid Upbound API token. A
-      new context will be created for the cluster and authentication data and it
-      will be set as current.
+        - `-f,--file = FILE`: Path to token credentials file. Credentials from
+          profile are used if not specified.
+        - `--kubeconfig = STRING`: sets `kubeconfig` path. Same defaults as
+        `kubectl` are used if not provided.
+        - `-n,--namespace = STRING` (Env: `UPBOUND_NAMESPACE`) (Default:
+          `upbound-system`): Kubernetes namespace used for installing and
+          managing Upbound.
+    - Behavior: Creates a package pull secret in the cluster pointed to by the
+      currently configured `kubeconfig`. If `-f` is not provided, the session
+      token in the current profile is used. Session tokens expire within 30
+      days. If `-f` is provided, it must point to a file with valid token
+      credentials in the following JSON format: `{"accessId": "<access-id>",
+      "token":"<token>"}`. This is the same format emitted by `up robot token
+      create`. Robot tokens do not expire.
 
-## Upbound
+## Profile
 
-Format: `up upbound <cmd> ...`
+Format: `up profile <cmd> ...` 
 
-Commands in the **Upbound** group are used to install and manage Upbound.
-Installing and upgrading Upbound requires an Upbound customer license. Users
-will be prompted for their License ID and License Key on installation.
+Commands in the **Profile** group are used to configure `up` using named
+profiles. See the [configuration documentation] for more information on how
+Upbound profiles are structured.
 
-- `install <version>`
-    - Flags:
-        - `--license-secret-name = STRING` (Default: `upbound-license`): Allows
-          setting the name of the license `Secret` that is created on
-          installation. The default value is expected, so passing an alternate
-          value for this flag usually requires modifying the installation
-          configuration using one of the following flags.
-        - `--set = KEY=VALUE`: Set install parameters for Upbound. Flag can be
-          passed multiple times and multiple key-value pairs can be provided in
-          a comma-separated list.
-        - `-f,--file = FILE`: YAML file with parameters for Upbound install.
-          Follows format of Helm-style values file.
-    - Behavior: Installs Upbound into cluster specified by currently configured
-      `kubeconfig`. When using Helm as install engine, the command mirrors the
-      behavior of `helm install`. If `[version]` is not provided, the latest
-      chart version will be used from the either the stable or unstable
-      repository.
-- `upgrade <version>` 
-    - Flags:
-        - `--rollback = BOOL`: Indicates that the upgrade should be rolled back
-          in case of failure.
-        - `--set = KEY=VALUE`: Set install parameters for Upbound. Flag can be
-          passed multiple times and multiple key-value pairs can be provided in
-          a comma-separated list.
-        - `-f,--file = FILE`: YAML file with parameters for Upbound install.
-          Follows format of Helm-style values file.
-    - Behavior: Upgrades Upbound in cluster specified by currently configured
-      `kubeconfig` in the specified namespace.
-- `uninstall` 
-    - Behavior: Uninstalls Upbound from the cluster specified by currently
-      configured `kubeconfig`.
-- `mail` (_EXPERIMENTAL_)
-    - Flags:
-        - `-p,--port = INT` (Default: `8085`): Port used for mail portal.
-        - `--verbose = BOOL`: Run server with verbose logging.
-    - Behavior: Runs a local mail portal for Upbound when configured to send
-      emails as Kubernetes Secrets.
+- `current`
+    - Behavior: Gets the current Upbound profile. Sensitive data is obfuscated.
+- `list`
+    - Behavior: Lists all Upbound profiles.
+- `use <name>`
+    - Behavior: Sets the default Upbound profile to the one specified by the
+      provided name.
+- `view`
+    - Behavior: Gets all Upbound profiles. Sensitive data is obfuscated.
 
 **Group Flags**
 
-Group flags can be passed for any command in the **Upbound** group. Some
+Group flags can be passed for any command in the **Profile** group. Some
 commands may choose not to utilize the group flags when not relevant.
 
-- `--kubeconfig = STRING`: sets `kubeconfig` path. Same defaults as `kubectl`
-  are used if not provided.
-- `-n,--namespace = STRING` (Env: `UPBOUND_NAMESPACE`) (Default:
-  `upbound-system`): Kubernetes namespace used for installing and managing
-  Upbound.
+- `--domain = URL` (Env: `UP_DOMAIN`) (Default: `https://upbound.io`): Endpoint
+  to use when communicating with the Upbound API.
+- `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
+  specified command.
+- `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to perform the
+  specified command. Can be either an organization or a personal account.
+- `--insecure-skip-tls-verify = BOOL` (Env: `UP_INSECURE_SKIP_TLS_VERIFY`): Skip
+  verifying TLS certificates.
+
+**Subgroup: Config**
+
+Format: `up profile config <cmd> ...`
+
+- `set [<key> [<value>]]`
+    - Flags:
+        - `-f, --file = FILE`: Path to configuration file. Must be in JSON
+          format.
+    - Behavior: Adds the provided key, value pair(s) to the Upbound profile.
+- `unset [<key>]`
+    - Flags:
+        - `-f, --file = FILE`: Path to configuration file. Must be in JSON
+          format.
+    - Behavior: Removes the provided key, value pair(s) from the Upbound
+      profile.
+
+## Organization
+
+Format: `up organization <cmd> ...` Alias: `up org <cmd>...`
+
+Commands in the **Organization** group are used to interact with Upbound
+organizations.
+
+- `create <name>`
+    - Behavior: Creates an Upbound organization.
+- `delete <name>`
+    - Flags:
+        - `--force = BOOL`: Force deletion of organization.
+    - Behavior: Deletes an Upbound organization.
+- `list`
+    - Behavior: Lists all Upbound organizations in which the user is a member or
+      owner.
+
+**Group Flags**
+
+Group flags can be passed for any command in the **Organization** group. Some
+commands may choose not to utilize the group flags when not relevant.
+
+- `--domain = URL` (Env: `UP_DOMAIN`) (Default: `https://upbound.io`): Endpoint
+  to use when communicating with the Upbound API.
+- `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
+  specified command.
+- `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to perform the
+  specified command. Can be either an organization or a personal account.
+- `--insecure-skip-tls-verify = BOOL` (Env: `UP_INSECURE_SKIP_TLS_VERIFY`): Skip
+  verifying TLS certificates.
+
+## Repository
+
+Format: `up repository <cmd> ...` Alias: `up repo <cmd>...`
+
+Commands in the **Repository** group are used to interact with repositories in
+Upbound accounts.
+
+- `create <name>`
+    - Behavior: Creates a repository with the specified name in the current
+      account.
+- `delete <name>`
+    - Flags:
+        - `--force = BOOL`: Force deletion of repository.
+    - Behavior: Deletes the repository with the specified name in the current
+      account.
+- `list`
+    - Behavior: Lists all repositories in the current account.
+
+**Group Flags**
+
+Group flags can be passed for any command in the **Organization** group. Some
+commands may choose not to utilize the group flags when not relevant.
+
+- `--domain = URL` (Env: `UP_DOMAIN`) (Default: `https://upbound.io`): Endpoint
+  to use when communicating with the Upbound API.
+- `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
+  specified command.
+- `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to perform the
+  specified command. Can be either an organization or a personal account.
+- `--insecure-skip-tls-verify = BOOL` (Env: `UP_INSECURE_SKIP_TLS_VERIFY`): Skip
+  verifying TLS certificates.
+
+## Robot
+
+Format: `up robot <cmd> ...`
+
+Commands in the **Robot** group are used to interact with robot accounts in
+Upbound organizations.
+
+- `create <name>`
+    - Behavior: Creates a robot account with the specified name in the current
+      organization.
+- `delete <name>`
+    - Flags:
+        - `--force = BOOL`: Force deletion of robot.
+    - Behavior: Deletes the robot with the specified name in the current
+      organization.
+- `list`
+    - Behavior: Lists all robots in the current organization.
+
+**Group Flags**
+
+Group flags can be passed for any command in the **Organization** group. Some
+commands may choose not to utilize the group flags when not relevant.
+
+- `--domain = URL` (Env: `UP_DOMAIN`) (Default: `https://upbound.io`): Endpoint
+  to use when communicating with the Upbound API.
+- `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
+  specified command.
+- `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to perform the
+  specified command. Can be either an organization or a personal account.
+- `--insecure-skip-tls-verify = BOOL` (Env: `UP_INSECURE_SKIP_TLS_VERIFY`): Skip
+  verifying TLS certificates.
+
+**Subgroup: Token**
+
+Format: `up robot token <cmd> ...`
+
+- `create <robot-name> <token-name>`
+    - Flags:
+        - `-o,--output = FILE` (*Required*): Path to file for writing token
+          credentials. If `-` is provided, credentials will be printed to the
+          terminal.
+    - Behavior: Creates a token with the specified name for the specified robot
+      account in the current organization.
+- `delete <robot-name> <token-name>`
+    - Flags:
+        - `--force = BOOL`: Force deletion of token.
+    - Behavior: Deletes the token with the specified name for the specified
+      robot account in the current organization.
+- `list <robot-name>`
+    - Behavior: Lists all tokens for the specified robot account in the current
+      organization.
 
 ## UXP
 
@@ -248,52 +356,50 @@ may choose not to utilize the group flags when not relevant.
 Format: `up xpkg <cmd> ...`
 
 Commands in the **XPKG** group are used to build, push, and interact with
-on-disk UXP packages.
+on-disk Crossplane packages.
 
 - `build`
     - Flags:
-        - `--name = STRING`: Name of the package to be built. Uses name in
-          crossplane.yaml if not specified. Does not correspond to package tag.
-        - `-f, --package-root = STRING`: Path to package directory.
+        - `--name = STRING` (*DEPRECATED: use `--output` instead.*): Name of the
+          package to be built. Uses name in `crossplane.yaml` if not specified.
+          Does not correspond to package tag.
+        - `-o,--output = FILE`: Path to out file for package. Uses name in
+          `crossplane.yaml` and root package directory if not specified. Does
+          not correspond to package tag.
+        - `--controller = STRING`: Controller image to use as base when
+          constructing bundled Provider packages. Image must be available in
+          local Docker daemon.
+        - `-f,--package-root = STRING`: Path to package directory.
+        - `-e,--examples-root = STRING` (Default: `./examples`): Path to package
+          examples directory.
         - `--ignore = STRING,...`: Paths, specified relative to --package-root,
           to exclude from the package.
-    - Behavior: Builds a UXP package (`.xpkg`) that is compatible with upstream
-      Crossplane packages and is a valid OCI image. Build will fail if package
-      is malformed or contains resources that are not compatible with its type
-      (e.g. a `Provider` package containing a `Composition`).
-- `xp-extract <package>` (_EXPERIMENTAL_)
-    - Flags:.
-        - `--from-daemon = BOOL`: Indicates that the image should be fetched
-          from the Docker daemon instead of the registry.
-        - `-o, --output = STRING` (Default: `out.gz`): Package output file path.
-          Extension must be .gz or will be replaced
-    - Behavior: Extract package contents into a Crossplane cache compatible
-      format. `package` must be a valid OCI image reference and is fetched from
-      a remote registry unless `--from-daemon` is specified. The [Upbound
-      Registry] (`registry.upbound.io`) will be used by default if reference
-      does not specify.
+    - Behavior: Builds a Crossplane package (`.xpkg`) that is compatible with
+      upstream Crossplane packages and is a valid OCI image. Build will fail if
+      package is malformed or contains resources that are not compatible with
+      its type (e.g. a `Provider` package containing a `Composition`).
 - `init`
-    - Flags:.
-        - `-p, --package-root = STRING` (Default: `.`): Path to directory where
+    - Flags:
+        - `-p,--package-root = STRING` (Default: `.`): Path to directory where
           package will be initialized.
-        - `-t, --type = STRING` (Default: `configuration`): Type of package to
+        - `-t,--type = STRING` (Default: `configuration`): Type of package to
           initialize.
     - Behavior: Initializes a package in the specified directory.
 - `dep [package]`
-    - Flags:.
+    - Flags:
         - `--cache-dir = STRING` (Default: `~/.up/cache`): Path to package
           dependency cache.
-        - `-c, --clean-cache = BOOL`: Clean the dependency cache.
+        - `-c,--clean-cache = BOOL`: Clean the dependency cache.
     - Behavior: Adds a package to the dependency cache.
 - `push <tag>`
-    - Flags:.
-        - `-f, --package = STRING`: Path to package. If not specified and only
+    - Flags:
+        - `-f,--package = STRING`: Path to package. If not specified and only
           one package exists in current directory it will be used.
         - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to
           perform the specified command.
-    - Behavior: Pushes a UXP package (`.xpkg`) to an OCI compliant registry. The
-      [Upbound Registry] (`registry.upbound.io`) will be used by default if tag
-      does not specify.
+    - Behavior: Pushes a Crossplane package (`.xpkg`) to an OCI compliant
+      registry. The [Upbound Marketplace] (`xpkg.upbound.io`) will be used by
+      default if tag does not specify.
 
 ## XPLS
 
@@ -308,6 +414,147 @@ server.
         - `--verbose = BOOL`: Run server with verbose logging.
     - Behavior: Runs the Crossplane language server.
 
+## Alpha
+
+The **Alpha** group includes commands that are _alpha_ maturity level. These
+commands may or may not be present in subsequent releases of `up`.
+
+### Control Plane
+
+Format: `up alpha controlplane <cmd> ...` Alias: `up alpha ctp <cmd> ...`
+
+Commands in the **Control Plane** group are used to manage and interact with
+control planes.
+
+- `create <name>`
+    - Flags:
+        - `--description = STRING`: Control plane description.
+    - Behavior: Creates a hosted control plane in Upbound.
+- `delete <id>`
+    - Behavior: Deletes a control plane in Upbound.
+- `list`
+    - Behavior: Lists all control planes for the configured account.
+
+**Group Flags**
+
+Group flags can be passed for any command in the **Control Plane** group. Some
+commands may choose not to utilize the group flags when not relevant.
+
+- `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to perform the
+  specified command. Can be either an organization or a personal account.
+- `--endpoint = URL` (Env: `UP_DOMAIN`) (Default: `https://api.upbound.io`):
+  Endpoint to use when communicating with the Upbound API.
+- `--mcp-experimental = BOOL` (Env: `UP_MCP_EXPERIMENTAL`): Use experimental
+  control planes API.
+- `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
+  specified command.
+
+**Subgroup: Kubeconfig**
+
+Format: `up alpha controlplane kubeconfig <cmd> ...` Alias: `up ctp kubeconfig
+<cmd>...`
+
+- `get <control-plane-ID>`
+    - Flags:
+        - `--token = STRING` (*Required*): API token for authenticating to
+          control plane. If `-` is given the value will be read from stdin.
+        - `-f,--file = FILE`: File to merge `kubeconfig`.
+        - `--proxy = URL` (Env: `UP_PROXY`) (Default:
+          `https://proxy.upbound.io/env`): Endpoint for Upbound control plane
+          proxy.
+    - Behavior: Merges control plane cluster and authentication data into
+      currently configured `kubeconfig`, or one specified by `--file`. The
+      `--token` flag must be provided and must be a valid Upbound API token. A
+      new context will be created for the cluster and authentication data and it
+      will be set as current.
+
+### Upbound
+
+Format: `up upbound <cmd> ...`
+
+Commands in the **Upbound** group are used to install and manage Upbound.
+Installing and upgrading Upbound requires an Upbound customer license. Users
+will be prompted for their License ID and License Key on installation.
+
+- `install <version>`
+    - Flags:
+        - `--license-secret-name = STRING` (Default: `upbound-license`): Allows
+          setting the name of the license `Secret` that is created on
+          installation. The default value is expected, so passing an alternate
+          value for this flag usually requires modifying the installation
+          configuration using one of the following flags.
+        - `--set = KEY=VALUE`: Set install parameters for Upbound. Flag can be
+          passed multiple times and multiple key-value pairs can be provided in
+          a comma-separated list.
+        - `-f,--file = FILE`: YAML file with parameters for Upbound install.
+          Follows format of Helm-style values file.
+        - `-a,--account = STRING` (Env: `UP_ACCOUNT`): Account with which to
+          perform the specified command. Can be either an organization or a
+          personal account.
+        - `--endpoint = URL` (Env: `UP_DOMAIN`) (Default:
+          `https://api.upbound.io`): Endpoint to use when communicating with the
+          Upbound API.
+        - `--mcp-experimental = BOOL` (Env: `UP_MCP_EXPERIMENTAL`): Use
+          experimental control planes API.
+        - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to
+          perform the specified command.
+    - Behavior: Installs Upbound into cluster specified by currently configured
+      `kubeconfig`. When using Helm as install engine, the command mirrors the
+      behavior of `helm install`. If `[version]` is not provided, the latest
+      chart version will be used from the either the stable or unstable
+      repository.
+- `upgrade <version>` 
+    - Flags:
+        - `--rollback = BOOL`: Indicates that the upgrade should be rolled back
+          in case of failure.
+        - `--set = KEY=VALUE`: Set install parameters for Upbound. Flag can be
+          passed multiple times and multiple key-value pairs can be provided in
+          a comma-separated list.
+        - `-f,--file = FILE`: YAML file with parameters for Upbound install.
+          Follows format of Helm-style values file.
+    - Behavior: Upgrades Upbound in cluster specified by currently configured
+      `kubeconfig` in the specified namespace.
+- `uninstall` 
+    - Behavior: Uninstalls Upbound from the cluster specified by currently
+      configured `kubeconfig`.
+- `mail`
+    - Flags:
+        - `-p,--port = INT` (Default: `8085`): Port used for mail portal.
+        - `--verbose = BOOL`: Run server with verbose logging.
+    - Behavior: Runs a local mail portal for Upbound when configured to send
+      emails as Kubernetes Secrets.
+
+**Group Flags**
+
+Group flags can be passed for any command in the **Upbound** group. Some
+commands may choose not to utilize the group flags when not relevant.
+
+- `--kubeconfig = STRING`: sets `kubeconfig` path. Same defaults as `kubectl`
+  are used if not provided.
+- `-n,--namespace = STRING` (Env: `UPBOUND_NAMESPACE`) (Default:
+  `upbound-system`): Kubernetes namespace used for installing and managing
+  Upbound.
+
+### XPKG
+
+Format: `up alpha xpkg <cmd> ...`
+
+Commands in the **XPKG** group are used to build, push, and interact with
+on-disk Crossplane packages.
+
+- `xp-extract <package>`
+    - Flags:
+        - `--from-daemon = BOOL`: Indicates that the image should be fetched
+          from the Docker daemon instead of the registry.
+        - `-o, --output = STRING` (Default: `out.gz`): Package output file path.
+          Extension must be .gz or will be replaced
+    - Behavior: Extract package contents into a Crossplane cache compatible
+      format. `package` must be a valid OCI image reference and is fetched from
+      a remote registry unless `--from-daemon` is specified. The [Upbound
+      Registry] (`xpkg.upbound.io`) will be used by default if reference does
+      not specify.
+
 <!-- Named Links -->
 [Upbound Software License]: https://licenses.upbound.io/upbound-software-license.html
-[Upbound Registry]: https://www.upbound.io/registry
+[Upbound Marketplace]: https://www.upbound.io/registry
+[configuration documentation]: configuration.md

--- a/docs/maturity.md
+++ b/docs/maturity.md
@@ -1,0 +1,74 @@
+# API Maturity
+
+`up` aims to be explicit about the level of support for individual commands. As
+such, every command is denoted with an associated level of maturity. Currently,
+there are only two levels:
+
+- `alpha`: command is experimental and is likely to be removed in a future minor
+  version release.
+- `stable`: command is expected to be supported in perpetuity, but may be
+  deprecated or removed in subsequent minor version releases.
+
+The `stable` guarantee is expected to move to a backwards compatibility
+guarantee once the `up` CLI reaches `v1.0`. 
+
+The second command node in the graph (i.e. the noun after `up`) indicates the
+maturity level of a given command. For example, all `alpha` commands will start
+with `up alpha` (e.g. `up alpha xpkg xp-extract`). If the second noun is not a
+maturity level, the command is `stable` (e.g. `up xpkg build`). This structure
+is implemented to ensure that users are opting in to using commands that are
+likely to change from one release to another.
+
+## Hidden Commands
+
+In special circumstances, `up` may attach a command node at multiple locations
+in the graph, with only one variant being visible. For example, in the `v0.13.0`
+release, which introduced the API maturity framework, some commands were moved
+to `alpha` that were already widely depended upon by existing user workflows and
+CI systems. In order to ensure that those commands did not immediately break on
+upgrade, they remained as hidden at their previous location in the command
+graph.
+
+For example, `up ctp create` was moved to `up alpha ctp create` in `v0.13.0`.
+Executing `up ctp create -h` will inform the user that the command exists, but
+they are encouraged to use the unhidden variant. If a user does execute the
+hidden command with valid arguments, it will run successfully.
+
+```
+$ up ctp create -h
+Refusing to emit help for hidden command. See alpha variant.
+
+$ up ctp create cool-plane
+dan/cool-plane created
+
+$ up alpha ctp create -h
+Usage: up alpha controlplane (ctp) create <name>
+
+Create a hosted control plane.
+
+Arguments:
+  <name>    Name of control plane.
+
+Flags:
+  -h, --help                         Show context-sensitive help.
+  -v, --version                      Print version and exit.
+  -q, --quiet                        Suppress all output.
+      --pretty                       Pretty print output.
+
+      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
+      --profile=STRING               Profile used to execute command ($UP_PROFILE).
+  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
+      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).
+
+  -d, --description=STRING           Description for control plane.
+
+$ up alpha ctp create cool-plane-2
+dan/cool-plane-2 created
+
+```
+
+This strategy may also be implemented in the future when promoting commands from
+a lower level of maturity to a higher level, but it is encouraged for users to
+_never_ depend on hidden commands. This functionality is only provided as a
+convenience for users to extend the window in which they must update their
+systems to the new commands.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -73,25 +73,12 @@ $ up login --username=hasheddan --password=supersecret --profile=dev
 $ up login --token=supersecrettoken --profile=dev
 ```
 
-## Hosted Control Plane
+## Universal Crossplane
 
-Create hosted control plane in Upbound:
+`up` can be used to manage the lifecycle of an [Upbound Universal Crossplane]
+installation.
 
-```
-$ up controlplane create my-hosted-cp
-```
-
-```
-$ up ctp create my-hosted-cp
-```
-
-## Self-Hosted Control Plane
-
-Creating a self-hosted control plane in Upbound consists of three primary steps:
-installing UXP, creating a self-hosted control plane in Upbound (i.e.
-"attaching"), and connecting UXP to that control plane.
-
-### Installing UXP
+### Installing
 
 Install latest stable version:
 
@@ -131,11 +118,11 @@ $ up uxp install -f uxp-params.yaml
 
 ### Upgrading Crossplane to UXP
 
-`up` also supports upgrading a Crossplane installation to a compatible UXP
-version. Compatibility is defined as having matching major, minor, and patch
-versions (in accordance with [semantic versioning]). In addition, UXP must be
-installed in the same namespace where Crossplane is currently installed.
-Crossplane is typically installed in the `crossplane-system` namespace.
+`up` supports upgrading a Crossplane installation to a compatible UXP version.
+Compatibility is defined as having matching major, minor, and patch versions (in
+accordance with [semantic versioning]). In addition, UXP must be installed in
+the same namespace where Crossplane is currently installed. Crossplane is
+typically installed in the `crossplane-system` namespace.
 
 Upgrade Crossplane vX.Y.Z to UXP:
 
@@ -148,44 +135,7 @@ $ up uxp upgrade vX.Y.Z-up.N -n crossplane-system
 > set `UXP_NAMESPACE=<namespace>` to avoid having to supply it for every UXP
 > command.
 
-### Attaching a Self-Hosted Control PLane
-
-Attach a self-hosted control plane in Upbound:
-
-```
-$ up controlplane attach my-self-hosted-cp
-<control-plane-token>
-```
-
-```
-$ up ctp attach my-self-hosted-cp
-<control-plane-token>
-```
-
-Self-hosted control planes can be created with "view only" permissions:
-
-```
-$ up ctp attach my-self-hosted-cp --view-only
-<control-plane-token>
-```
-
-### Connecting UXP to a Self-Hosted Control Plane
-
-Connect UXP to self-hosted control plane:
-
-```
-$ up uxp connect <control-plane-token>
-```
-
-Most users pipe the attach command into the connect one:
-
-```
-$ up controlplane attach my-self-hosted-cp | up uxp connect -
-```
-
-```
-$ up ctp attach my-self-hosted-cp | up uxp connect -
-```
 
 <!-- Named Links -->
+[Upbound Universal Crossplane]: https://github.com/upbound/universal-crossplane
 [semantic versioning]: https://semver.org/

--- a/internal/feature/maturity.go
+++ b/internal/feature/maturity.go
@@ -32,8 +32,9 @@ const (
 
 // HideMaturity hides commands that are not at the specified level of maturity.
 func HideMaturity(p *kong.Path, maturity Maturity) error {
-	children := p.Node().Children
-	for _, c := range children {
+	nodes := p.Node().Children // copy to avoid possibility of reslicing
+	nodes = append(nodes, p.Node())
+	for _, c := range nodes {
 		mt := Maturity(c.Tag.Get(maturityTag))
 		if mt == "" {
 			mt = Stable


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the HideMaturity method to also consider self such that any
nodes that hide their children will also hide themselves if they do not
match the specified maturity level.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Cleans up workflow documentation by removing unsupported functionality.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Updates the commands doc to reflect that state of commands for v0.13.0.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds documentation describing the up command maturity framework and how
commands are migrated to one level of maturity to another.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes https://github.com/upbound/up/issues/237

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Before:

```
🤖 (up) up upbound -h
Usage: up upbound <command>

Interact with Upbound.

Flags:
  -h, --help                          Show context-sensitive help.
  -v, --version                       Print version and exit.
  -q, --quiet                         Suppress all output.
      --pretty                        Pretty print output.

      --kubeconfig=STRING             Override default kubeconfig path.
  -n, --namespace="upbound-system"    Kubernetes namespace for Upbound ($UPBOUND_NAMESPACE).

Commands:
🤖 (up) up alpha upbound -h
Usage: up alpha upbound <command>

Interact with Upbound.

Flags:
  -h, --help                          Show context-sensitive help.
  -v, --version                       Print version and exit.
  -q, --quiet                         Suppress all output.
      --pretty                        Pretty print output.

      --kubeconfig=STRING             Override default kubeconfig path.
  -n, --namespace="upbound-system"    Kubernetes namespace for Upbound ($UPBOUND_NAMESPACE).

Commands:
  alpha upbound install <version>
    Install Upbound.

  alpha upbound mail
    Run a local mail portal.

  alpha upbound uninstall [<name>]
    Uninstall Upbound.

  alpha upbound upgrade <version>
    Upgrade Upbound.
```

After:
```
🤖 (up) up upbound -h
Refusing to emit help for hidden command. See alpha variant.
🤖 (up) up alpha upbound -h
Usage: up alpha upbound <command>

Interact with Upbound.

Flags:
  -h, --help                          Show context-sensitive help.
  -v, --version                       Print version and exit.
  -q, --quiet                         Suppress all output.
      --pretty                        Pretty print output.

      --kubeconfig=STRING             Override default kubeconfig path.
  -n, --namespace="upbound-system"    Kubernetes namespace for Upbound ($UPBOUND_NAMESPACE).

Commands:
  alpha upbound install <version>
    Install Upbound.

  alpha upbound mail
    Run a local mail portal.

  alpha upbound uninstall [<name>]
    Uninstall Upbound.

  alpha upbound upgrade <version>
    Upgrade Upbound.
```