### PR TITLE
Drop `UP_MCP_EXPERIMENTAL` in favor of new control planes API

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -44,7 +44,6 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
-	kongCtx.Bind(upCtx.MCPExperimental)
 	kongCtx.Bind(cp.NewClient(cfg))
 	kongCtx.Bind(op.NewClient(cfg))
 	kongCtx.Bind(accounts.NewClient(cfg))

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -32,22 +32,12 @@ type createCmd struct {
 }
 
 // Run executes the create command.
-func (c *createCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
-	if experimental {
-		if _, err := cc.Create(context.Background(), upCtx.Account, &cp.ControlPlaneCreateParameters{
-			Name:        c.Name,
-			Description: c.Description,
-		}); err != nil {
-			return err
-		}
-	} else {
-		if _, err := oc.Create(context.Background(), &op.ControlPlaneCreateParameters{
-			Account:     upCtx.Account,
-			Name:        c.Name,
-			Description: c.Description,
-		}); err != nil {
-			return err
-		}
+func (c *createCmd) Run(p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
+	if _, err := cc.Create(context.Background(), upCtx.Account, &cp.ControlPlaneCreateParameters{
+		Name:        c.Name,
+		Description: c.Description,
+	}); err != nil {
+		return err
 	}
 
 	p.Printfln("%s created", c.Name)

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -45,15 +45,9 @@ type deleteCmd struct {
 }
 
 // Run executes the delete command.
-func (c *deleteCmd) Run(experimental bool, p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
-	if experimental {
-		if err := cc.Delete(context.Background(), upCtx.Account, c.ID); err != nil {
-			return err
-		}
-	} else {
-		if err := oc.Delete(context.Background(), c.id); err != nil {
-			return err
-		}
+func (c *deleteCmd) Run(p pterm.TextPrinter, cc *cp.Client, oc *op.Client, upCtx *upbound.Context) error {
+	if err := cc.Delete(context.Background(), upCtx.Account, c.ID); err != nil {
+		return err
 	}
 	p.Printfln("%s deleted", c.ID)
 	return nil

--- a/cmd/up/upbound/profiles.go
+++ b/cmd/up/upbound/profiles.go
@@ -29,7 +29,6 @@ var (
 	accountKey            = "UP_ACCOUNT"
 	domainKey             = "UP_DOMAIN"
 	insecureTLSSkipVerify = "UP_INSECURE_SKIP_TLS_VERIFY"
-	mcpExperimentalKey    = "UP_MCP_EXPERIMENTAL"
 )
 
 // getSelfHostedProfile returns the standard profile we set up for selfhosted
@@ -44,7 +43,6 @@ func getSelfHostedProfile(domain string) (string, config.Profile) {
 			accountKey:            account,
 			domainKey:             fmt.Sprintf("https://%s", domain),
 			insecureTLSSkipVerify: "true",
-			mcpExperimentalKey:    "true",
 		},
 	}
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -450,8 +450,6 @@ commands may choose not to utilize the group flags when not relevant.
   specified command. Can be either an organization or a personal account.
 - `--endpoint = URL` (Env: `UP_DOMAIN`) (Default: `https://api.upbound.io`):
   Endpoint to use when communicating with the Upbound API.
-- `--mcp-experimental = BOOL` (Env: `UP_MCP_EXPERIMENTAL`): Use experimental
-  control planes API.
 - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to perform the
   specified command.
 
@@ -500,8 +498,6 @@ will be prompted for their License ID and License Key on installation.
         - `--endpoint = URL` (Env: `UP_DOMAIN`) (Default:
           `https://api.upbound.io`): Endpoint to use when communicating with the
           Upbound API.
-        - `--mcp-experimental = BOOL` (Env: `UP_MCP_EXPERIMENTAL`): Use
-          experimental control planes API.
         - `--profile = STRING` (Env: `UP_PROFILE`); Profile with which to
           perform the specified command.
     - Behavior: Installs Upbound into cluster specified by currently configured

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -56,9 +56,6 @@ type Flags struct {
 	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command."`
 	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
 
-	// Experimental
-	MCPExperimental bool `env:"UP_MCP_EXPERIMENTAL" hidden:"" help:"Use experimental managed control planes API."`
-
 	// Insecure
 	InsecureSkipTLSVerify bool `env:"UP_INSECURE_SKIP_TLS_VERIFY" help:"[INSECURE] Skip verifying TLS certificates."`
 
@@ -77,7 +74,6 @@ type Context struct {
 	Domain      *url.URL
 
 	InsecureSkipTLSVerify bool
-	MCPExperimental       bool
 
 	APIEndpoint      *url.URL
 	ProxyEndpoint    *url.URL
@@ -175,8 +171,6 @@ func NewFromFlags(f Flags, opts ...Option) (*Context, error) { //nolint:gocyclo
 		c.RegistryEndpoint = &u
 	}
 
-	c.MCPExperimental = of.MCPExperimental
-
 	c.Account = of.Account
 	c.Domain = of.Domain
 
@@ -262,7 +256,6 @@ func (f Flags) MarshalJSON() ([]byte, error) {
 		Domain                string `json:"domain,omitempty"`
 		Profile               string `json:"profile,omitempty"`
 		Account               string `json:"account,omitempty"`
-		MCPExperimental       bool   `json:"mcp_experimental,omitempty"`
 		InsecureSkipTLSVerify bool   `json:"insecure_skip_tls_verify,omitempty"`
 		APIEndpoint           string `json:"override_api_endpoint,omitempty"`
 		ProxyEndpoint         string `json:"override_proxy_endpoint,omitempty"`
@@ -271,7 +264,6 @@ func (f Flags) MarshalJSON() ([]byte, error) {
 		Domain:                nullableURL(f.Domain),
 		Profile:               f.Profile,
 		Account:               f.Account,
-		MCPExperimental:       f.MCPExperimental,
 		InsecureSkipTLSVerify: f.InsecureSkipTLSVerify,
 		APIEndpoint:           nullableURL(f.APIEndpoint),
 		ProxyEndpoint:         nullableURL(f.ProxyEndpoint),

--- a/internal/upbound/context_test.go
+++ b/internal/upbound/context_test.go
@@ -54,7 +54,6 @@ var (
 			  "session": "a token",
 			  "base": {
 				"UP_DOMAIN": "https://local.upbound.io",
-				"UP_MCP_EXPERIMENTAL": "true",
 				"UP_ACCOUNT": "my-org",
 				"UP_INSECURE_SKIP_TLS_VERIFY": "true"
 			  }
@@ -65,7 +64,6 @@ var (
 				"session": "a token",
 				"base": {
 				  "UP_DOMAIN": "https://local.upbound.io",
-				  "UP_MCP_EXPERIMENTAL": "true",
 				  "UP_ACCOUNT": "my-org",
 				  "UP_INSECURE_SKIP_TLS_VERIFY": "true"
 				}
@@ -220,7 +218,6 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:           withURL("https://api.local.upbound.io"),
 					Domain:                withURL("https://local.upbound.io"),
 					InsecureSkipTLSVerify: true,
-					MCPExperimental:       true,
 					Profile: config.Profile{
 						ID:      "someone@upbound.io",
 						Type:    config.UserProfileType,
@@ -230,7 +227,6 @@ func TestNewFromFlags(t *testing.T) {
 							"UP_ACCOUNT":                  "my-org",
 							"UP_DOMAIN":                   "https://local.upbound.io",
 							"UP_INSECURE_SKIP_TLS_VERIFY": "true",
-							"UP_MCP_EXPERIMENTAL":         "true",
 						},
 					},
 					ProxyEndpoint:    withURL("https://proxy.local.upbound.io"),
@@ -260,7 +256,6 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:           withURL("http://not.a.url"),
 					Domain:                withURL("http://a.domain.org"),
 					InsecureSkipTLSVerify: true,
-					MCPExperimental:       true,
 					Profile: config.Profile{
 						ID:      "someone@upbound.io",
 						Type:    config.UserProfileType,
@@ -270,7 +265,6 @@ func TestNewFromFlags(t *testing.T) {
 							"UP_ACCOUNT":                  "my-org",
 							"UP_DOMAIN":                   "https://local.upbound.io",
 							"UP_INSECURE_SKIP_TLS_VERIFY": "true",
-							"UP_MCP_EXPERIMENTAL":         "true",
 						},
 					},
 					ProxyEndpoint:    withURL("http://proxy.a.domain.org"),


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Drops all conditional API calls as the previously experimental API is
now the only control plane API.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #255 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->


Verified all modified commands execute correctly against `https://api.upbound.io`.