### PR TITLE
Move "controlplane" commands to stable maturity level

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -86,20 +86,20 @@ func PredictControlPlanes() complete.Predictor {
 
 // Cmd contains commands for interacting with control planes.
 type Cmd struct {
-	Create createCmd `cmd:"" maturity:"alpha" help:"Create a managed control plane."`
-	Delete deleteCmd `cmd:"" maturity:"alpha" help:"Delete a control plane."`
-	List   listCmd   `cmd:"" maturity:"alpha" help:"List control planes for the account."`
-	Get    getCmd    `cmd:"" maturity:"alpha" help:"Get a single control plane."`
+	Create createCmd `cmd:"" help:"Create a managed control plane."`
+	Delete deleteCmd `cmd:"" help:"Delete a control plane."`
+	List   listCmd   `cmd:"" help:"List control planes for the account."`
+	Get    getCmd    `cmd:"" help:"Get a single control plane."`
 
-	Connect connectCmd `cmd:"" maturity:"alpha" help:"Connect an App Cluster to a managed control plane."`
-	Bind    bindCmd    `cmd:"" maturity:"alpha" help:"Bind APIs to a managed pontrol plane."`
+	Connect connectCmd `cmd:"" help:"Connect an App Cluster to a managed control plane."`
+	Bind    bindCmd    `cmd:"" help:"Bind APIs to a managed pontrol plane."`
 
 	Configuration pkg.Cmd `cmd:"" set:"package_type=Configuration" help:"Manage Configurations."`
 	Provider      pkg.Cmd `cmd:"" set:"package_type=Provider" help:"Manage Providers."`
 
 	PullSecret pullsecret.Cmd `cmd:"" help:"Manage package pull secrets."`
 
-	Kubeconfig kubeconfig.Cmd `cmd:"" maturity:"alpha" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
+	Kubeconfig kubeconfig.Cmd `cmd:"" name:"kubeconfig" help:"Manage control plane kubeconfig data."`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -31,7 +31,7 @@ const (
 	maxItems = 100
 )
 
-var fieldNames = []string{"NAME", "ID", "STATUS"}
+var fieldNames = []string{"NAME", "ID", "STATUS", "DEPLOYED CONFIGURATION", "CONFIGURATION STATUS"}
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
@@ -60,5 +60,5 @@ func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.
 
 func extractFields(obj any) []string {
 	c := obj.(cp.ControlPlaneResponse)
-	return []string{c.ControlPlane.Name, c.ControlPlane.ID.String(), string(c.Status)}
+	return []string{c.ControlPlane.Name, c.ControlPlane.ID.String(), string(c.Status), *c.ControlPlane.Configuration.Name, string(c.ControlPlane.Configuration.Status)}
 }

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -123,7 +123,9 @@ func (a *alpha) BeforeReset(ctx *kong.Context) error { //nolint:unparam
 }
 
 type alpha struct {
-	ControlPlane controlplane.Cmd `cmd:"" maturity:"alpha" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
+	// For now, we maintain compatibility for systems that may still use the alpha variant.
+	// This nudges users towards the stable variant when they attempt to emit help.
+	ControlPlane controlplane.Cmd `cmd:"" hidden:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes."`
 	Upbound      upbound.Cmd      `cmd:"" maturity:"alpha" help:"Interact with Upbound."`
 	XPKG         xpkg.Cmd         `cmd:"" maturity:"alpha" help:"Interact with UXP packages."`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

The alpha variant will now be hidden to maintain compatibility with systems (e.g. CI) that may use it.

`ctp list` and `ctp get` will now also emit basic information about the Configuration that is deployed to them.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Help on `alpha`:
```
➜  bin ./up alpha -h
Usage: up alpha <command>

Alpha features. Commands may be removed in future releases.

Flags:
  -h, --help                Show context-sensitive help.
      --format="default"    Format for get/list commands. Can be: json, yaml, default
  -v, --version             Print version and exit.
  -q, --quiet               Suppress all output.
      --pretty              Pretty print output.

Commands:
  alpha upbound    Interact with Upbound.
  alpha xpkg       Interact with UXP packages.
  ```
  
  Help on `alpha ctp`:
  ```
  ➜  bin ./up alpha ctp -h
Refusing to emit help for hidden command. See stable variant.
```

Help on stable variant of `ctp create`:
```
➜  bin ./up ctp create -h
Usage: up controlplane (ctp) create --configuration-name=STRING <name>

Create a managed control plane.

Arguments:
  <name>    Name of control plane.

Flags:
  -h, --help                         Show context-sensitive help.
      --format="default"             Format for get/list commands. Can be: json, yaml, default
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

      --configuration-name=STRING    The name of the Configuration.
  -d, --description=STRING           Description for control plane.
  ```

`alpha ctp list`:
```
➜  bin ./up alpha ctp list
NAME       ID                                     STATUS   DEPLOYED CONFIGURATION   CONFIGURATION STATUS
sdk-test   8b9865f9-xxxx-4202-b17b-4e1ac8b3cfa4   ready    eks-api                  ready               
cli-two    4d093850-xxxx-4646-bdd7-d20b04f83676   ready    eks-api                  ready     
```