### PR TITLE
Fail build if sha256sum is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,14 @@ GOLANGCILINT_VERSION = 1.47.3
 -include build/makelib/golang.mk
 
 # ====================================================================================
+# Setup binaries
+ifneq ($(shell type sha256sum 2>/dev/null),)
+SHA256SUM := sha256sum
+else
+$(error Please install sha256sum)
+endif
+
+# ====================================================================================
 # Targets
 
 # run `make help` to see the targets and options
@@ -67,9 +75,9 @@ build.artifacts.platform: build.artifacts.bundle.platform
 endif
 
 build.artifacts.bundle.platform:
-	@sha256sum $(GO_OUT_DIR)/up$(GO_OUT_EXT) | head -c 64 >  $(GO_OUT_DIR)/up.sha256
+	@$(SHA256SUM) $(GO_OUT_DIR)/up$(GO_OUT_EXT) | head -c 64 >  $(GO_OUT_DIR)/up.sha256
 	@tar -czvf $(abspath $(OUTPUT_DIR)/bundle/up/$(PLATFORM)).tar.gz -C $(GO_BIN_DIR) $(PLATFORM)/up$(GO_OUT_EXT) $(PLATFORM)/up.sha256
-	@sha256sum $(GO_OUT_DIR)/docker-credential-up$(GO_OUT_EXT) | head -c 64 >  $(GO_OUT_DIR)/docker-credential-up.sha256
+	@$(SHA256SUM) $(GO_OUT_DIR)/docker-credential-up$(GO_OUT_EXT) | head -c 64 >  $(GO_OUT_DIR)/docker-credential-up.sha256
 	@tar -czvf $(abspath $(OUTPUT_DIR)/bundle/docker-credential-up/$(PLATFORM)).tar.gz -C $(GO_BIN_DIR) $(PLATFORM)/docker-credential-up$(GO_OUT_EXT) $(PLATFORM)/docker-credential-up.sha256
 
 build.artifacts.pkg.platform:


### PR DESCRIPTION
### Description of your changes

This change will cause 'make' to fail if sha256sum is not installed.

Previously if sha256sum was not installed, make would print an error that was easily lost in the output, and the files containing the SHA sums were not created.

This does an upfront check for sha256sum and fails the build if it can't be found. 

I discovered this because sah256sum is not installed on Mac OS by default. 

Note: I could have included image.mk or imagelight.mk to define the binary. I didn't do that because I didn't want to pull all the other irrelevant definitions in those files. Also, this avoided modifying the build submodule and accidentally affecting other builds.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
I ran 'make' multiple times, with and without sha256sum installed.
