### PR TITLE
Add formatted ouput for more get & list commands

### DIFF
--- a/cmd/up/organization/get.go
+++ b/cmd/up/organization/get.go
@@ -24,6 +24,7 @@ import (
 	"github.com/upbound/up-sdk-go/service/organizations"
 
 	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
 )
 
 // AfterApply sets default values in command after assignment and validation.
@@ -38,7 +39,7 @@ type getCmd struct {
 }
 
 // Run executes the get command.
-func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+func (c *getCmd) Run(printer upterm.ObjectPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
 
 	// The get command accepts a name, but the get API call takes an ID
 	// Therefore we get all orgs and find the one the user requested
@@ -48,9 +49,7 @@ func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, oc *organizati
 	}
 	for _, o := range orgs {
 		if o.Name == c.Name {
-			// We convert to a list so we can match the output of the list command
-			orgs := []organizations.Organization{o}
-			return printOrganizations(orgs, pt)
+			return printer.Print(o, fieldNames, extractFields)
 		}
 	}
 	return errors.Errorf("no organization named %s", c.Name)

--- a/cmd/up/repository/get.go
+++ b/cmd/up/repository/get.go
@@ -23,6 +23,7 @@ import (
 	repos "github.com/upbound/up-sdk-go/service/repositories"
 
 	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
 )
 
 // AfterApply sets default values in command after assignment and validation.
@@ -37,7 +38,7 @@ type getCmd struct {
 }
 
 // Run executes the get command.
-func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, rc *repos.Client, upCtx *upbound.Context) error {
+func (c *getCmd) Run(printer upterm.ObjectPrinter, rc *repos.Client, upCtx *upbound.Context) error {
 	repo, err := rc.Get(context.Background(), upCtx.Account, c.Name)
 	if err != nil {
 		return err
@@ -47,5 +48,5 @@ func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, rc *repos.Clie
 	repoList := repos.RepositoryListResponse{
 		Repositories: []repos.Repository{repo.Repository},
 	}
-	return printRepos(&repoList, pt)
+	return printer.Print(repoList.Repositories, fieldNames, extractFields)
 }

--- a/cmd/up/robot/get.go
+++ b/cmd/up/robot/get.go
@@ -25,6 +25,7 @@ import (
 	"github.com/upbound/up-sdk-go/service/organizations"
 
 	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
 )
 
 // AfterApply sets default values in command after assignment and validation.
@@ -39,7 +40,7 @@ type getCmd struct {
 }
 
 // Run executes the get robot command.
-func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, ac *accounts.Client, oc *organizations.Client, upCtx *upbound.Context) error {
+func (c *getCmd) Run(printer upterm.ObjectPrinter, ac *accounts.Client, oc *organizations.Client, upCtx *upbound.Context) error {
 	a, err := ac.Get(context.Background(), upCtx.Account)
 	if err != nil {
 		return err
@@ -60,9 +61,7 @@ func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, ac *accounts.C
 
 	for _, r := range rs {
 		if r.Name == c.Name {
-			// We convert to a list so we can match the output of the list command
-			rList := []organizations.Robot{r}
-			return printRobots(rList, pt)
+			return printer.Print(r, fieldNames, extractFields)
 		}
 	}
 	return errors.New("no robot named \"" + c.Name + "\"")

--- a/cmd/up/robot/token/get.go
+++ b/cmd/up/robot/token/get.go
@@ -30,6 +30,7 @@ import (
 	"github.com/upbound/up-sdk-go/service/tokens"
 
 	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
 )
 
 // AfterApply sets default values in command after assignment and validation.
@@ -45,7 +46,7 @@ type getCmd struct {
 }
 
 // Run executes the get robot token command.
-func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
+func (c *getCmd) Run(printer upterm.ObjectPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
 	a, err := ac.Get(context.Background(), upCtx.Account)
 	if err != nil {
 		return err
@@ -100,6 +101,5 @@ func (c *getCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, ac *accounts.C
 	if theToken == nil {
 		return errors.Errorf(errFindTokenFmt, c.TokenName, c.RobotName, upCtx.Account)
 	}
-	tList := []common.DataSet{*theToken}
-	return printTokens(tList, pt)
+	return printer.Print(*theToken, fieldNames, extractFields)
 }


### PR DESCRIPTION
### Description
For the org, repo, robot, and robot commands, add support for formatted (json/yaml) output for the get and list commands.

Examples:

```
up org list --format json
[
    {
        "id": 1,
        "name": "upbound",
        "displayName": "Upbound Inc",
        "creatorId": 0,
        "role": "owner",
        "reservedEnvironments": 5
    },
    {
        "id": 829,
        "name": "upbound-dev",
        "displayName": "Upbound Dev",
        "creatorId": 0,
        "role": "owner",
        "reservedEnvironments": 0
    }
]
```

```
up org get upbound --format json
{
    "id": 1,
    "name": "upbound",
    "displayName": "Upbound Inc",
    "creatorId": 0,
    "role": "owner",
    "reservedEnvironments": 5
}
```

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

This code has been manually tested.