### PR TITLE
Add Organization user management

### DIFF
--- a/cmd/up/organization/organization.go
+++ b/cmd/up/organization/organization.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/upbound/up-sdk-go/service/organizations"
 
+	"github.com/upbound/up/cmd/up/organization/user"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -80,6 +81,8 @@ type Cmd struct {
 	Delete deleteCmd `cmd:"" help:"Delete an organization."`
 	List   listCmd   `cmd:"" help:"List organizations."`
 	Get    getCmd    `cmd:"" help:"Get an organization."`
+
+	User user.Cmd `cmd:"" help:"Manage organization users."`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/organization/user/deleteinvite.go
+++ b/cmd/up/organization/user/deleteinvite.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"context"
+
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up-sdk-go/service/organizations"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// deleteInviteCmd deletes an invitation to a user to join an organization.
+type deleteInviteCmd struct {
+	OrgID    uint `arg:"" required:"" help:"ID of the organization."`
+	InviteID uint `arg:"" required:"" help:"ID of the invitation to delete."`
+}
+
+// Run executes the invite command.
+func (c *deleteInviteCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+	if err := oc.DeleteInvite(context.Background(), c.OrgID, c.InviteID); err != nil {
+		return err
+	}
+
+	p.Printfln("Invitation %d deleted", c.InviteID)
+	return nil
+}

--- a/cmd/up/organization/user/invite.go
+++ b/cmd/up/organization/user/invite.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"context"
+
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up-sdk-go/service/organizations"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// inviteCmd sends out an invitation to a user to join an organization.
+type inviteCmd struct {
+	OrgID      uint   `arg:"" required:"" help:"ID of the organization."`
+	Email      string `arg:"" required:"" help:"Email address of the user to invite."`
+	Permission string `short:"p" default:"member" help:"Role of the user to invite (owner or member)."`
+}
+
+// Run executes the invite command.
+func (c *inviteCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+	if err := oc.CreateInvite(context.Background(), c.OrgID, &organizations.OrganizationInviteCreateParameters{
+		Email:      c.Email,
+		Permission: organizations.OrganizationPermissionGroup(c.Permission),
+	}); err != nil {
+		return err
+	}
+
+	p.Printfln("%s invited", c.Email)
+	return nil
+}

--- a/cmd/up/organization/user/invite.go
+++ b/cmd/up/organization/user/invite.go
@@ -26,16 +26,16 @@ import (
 
 // inviteCmd sends out an invitation to a user to join an organization.
 type inviteCmd struct {
-	OrgID      uint   `arg:"" required:"" help:"ID of the organization."`
-	Email      string `arg:"" required:"" help:"Email address of the user to invite."`
-	Permission string `short:"p" default:"member" help:"Role of the user to invite (owner or member)."`
+	OrgID      uint                                      `arg:"" required:"" help:"ID of the organization."`
+	Email      string                                    `arg:"" required:"" help:"Email address of the user to invite."`
+	Permission organizations.OrganizationPermissionGroup `short:"p" default:"member" help:"Role of the user to invite (owner or member)."`
 }
 
 // Run executes the invite command.
 func (c *inviteCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
 	if err := oc.CreateInvite(context.Background(), c.OrgID, &organizations.OrganizationInviteCreateParameters{
 		Email:      c.Email,
-		Permission: organizations.OrganizationPermissionGroup(c.Permission),
+		Permission: c.Permission,
 	}); err != nil {
 		return err
 	}

--- a/cmd/up/organization/user/invite.go
+++ b/cmd/up/organization/user/invite.go
@@ -28,7 +28,7 @@ import (
 type inviteCmd struct {
 	OrgID      uint                                      `arg:"" required:"" help:"ID of the organization."`
 	Email      string                                    `arg:"" required:"" help:"Email address of the user to invite."`
-	Permission organizations.OrganizationPermissionGroup `short:"p" default:"member" help:"Role of the user to invite (owner or member)."`
+	Permission organizations.OrganizationPermissionGroup `short:"p" enum:"member,owner" default:"member" help:"Role of the user to invite (owner or member)."`
 }
 
 // Run executes the invite command.

--- a/cmd/up/organization/user/removemember.go
+++ b/cmd/up/organization/user/removemember.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"context"
+
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up-sdk-go/service/organizations"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// removeMemberCmd removes a user from an organization.
+type removeMemberCmd struct {
+	OrgID  uint `arg:"" required:"" help:"ID of the organization."`
+	UserID uint `arg:"" required:"" help:"ID of the user to remove."`
+}
+
+// Run executes the invite command.
+func (c *removeMemberCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+	if err := oc.RemoveMember(context.Background(), c.OrgID, c.UserID); err != nil {
+		return err
+	}
+
+	p.Printfln("User %d removed", c.UserID)
+	return nil
+}

--- a/cmd/up/organization/user/removemember.go
+++ b/cmd/up/organization/user/removemember.go
@@ -16,18 +16,49 @@ package user
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pterm/pterm"
 
 	"github.com/upbound/up-sdk-go/service/organizations"
+	"github.com/upbound/up/internal/input"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
 
 // removeMemberCmd removes a user from an organization.
 type removeMemberCmd struct {
+	prompter input.Prompter
+
 	OrgID  uint `arg:"" required:"" help:"ID of the organization."`
 	UserID uint `arg:"" required:"" help:"ID of the user to remove."`
+
+	Force bool `help:"Force removal of the member." default:"false"`
+}
+
+// BeforeApply sets default values for the delete command, before assignment and validation.
+func (c *removeMemberCmd) BeforeApply() error {
+	c.prompter = input.NewPrompter()
+	return nil
+}
+
+// AfterApply accepts user input by default to confirm the delete operation.
+func (c *removeMemberCmd) AfterApply(p pterm.TextPrinter) error {
+	if c.Force {
+		return nil
+	}
+
+	confirm, err := c.prompter.Prompt("Are you sure you want to remove this member? [y/n]", false)
+	if err != nil {
+		return err
+	}
+
+	if input.InputYes(confirm) {
+		p.Printfln("Removing member %s. This cannot be undone.", c.UserID)
+		return nil
+	}
+
+	return fmt.Errorf("operation canceled")
 }
 
 // Run executes the invite command.

--- a/cmd/up/organization/user/user.go
+++ b/cmd/up/organization/user/user.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"github.com/alecthomas/kong"
+
+	"github.com/upbound/up-sdk-go/service/organizations"
+	"github.com/upbound/up/internal/upbound"
+)
+
+// AfterApply constructs and binds a robots client to any subcommands
+// that have Run() methods that receive it.
+func (c *Cmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	cfg, err := upCtx.BuildSDKConfig(upCtx.Profile.Session)
+	if err != nil {
+		return err
+	}
+	kongCtx.Bind(organizations.NewClient(cfg))
+	return nil
+}
+
+// Cmd contains commands for managing organization users.
+type Cmd struct {
+	Invite       inviteCmd       `cmd:"" help:"Invite a user to the organization."`
+	DeleteInvite deleteInviteCmd `cmd:"" help:"Delete an invitation to the organization."`
+	ListInvites  listInvitesCmd  `cmd:"" help:"List user invites of an organization."`
+	ListMembers  listMembersCmd  `cmd:"" help:"List members of an organization."`
+	RemoveMember removeMemberCmd `cmd:"" help:"Remove a member from the organization."`
+}

--- a/cmd/up/organization/user/user.go
+++ b/cmd/up/organization/user/user.go
@@ -24,7 +24,7 @@ import (
 // AfterApply constructs and binds a robots client to any subcommands
 // that have Run() methods that receive it.
 func (c *Cmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-	cfg, err := upCtx.BuildSDKConfig(upCtx.Profile.Session)
+	cfg, err := upCtx.BuildSDKConfig()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes https://github.com/upbound/up/issues/285

Adds the following commands:
```
Usage: up organization (org) user <command>

Manage organization users.

Flags:
  -h, --help                         Show context-sensitive help.
      --format="default"             Format for get/list commands. Can be: json, yaml, default
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

Commands:
  organization (org) user invite           Invite a user to the organization.
  organization (org) user delete-invite    Delete an invitation to the organization.
  organization (org) user list-invites     List user invites of an organization.
  organization (org) user list-members     List members of an organization.
  organization (org) user remove-member    Remove a member from the organization.
```
