### PR TITLE
Add ctp get command, to show a single control plane.

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -52,6 +52,7 @@ type Cmd struct {
 	Create createCmd `cmd:"" maturity:"alpha" help:"Create a hosted control plane."`
 	Delete deleteCmd `cmd:"" maturity:"alpha" help:"Delete a control plane."`
 	List   listCmd   `cmd:"" maturity:"alpha" help:"List control planes for the account."`
+	Get    getCmd    `cmd:"" maturity:"alpha" help:"Get a single control plane."`
 
 	Configuration pkg.Cmd `cmd:"" set:"package_type=Configuration" help:"Manage Configurations."`
 	Provider      pkg.Cmd `cmd:"" set:"package_type=Provider" help:"Manage Providers."`

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -31,7 +31,7 @@ func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error
 	return nil
 }
 
-// listCmd list control planes in an account on Upbound.
+// getCmd gets a single control plane in an account on Upbound.
 type getCmd struct {
 	Name string `arg:"" required:"" help:"Name of control plane."`
 }
@@ -45,8 +45,7 @@ func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, cc *cp.Client,
 
 	// We convert to a list so we can match the output of the list command
 	cpList := cp.ControlPlaneListResponse{
-		ControlPlanes: make([]cp.ControlPlaneResponse, 1),
+		ControlPlanes: []cp.ControlPlaneResponse{*ctp},
 	}
-	cpList.ControlPlanes[0] = *ctp
-	return PrintControlPlanes(&cpList, pt)
+	return printControlPlanes(&cpList, pt)
 }

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -1,0 +1,52 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+
+	cp "github.com/upbound/up-sdk-go/service/controlplanes"
+
+	"github.com/upbound/up/internal/upbound"
+)
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+	return nil
+}
+
+// listCmd list control planes in an account on Upbound.
+type getCmd struct {
+	Name string `arg:"" required:"" help:"Name of control plane."`
+}
+
+// Run executes the get command.
+func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, cc *cp.Client, upCtx *upbound.Context) error {
+	ctp, err := cc.Get(context.Background(), upCtx.Account, c.Name)
+	if err != nil {
+		return err
+	}
+
+	// We convert to a list so we can match the output of the list command
+	cpList := cp.ControlPlaneListResponse{
+		ControlPlanes: make([]cp.ControlPlaneResponse, 1),
+	}
+	cpList.ControlPlanes[0] = *ctp
+	return PrintControlPlanes(&cpList, pt)
+}

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -52,6 +52,11 @@ func (c *listCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, cc *cp.Client
 		p.Printfln("No control planes found in %s", upCtx.Account)
 		return nil
 	}
+	return PrintControlPlanes(cpList, pt)
+}
+
+// Prints a list of control planes. This is also used by the get command
+func PrintControlPlanes(cpList *cp.ControlPlaneListResponse, pt *pterm.TablePrinter) error {
 	data := make([][]string, len(cpList.ControlPlanes)+1)
 	data[0] = []string{"NAME", "ID", "STATUS"}
 	for i, cp := range cpList.ControlPlanes {

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -52,11 +52,11 @@ func (c *listCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, cc *cp.Client
 		p.Printfln("No control planes found in %s", upCtx.Account)
 		return nil
 	}
-	return PrintControlPlanes(cpList, pt)
+	return printControlPlanes(cpList, pt)
 }
 
 // Prints a list of control planes. This is also used by the get command
-func PrintControlPlanes(cpList *cp.ControlPlaneListResponse, pt *pterm.TablePrinter) error {
+func printControlPlanes(cpList *cp.ControlPlaneListResponse, pt *pterm.TablePrinter) error {
 	data := make([][]string, len(cpList.ControlPlanes)+1)
 	data[0] = []string{"NAME", "ID", "STATUS"}
 	for i, cp := range cpList.ControlPlanes {


### PR DESCRIPTION
### Description

This adds a new command: "ctp get", which shows details of a single control plane. It shows the details as a table with a single row, similar to kubectl. 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Tested manually. I didn't see tests for most commands, so I followed suit. 

Sample output:
```
up alpha ctp get demo-ucp-idp
NAME           ID                                     STATUS
demo-ucp-idp   ffa9da67-8439-4b7d-a466-e1fb635f6ebe   ready 
```

### Future Work
- Add 'get' for other types (e.g. organizations, robots...)
- Add the ability to output in JSON or YAML, to see more details
