### PR TITLE
Add completion predictors for control planes, profiles, repos, and ro…

### DIFF
--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -25,7 +25,7 @@ import (
 
 // deleteCmd deletes a control plane on Upbound.
 type deleteCmd struct {
-	Name string `arg:"" help:"Name of control plane."`
+	Name string `arg:"" help:"Name of control plane." predictor:"ctps"`
 }
 
 // Run executes the delete command.

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -34,7 +34,7 @@ func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error
 
 // getCmd gets a single control plane in an account on Upbound.
 type getCmd struct {
-	Name string `arg:"" required:"" help:"Name of control plane."`
+	Name string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
 }
 
 // Run executes the get command.

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -148,7 +148,12 @@ func main() {
 
 	kongplete.Complete(parser,
 		kongplete.WithPredictor("orgs", organization.PredictOrgs()),
+		kongplete.WithPredictor("ctps", controlplane.PredictControlPlanes()),
+		kongplete.WithPredictor("repos", repository.PredictRepos()),
+		kongplete.WithPredictor("robots", robot.PredictRobots()),
+		kongplete.WithPredictor("profiles", profile.PredictProfiles()),
 	)
+
 	ctx, err := parser.Parse(os.Args[1:])
 	parser.FatalIfErrorf(err)
 	ctx.FatalIfErrorf(ctx.Run())

--- a/cmd/up/organization/delete.go
+++ b/cmd/up/organization/delete.go
@@ -54,7 +54,7 @@ func (c *deleteCmd) AfterApply(p pterm.TextPrinter) error {
 type deleteCmd struct {
 	prompter input.Prompter
 
-	Name string `arg:"" required:"" help:"Name of organization."`
+	Name string `arg:"" required:"" help:"Name of organization." predictor:"orgs"`
 
 	Force bool `help:"Force deletion of the organization." default:"false"`
 }

--- a/cmd/up/organization/organization.go
+++ b/cmd/up/organization/organization.go
@@ -43,7 +43,11 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 func PredictOrgs() complete.Predictor {
 	return complete.PredictFunc(func(a complete.Args) (prediction []string) {
-		cfg, err := upbound.BuildSDKConfigForCompletors()
+		upCtx, err := upbound.NewFromFlags(upbound.Flags{})
+		if err != nil {
+			return nil
+		}
+		cfg, err := upCtx.BuildSDKConfig(upCtx.Profile.Session)
 		if err != nil {
 			return nil
 		}
@@ -73,7 +77,7 @@ func PredictOrgs() complete.Predictor {
 // Cmd contains commands for interacting with organizations.
 type Cmd struct {
 	Create createCmd `cmd:"" help:"Create an organization."`
-	Delete deleteCmd `cmd:"" help:"Delete an organization." predictor:"orgs"`
+	Delete deleteCmd `cmd:"" help:"Delete an organization."`
 	List   listCmd   `cmd:"" help:"List organizations."`
 	Get    getCmd    `cmd:"" help:"Get an organization."`
 

--- a/cmd/up/profile/profile.go
+++ b/cmd/up/profile/profile.go
@@ -16,6 +16,7 @@ package profile
 
 import (
 	"github.com/alecthomas/kong"
+	"github.com/posener/complete"
 
 	"github.com/upbound/up/cmd/up/profile/config"
 	"github.com/upbound/up/internal/upbound"
@@ -42,4 +43,25 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 
 	kongCtx.Bind(upCtx)
 	return nil
+}
+
+func PredictProfiles() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) (prediction []string) {
+		upCtx, err := upbound.NewFromFlags(upbound.Flags{})
+		if err != nil {
+			return nil
+		}
+
+		profiles, err := upCtx.Cfg.GetUpboundProfiles()
+		if err != nil {
+			return nil
+		}
+
+		data := make([]string, 0)
+
+		for name := range profiles {
+			data = append(data, name)
+		}
+		return data
+	})
 }

--- a/cmd/up/profile/use.go
+++ b/cmd/up/profile/use.go
@@ -25,7 +25,7 @@ const (
 )
 
 type useCmd struct {
-	Name string `arg:"" required:"" help:"Name of the Profile to use."`
+	Name string `arg:"" required:"" help:"Name of the Profile to use." predictor:"profiles"`
 }
 
 // Run executes the Use command.

--- a/cmd/up/repository/delete.go
+++ b/cmd/up/repository/delete.go
@@ -55,7 +55,7 @@ func (c *deleteCmd) AfterApply(p pterm.TextPrinter, upCtx *upbound.Context) erro
 type deleteCmd struct {
 	prompter input.Prompter
 
-	Name string `arg:"" required:"" help:"Name of repository."`
+	Name string `arg:"" required:"" help:"Name of repository." predictor:"repos"`
 
 	Force bool `help:"Force deletion of repository." default:"false"`
 }

--- a/cmd/up/repository/get.go
+++ b/cmd/up/repository/get.go
@@ -34,7 +34,7 @@ func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error
 
 // getCmd gets a single repo.
 type getCmd struct {
-	Name string `arg:"" required:"" help:"Name of repo."`
+	Name string `arg:"" required:"" help:"Name of repo." predictor:"repos"`
 }
 
 // Run executes the get command.

--- a/cmd/up/robot/delete.go
+++ b/cmd/up/robot/delete.go
@@ -64,7 +64,7 @@ func (c *deleteCmd) AfterApply(p pterm.TextPrinter, upCtx *upbound.Context) erro
 type deleteCmd struct {
 	prompter input.Prompter
 
-	Name string `arg:"" required:"" help:"Name of robot."`
+	Name string `arg:"" required:"" help:"Name of robot." predictor:"robots"`
 
 	Force bool `help:"Force delete robot even if conflicts exist." default:"false"`
 }

--- a/cmd/up/robot/get.go
+++ b/cmd/up/robot/get.go
@@ -36,7 +36,7 @@ func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error
 
 // getCmd gets a single robot in an account on Upbound.
 type getCmd struct {
-	Name string `arg:"" required:"" help:"Name of robot."`
+	Name string `arg:"" required:"" help:"Name of robot." predictor:"robots"`
 }
 
 // Run executes the get robot command.

--- a/cmd/up/robot/token/list.go
+++ b/cmd/up/robot/token/list.go
@@ -44,7 +44,7 @@ func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) erro
 
 // listCmd creates a robot on Upbound.
 type listCmd struct {
-	RobotName string `arg:"" required:"" help:"Name of robot."`
+	RobotName string `arg:"" required:"" help:"Name of robot." predictor:"robots"`
 }
 
 // Run executes the list robot tokens command.

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -57,7 +57,7 @@ const (
 type Flags struct {
 	// Optional
 	Domain  *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain."`
-	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command."`
+	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command." predictor:"profiles"`
 	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
 
 	// Insecure
@@ -217,24 +217,6 @@ func (c *Context) BuildSDKConfig(session string) (*up.Config, error) {
 	return up.NewConfig(func(conf *up.Config) {
 		conf.Client = client
 	}), nil
-}
-
-// BuildSDKConfigForCompletors reduces boilerplate
-// code for writing completers.  Note that at completion time,
-// the command-line has not been parsed, so we cannot use any flags
-// the user has specified.
-// TODO: Check the environment for variables like UP_DOMAIN
-func BuildSDKConfigForCompletors() (*up.Config, error) {
-	f := Flags{}
-	upCtx, err := NewFromFlags(f)
-	if err != nil {
-		return nil, err
-	}
-	cfg, err := upCtx.BuildSDKConfig(upCtx.Profile.Session)
-	if err != nil {
-		return nil, err
-	}
-	return cfg, nil
 }
 
 // applyOverrides applies applicable overrides to the given Flags based on the


### PR DESCRIPTION
### Description
* Add completion predictors for control planes, profiles, repos, and robots.
* Remove BuildSDKConfigForCompletors() because it wasn't actually helpful. 

Fixes #54 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manual testing
