### PR TITLE
Add completion predictor for configurations

### DIFF
--- a/cmd/up/configuration/get.go
+++ b/cmd/up/configuration/get.go
@@ -26,7 +26,7 @@ import (
 
 // getCmd gets a single root configuration in an account on Upbound.
 type getCmd struct {
-	Name string `arg:"" required:"" name:"The name of the configuration."`
+	Name string `arg:"" required:"" name:"The name of the configuration." predictor:"configs"`
 }
 
 // Run executes the get command.

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -154,6 +154,7 @@ func main() {
 		kongplete.WithPredictor("repos", repository.PredictRepos()),
 		kongplete.WithPredictor("robots", robot.PredictRobots()),
 		kongplete.WithPredictor("profiles", profile.PredictProfiles()),
+		kongplete.WithPredictor("configs", configuration.PredictConfigurations()),
 	)
 
 	ctx, err := parser.Parse(os.Args[1:])


### PR DESCRIPTION
### Description of your changes

Add a completion predictor (which support tab complete) for configuration

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manual testing
