### PR TITLE
Add support for `up ctp provider install` and `up ctp configuration install`

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -20,6 +20,7 @@ import (
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
+	"github.com/upbound/up/cmd/up/controlplane/pkg"
 	"github.com/upbound/up/cmd/up/controlplane/pullsecret"
 	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/upbound"
@@ -51,6 +52,9 @@ type Cmd struct {
 	Create createCmd `cmd:"" maturity:"alpha" help:"Create a hosted control plane."`
 	Delete deleteCmd `cmd:"" maturity:"alpha" help:"Delete a control plane."`
 	List   listCmd   `cmd:"" maturity:"alpha" help:"List control planes for the account."`
+
+	Configuration pkg.Cmd `cmd:"" set:"package_type=Configuration" help:"Manage Configurations."`
+	Provider      pkg.Cmd `cmd:"" set:"package_type=Provider" help:"Manage Providers."`
 
 	PullSecret pullsecret.Cmd `cmd:"" help:"Manage package pull secrets."`
 

--- a/cmd/up/controlplane/pkg/install.go
+++ b/cmd/up/controlplane/pkg/install.go
@@ -1,0 +1,151 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pterm/pterm"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/upbound/up/internal/kube"
+	"github.com/upbound/up/internal/resources"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+	"github.com/upbound/up/internal/xpkg"
+)
+
+const errUnknownPkgType = "provided package type is unknown"
+
+// Supported package kinds.
+const (
+	ConfigurationKind = "Configuration"
+	ProviderKind      = "Provider"
+)
+
+var (
+	providerGVR = schema.GroupVersionResource{
+		Group:    "pkg.crossplane.io",
+		Version:  "v1",
+		Resource: "providers",
+	}
+
+	configurationGVR = schema.GroupVersionResource{
+		Group:    "pkg.crossplane.io",
+		Version:  "v1",
+		Resource: "configurations",
+	}
+)
+
+// AfterApply constructs and binds Upbound-specific context to any subcommands
+// that have Run() methods that receive it.
+func (c *installCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	switch kongCtx.Selected().Vars()["package_type"] {
+	case ProviderKind:
+		c.gvr = providerGVR
+		c.kind = ProviderKind
+	case ConfigurationKind:
+		c.gvr = configurationGVR
+		c.kind = ConfigurationKind
+	default:
+		return errors.New(errUnknownPkgType)
+	}
+
+	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	client, err := dynamic.NewForConfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	c.r = client.Resource(c.gvr)
+	return nil
+}
+
+// installCmd installs a package.
+type installCmd struct {
+	gvr  schema.GroupVersionResource
+	kind string
+
+	r dynamic.NamespaceableResourceInterface
+
+	Package string `arg:"" help:"Reference to the ${package_type}."`
+
+	// NOTE(hasheddan): kong automatically cleans paths tagged with existingfile.
+	Kubeconfig string        `type:"existingfile" help:"Override default kubeconfig path."`
+	Name       string        `help:"Name of ${package_type}."`
+	Wait       time.Duration `short:"w" help:"Wait duration for successful ${package_type} installation."`
+}
+
+// Run executes the install command.
+func (c *installCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+	ref, err := name.ParseReference(c.Package, name.WithDefaultRegistry(upCtx.RegistryEndpoint.Hostname()))
+	if err != nil {
+		return err
+	}
+	if c.Name == "" {
+		c.Name = xpkg.ToDNSLabel(ref.Context().RepositoryStr())
+	}
+	if _, err := c.r.Create(context.Background(), &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "pkg.crossplane.io/v1",
+		"kind":       c.kind,
+		"metadata": map[string]interface{}{
+			"name": c.Name,
+		},
+		"spec": map[string]interface{}{
+			"package": ref.Name(),
+		},
+	}}, v1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	// Return early if wait duration is not provided.
+	if c.Wait == 0 {
+		p.Printfln("%s installed", c.Name)
+		return nil
+	}
+
+	s, _ := upterm.CheckmarkSuccessSpinner.Start(fmt.Sprintf("%s installed. Waiting to become healthy...", c.Name))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	t := int64(c.Wait.Seconds())
+	errC, err := kube.DynamicWatch(ctx, c.r, &t, func(u *unstructured.Unstructured) (bool, error) {
+		pkg := resources.Package{Unstructured: *u}
+		if pkg.GetInstalled() && pkg.GetHealthy() {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	if err := <-errC; err != nil {
+		return err
+	}
+
+	s.Success(fmt.Sprintf("%s installed and healthy", c.Name))
+	return nil
+}

--- a/cmd/up/controlplane/pkg/pkg.go
+++ b/cmd/up/controlplane/pkg/pkg.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Upbound Inc
+// Copyright 2022 Upbound Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/up/controlplane/pkg/pkg.go
+++ b/cmd/up/controlplane/pkg/pkg.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"github.com/alecthomas/kong"
+
+	"github.com/upbound/up/internal/feature"
+)
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(ctx *kong.Context, p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
+
+// Cmd contains commands for managing packages in a control plane.
+type Cmd struct {
+	Install installCmd `cmd:"" help:"Install a ${package_type}."`
+}

--- a/cmd/up/upbound/connecting.go
+++ b/cmd/up/upbound/connecting.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pterm/pterm"
 
 	"github.com/upbound/up/internal/resources"
+	"github.com/upbound/up/internal/upterm"
 )
 
 const (
@@ -30,7 +31,7 @@ const (
 
 func outputConnectingInfo(ipAddress, hostNames string) {
 	pterm.Println()
-	pterm.Info.WithPrefix(eyesPrefix).Println("Next Steps 👇")
+	pterm.Info.WithPrefix(upterm.EyesPrefix).Println("Next Steps 👇")
 	pterm.Println()
 	pterm.Println("👉 (1): Add the following entry to your /etc/hosts file:")
 	pterm.Println()

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Upbound Inc.
+Copyright 2022 Upbound Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/kube/watch.go
+++ b/internal/kube/watch.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Upbound Inc
+// Copyright 2022 Upbound Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/kube/watch.go
+++ b/internal/kube/watch.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+)
+
+const errClosedResults = "stopped watching before condition met"
+
+// DynamicWatch starts a watch on the given resource type. The done callback is
+// called on every received event until either timeout or context cancellation.
+func DynamicWatch(ctx context.Context, r dynamic.NamespaceableResourceInterface, timeout *int64, done func(u *unstructured.Unstructured) (bool, error)) (chan error, error) {
+	w, err := r.Watch(ctx, v1.ListOptions{
+		TimeoutSeconds: timeout,
+	})
+	if err != nil {
+		return nil, err
+	}
+	errChan := make(chan error)
+	go func() {
+		defer close(errChan)
+		for {
+			select {
+			case e, ok := <-w.ResultChan():
+				// If we are no longer watching return with error.
+				if !ok {
+					errChan <- errors.New(errClosedResults)
+					return
+				}
+
+				u, ok := e.Object.(*unstructured.Unstructured)
+				if !ok {
+					continue
+				}
+
+				// If we error on event callback return early.
+				d, err := done(u)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				// If event callback indicated done, return early with nil
+				// error.
+				if d {
+					errChan <- nil
+					return
+				}
+			// If context is canceled, stop watching and return error.
+			case <-ctx.Done():
+				w.Stop()
+				errChan <- ctx.Err()
+				return
+			}
+		}
+	}()
+	return errChan, nil
+}

--- a/internal/resources/package.go
+++ b/internal/resources/package.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type Package struct {
+	unstructured.Unstructured
+}
+
+// GetInstalled checks whether a package is installed. If installation status
+// cannot be determined, false is always returned.
+func (p *Package) GetInstalled() bool {
+	conditioned := xpv1.ConditionedStatus{}
+	// The path is directly `status` because conditions are inline.
+	if err := fieldpath.Pave(p.Object).GetValueInto("status", &conditioned); err != nil {
+		return false
+	}
+	return resource.IsConditionTrue(conditioned.GetCondition("Installed"))
+}
+
+// GetHealthy checks whether a package is healhty. If health cannot be
+// determined, false is always returned.
+func (p *Package) GetHealthy() bool {
+	conditioned := xpv1.ConditionedStatus{}
+	// The path is directly `status` because conditions are inline.
+	if err := fieldpath.Pave(p.Object).GetValueInto("status", &conditioned); err != nil {
+		return false
+	}
+	return resource.IsConditionTrue(conditioned.GetCondition("Healthy"))
+}

--- a/internal/upterm/styles.go
+++ b/internal/upterm/styles.go
@@ -26,7 +26,17 @@ var (
 		Text:  " 👀",
 	}
 
+	RaisedPrefix = pterm.Prefix{
+		Style: &pterm.Style{pterm.FgLightMagenta},
+		Text:  " 🙌",
+	}
+
 	spinnerStyle = &pterm.Style{pterm.FgDarkGray}
+
+	CheckmarkSuccessSpinner = pterm.DefaultSpinner.WithStyle(spinnerStyle)
+	EyesInfoSpinner         = pterm.DefaultSpinner.WithStyle(spinnerStyle)
+
+	ComponentText = pterm.DefaultBasicText.WithStyle(&pterm.ThemeDefault.TreeTextStyle)
 
 	cp = &pterm.PrefixPrinter{
 		MessageStyle: &pterm.Style{pterm.FgLightWhite},
@@ -35,20 +45,11 @@ var (
 			Text:  " √ ",
 		},
 	}
+
 	ip = &pterm.PrefixPrinter{
 		MessageStyle: &pterm.Style{pterm.FgLightWhite},
 		Prefix:       EyesPrefix,
 	}
-
-	CheckmarkSuccessSpinner = pterm.DefaultSpinner.WithStyle(spinnerStyle)
-	EyesInfoSpinner         = pterm.DefaultSpinner.WithStyle(spinnerStyle)
-
-	RaisedPrefix = pterm.Prefix{
-		Style: &pterm.Style{pterm.FgLightMagenta},
-		Text:  " 🙌",
-	}
-
-	ComponentText = pterm.DefaultBasicText.WithStyle(&pterm.ThemeDefault.TreeTextStyle)
 )
 
 func init() {

--- a/internal/upterm/styles.go
+++ b/internal/upterm/styles.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package upbound
+package upterm
 
 import (
 	"fmt"
@@ -21,14 +21,9 @@ import (
 )
 
 var (
-	eyesPrefix = pterm.Prefix{
+	EyesPrefix = pterm.Prefix{
 		Style: &pterm.Style{pterm.FgLightMagenta},
 		Text:  " 👀",
-	}
-
-	raisedPrefix = pterm.Prefix{
-		Style: &pterm.Style{pterm.FgLightMagenta},
-		Text:  " 🙌",
 	}
 
 	spinnerStyle = &pterm.Style{pterm.FgDarkGray}
@@ -42,21 +37,26 @@ var (
 	}
 	ip = &pterm.PrefixPrinter{
 		MessageStyle: &pterm.Style{pterm.FgLightWhite},
-		Prefix:       eyesPrefix,
+		Prefix:       EyesPrefix,
 	}
 
-	checkmarkSuccessSpinner = pterm.DefaultSpinner.WithStyle(spinnerStyle)
-	eyesInfoSpinner         = pterm.DefaultSpinner.WithStyle(spinnerStyle)
+	CheckmarkSuccessSpinner = pterm.DefaultSpinner.WithStyle(spinnerStyle)
+	EyesInfoSpinner         = pterm.DefaultSpinner.WithStyle(spinnerStyle)
 
-	componentText = pterm.DefaultBasicText.WithStyle(&pterm.ThemeDefault.TreeTextStyle)
+	RaisedPrefix = pterm.Prefix{
+		Style: &pterm.Style{pterm.FgLightMagenta},
+		Text:  " 🙌",
+	}
+
+	ComponentText = pterm.DefaultBasicText.WithStyle(&pterm.ThemeDefault.TreeTextStyle)
 )
 
 func init() {
-	checkmarkSuccessSpinner.SuccessPrinter = cp
-	eyesInfoSpinner.InfoPrinter = ip
+	CheckmarkSuccessSpinner.SuccessPrinter = cp
+	EyesInfoSpinner.InfoPrinter = ip
 }
 
-func wrapWithSuccessSpinner(msg string, spinner *pterm.SpinnerPrinter, f func() error) error {
+func WrapWithSuccessSpinner(msg string, spinner *pterm.SpinnerPrinter, f func() error) error {
 	s, err := spinner.Start(msg)
 	if err != nil {
 		return err
@@ -70,6 +70,6 @@ func wrapWithSuccessSpinner(msg string, spinner *pterm.SpinnerPrinter, f func() 
 	return nil
 }
 
-func stepCounter(msg string, index, total int) string {
+func StepCounter(msg string, index, total int) string {
 	return fmt.Sprintf("[%d/%d]: %s", index, total, msg)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds configuration and provider install commands to the ctp group. The
same struct is used for both commands, but variable interpolation is
used to parameterize based on the subtree from which the command is
invoked.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Fixes #159 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Verified successful install of providers and configurations, as well as updates to functionality in `up upbound` commands.

```
🤖 (up) kind create cluster
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
🤖 (up) up uxp install
UXP 1.9.1-up.1 installed
🤖 (up) up ctp provider -h
Usage: up controlplane (ctp) provider <command>

Manage Providers.

Flags:
  -h, --help                         Show context-sensitive help.
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

Commands:
  controlplane (ctp) provider install    Install a Provider.
🤖 (up) up ctp configuraiton -h
up: error: unexpected argument configuraiton, did you mean "configuration"?
🤖 (up) up ctp configuration -h
Usage: up controlplane (ctp) configuration <command>

Manage Configurations.

Flags:
  -h, --help                         Show context-sensitive help.
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

Commands:
  controlplane (ctp) configuration install    Install a Configuration.
🤖 (up) up ctp provider install -h
Usage: up controlplane (ctp) provider install <package>

Install a Provider.

Arguments:
  <package>    Reference to the Provider.

Flags:
  -h, --help                                             Show context-sensitive help.
  -v, --version                                          Print version and exit.
  -q, --quiet                                            Suppress all output.
      --pretty                                           Pretty print output.

      --domain=https://upbound.io                        Root Upbound domain ($UP_DOMAIN).
      --profile=STRING                                   Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING                                   Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify                         [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

      --kubeconfig=STRING                                Override default kubeconfig path.
      --name=STRING                                      Name of Provider.
      --package-pull-secrets=PACKAGE-PULL-SECRETS,...    List of secrets used to pull Provider.
  -w, --wait=DURATION                                    Wait duration for successful Provider installation.
🤖 (up) up ctp configuration install -h
Usage: up controlplane (ctp) configuration install <package>

Install a Configuration.

Arguments:
  <package>    Reference to the Configuration.

Flags:
  -h, --help                                             Show context-sensitive help.
  -v, --version                                          Print version and exit.
  -q, --quiet                                            Suppress all output.
      --pretty                                           Pretty print output.

      --domain=https://upbound.io                        Root Upbound domain ($UP_DOMAIN).
      --profile=STRING                                   Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING                                   Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify                         [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

      --kubeconfig=STRING                                Override default kubeconfig path.
      --name=STRING                                      Name of Configuration.
      --package-pull-secrets=PACKAGE-PULL-SECRETS,...    List of secrets used to pull Configuration.
  -w, --wait=DURATION                                    Wait duration for successful Configuration installation.
🤖 (up) up ctp provider install upbound/provider-aws:v0.15.0 --package-pull-secrets=pull-sec -w 30s --pretty
  √   upbound-provider-aws installed and healthy                                                                                                                                                               
🤖 (up) k get pkg
NAME                                              INSTALLED   HEALTHY   PACKAGE                                        AGE
provider.pkg.crossplane.io/upbound-provider-aws   True        True      xpkg.upbound.io/upbound/provider-aws:v0.15.0   33s
🤖 (up) up ctp configuration install upbound/platform-ref-aws:v0.2.3
upbound-platform-ref-aws installed
🤖 (up) k get pkg
NAME                                                 INSTALLED   HEALTHY   PACKAGE                                                                 AGE
provider.pkg.crossplane.io/crossplane-provider-aws   True        Unknown   registry.upbound.io/crossplane/provider-aws:v0.32.0-rc.0.47.gd90a07b6   7s
provider.pkg.crossplane.io/upbound-provider-aws      True        True      xpkg.upbound.io/upbound/provider-aws:v0.15.0                            101s

NAME                                                       INSTALLED   HEALTHY   PACKAGE                                           AGE
configuration.pkg.crossplane.io/upbound-platform-ref-aws   True        Unknown   xpkg.upbound.io/upbound/platform-ref-aws:v0.2.3   10s
```