### PR TITLE
Clean up remaining mcp ID references in docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -96,7 +96,7 @@ commands may choose not to utilize the group flags when not relevant.
 Format: `up controlplane pull-secret <cmd> ...` Alias: `up ctp pull-secret
 <cmd>...`
 
-- `create <control-plane-ID>`
+- `create <control-plane-name>`
     - Flags:
         - `-f,--file = FILE`: Path to token credentials file. Credentials from
           profile are used if not specified.
@@ -436,7 +436,7 @@ control planes.
     - Flags:
         - `--description = STRING`: Control plane description.
     - Behavior: Creates a hosted control plane in Upbound.
-- `delete <id>`
+- `delete <name>`
     - Behavior: Deletes a control plane in Upbound.
 - `list`
     - Behavior: Lists all control planes for the configured account.
@@ -458,7 +458,7 @@ commands may choose not to utilize the group flags when not relevant.
 Format: `up alpha controlplane kubeconfig <cmd> ...` Alias: `up ctp kubeconfig
 <cmd>...`
 
-- `get <control-plane-ID>`
+- `get <control-plane-name>`
     - Flags:
         - `--token = STRING` (*Required*): API token for authenticating to
           control plane. If `-` is given the value will be read from stdin.


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

MCPs are now addressed by name, so the ID references are removed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

n/a