### PR TITLE
Updated user and invite commands for org to be consistent with other commands

### DIFF
--- a/cmd/up/organization/invite/create.go
+++ b/cmd/up/organization/invite/create.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package user
+package invite
 
 import (
 	"context"
@@ -24,15 +24,15 @@ import (
 	"github.com/upbound/up/internal/upterm"
 )
 
-// inviteCmd sends out an invitation to a user to join an organization.
-type inviteCmd struct {
+// createCmd sends out an invitation to a user to join an organization.
+type createCmd struct {
 	OrgName    string                                    `arg:"" required:"" help:"Name of the organization."`
 	Email      string                                    `arg:"" required:"" help:"Email address of the user to invite."`
 	Permission organizations.OrganizationPermissionGroup `short:"p" enum:"member,owner" default:"member" help:"Role of the user to invite (owner or member)."`
 }
 
 // Run executes the invite command.
-func (c *inviteCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+func (c *createCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
 	orgID, err := oc.GetOrgID(context.Background(), c.OrgName)
 	if err != nil {
 		return err

--- a/cmd/up/organization/invite/delete.go
+++ b/cmd/up/organization/invite/delete.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package user
+package invite
 
 import (
 	"context"
@@ -26,8 +26,8 @@ import (
 	"github.com/upbound/up/internal/upterm"
 )
 
-// deleteInviteCmd deletes an invitation to a user to join an organization.
-type deleteInviteCmd struct {
+// deleteCmd deletes an invitation to a user to join an organization.
+type deleteCmd struct {
 	prompter input.Prompter
 
 	OrgName     string `arg:"" required:"" help:"Name of the organization."`
@@ -37,13 +37,13 @@ type deleteInviteCmd struct {
 }
 
 // BeforeApply sets default values for the delete command, before assignment and validation.
-func (c *deleteInviteCmd) BeforeApply() error {
+func (c *deleteCmd) BeforeApply() error {
 	c.prompter = input.NewPrompter()
 	return nil
 }
 
 // AfterApply accepts user input by default to confirm the delete operation.
-func (c *deleteInviteCmd) AfterApply(p pterm.TextPrinter) error {
+func (c *deleteCmd) AfterApply(p pterm.TextPrinter) error {
 	if c.Force {
 		return nil
 	}
@@ -61,8 +61,8 @@ func (c *deleteInviteCmd) AfterApply(p pterm.TextPrinter) error {
 	return fmt.Errorf("operation canceled")
 }
 
-// Run executes the invite command.
-func (c *deleteInviteCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+// Run executes the create command.
+func (c *deleteCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
 	orgID, err := oc.GetOrgID(context.Background(), c.OrgName)
 	if err != nil {
 		return err

--- a/cmd/up/organization/invite/invite.go
+++ b/cmd/up/organization/invite/invite.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Upbound Inc
+// Copyright 2023 Upbound Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package user
+package invite
 
 import (
 	"github.com/alecthomas/kong"
@@ -34,6 +34,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 
 // Cmd contains commands for managing organization users.
 type Cmd struct {
-	List   listCmd   `cmd:"" help:"List members of an organization."`
-	Remove removeCmd `cmd:"" help:"Remove a member from the organization."`
+	Create createCmd `cmd:"" help:"Invite a user to the organization."`
+	Delete deleteCmd `cmd:"" help:"Delete an invitation to the organization."`
+	List   listCmd   `cmd:"" help:"List user invites to an organization."`
 }

--- a/cmd/up/organization/invite/list.go
+++ b/cmd/up/organization/invite/list.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package user
+package invite
 
 import (
 	"context"
@@ -29,18 +29,18 @@ import (
 var listInvitesFieldNames = []string{"ID", "EMAIL", "PERMISSION"}
 
 // AfterApply sets default values in command after assignment and validation.
-func (c *listInvitesCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
 	return nil
 }
 
-// listInvitesCmd lists invites in an organization.
-type listInvitesCmd struct {
+// listCmd lists invites in an organization.
+type listCmd struct {
 	OrgName string `arg:"" required:"" help:"Name of the organization."`
 }
 
 // Run executes the list command.
-func (c *listInvitesCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
 	orgID, err := oc.GetOrgID(context.Background(), c.OrgName)
 	if err != nil {
 		return err

--- a/cmd/up/organization/organization.go
+++ b/cmd/up/organization/organization.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/upbound/up-sdk-go/service/organizations"
 
+	"github.com/upbound/up/cmd/up/organization/invite"
 	"github.com/upbound/up/cmd/up/organization/user"
 	"github.com/upbound/up/internal/upbound"
 )
@@ -82,7 +83,8 @@ type Cmd struct {
 	List   listCmd   `cmd:"" help:"List organizations."`
 	Get    getCmd    `cmd:"" help:"Get an organization."`
 
-	User user.Cmd `cmd:"" help:"Manage organization users."`
+	User   user.Cmd   `cmd:"" help:"Manage organization users."`
+	Invite invite.Cmd `cmd:"" help:"Manage invites to organizations"`
 
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`

--- a/cmd/up/organization/user/list.go
+++ b/cmd/up/organization/user/list.go
@@ -29,18 +29,18 @@ import (
 var listMembersFieldNames = []string{"ID", "NAME", "PERMISSION"}
 
 // AfterApply sets default values in command after assignment and validation.
-func (c *listMembersCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
 	return nil
 }
 
-// listMembersCmd lists users in an organization.
-type listMembersCmd struct {
+// listCmd lists users in an organization.
+type listCmd struct {
 	OrgName string `arg:"" required:"" help:"Name of the organization."`
 }
 
 // Run executes the list command.
-func (c *listMembersCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
 	id, err := oc.GetOrgID(context.Background(), c.OrgName)
 	if err != nil {
 		return err

--- a/cmd/up/organization/user/remove.go
+++ b/cmd/up/organization/user/remove.go
@@ -26,10 +26,10 @@ import (
 	"github.com/upbound/up/internal/upterm"
 )
 
-// removeMemberCmd removes a user from an organization.
+// removeCmd removes a user from an organization.
 // Ideally it would take the username or email. Today that information
 // isn't available via the API, so the user ID is required.
-type removeMemberCmd struct {
+type removeCmd struct {
 	prompter input.Prompter
 
 	OrgName string `arg:"" required:"" help:"Name of the organization."`
@@ -39,13 +39,13 @@ type removeMemberCmd struct {
 }
 
 // BeforeApply sets default values for the delete command, before assignment and validation.
-func (c *removeMemberCmd) BeforeApply() error {
+func (c *removeCmd) BeforeApply() error {
 	c.prompter = input.NewPrompter()
 	return nil
 }
 
 // AfterApply accepts user input by default to confirm the delete operation.
-func (c *removeMemberCmd) AfterApply(p pterm.TextPrinter) error {
+func (c *removeCmd) AfterApply(p pterm.TextPrinter) error {
 	if c.Force {
 		return nil
 	}
@@ -64,7 +64,7 @@ func (c *removeMemberCmd) AfterApply(p pterm.TextPrinter) error {
 }
 
 // Run executes the remove-member command.
-func (c *removeMemberCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+func (c *removeCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
 	orgID, err := oc.GetOrgID(context.Background(), c.OrgName)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description
This PR reorganizes the user and invite commands to match the style of other commands.

For the user commands, we have changed the following:
```
up org user list-members
up org user remove-member
```
to:
```
up org user list
up org user remove
```

For the invite commands, we have changed the following:
```
up org user invite
up org user list-invites
up org user delete-invite
``` 
to:
```
up org invite create
up org invite list
up org invite delete
```

The implementation is unchanged--the only changes are to move around the commands. 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manual testing.