### PR TITLE
Querying control planes with no associated configurations

### DIFF
--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -60,5 +60,15 @@ func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.
 
 func extractFields(obj any) []string {
 	c := obj.(cp.ControlPlaneResponse)
-	return []string{c.ControlPlane.Name, c.ControlPlane.ID.String(), string(c.Status), *c.ControlPlane.Configuration.Name, string(c.ControlPlane.Configuration.Status)}
+	var cfgName string
+	var cfgStatus string
+	// All Upbound managed control planes in an account should be associated to a configuration.
+	// However, we should still list all control planes and indicate where this isn't the case.
+	if c.ControlPlane.Configuration.Name != nil && c.ControlPlane.Configuration != EmptyControlPlaneConfiguration() {
+		cfgName = *c.ControlPlane.Configuration.Name
+		cfgStatus = string(c.ControlPlane.Configuration.Status)
+	} else {
+		cfgName, cfgStatus = "n/a", "n/a"
+	}
+	return []string{c.ControlPlane.Name, c.ControlPlane.ID.String(), string(c.Status), cfgName, cfgStatus}
 }


### PR DESCRIPTION



<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
While all managed control planes on Upbound should have an associated configuration, we should not panic when there isn't one. This defines the behaviour for `ctp list` and `ctp get` in this scenario.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Manually created a control plane with no configuration associated.

New behaviour for list and get:
```
➜  bin ./up ctp list
NAME        ID                                     STATUS   DEPLOYED CONFIGURATION   CONFIGURATION STATUS
no-config   cec11904-b93e-427d-9cee-9344715a0fef   ready    n/a                      n/a                 
➜  bin ./up ctp get no-config
up: error: no configuration associated to this control plane
```
