### PR TITLE
Ignore whitespace when parsing examples

### DIFF
--- a/internal/xpkg/parser/examples/parser.go
+++ b/internal/xpkg/parser/examples/parser.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"unicode"
 
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -64,6 +65,9 @@ func (p *Parser) Parse(ctx context.Context, reader io.ReadCloser) (*Examples, er
 		if len(bytes) == 0 {
 			continue
 		}
+		if isWhiteSpace(bytes) {
+			continue
+		}
 		var obj unstructured.Unstructured
 		if err := k8syaml.Unmarshal(bytes, &obj); err != nil {
 			return ex, err
@@ -71,4 +75,17 @@ func (p *Parser) Parse(ctx context.Context, reader io.ReadCloser) (*Examples, er
 		ex.objects = append(ex.objects, obj)
 	}
 	return ex, nil
+}
+
+// isWhiteSpace determines whether the passed in bytes are all unicode white
+// space.
+func isWhiteSpace(bytes []byte) bool {
+	empty := true
+	for _, b := range bytes {
+		if !unicode.IsSpace(rune(b)) {
+			empty = false
+			break
+		}
+	}
+	return empty
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates examples parser to ignore whitespace. If a YAML document is provided that contains only whitespace then it is skipped, but does not cause an error. This is in alignment with the API types parser.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Testing in progress.. will be updated shortly.