### PR TITLE
combine xpkg auth ext anno during build

### DIFF
--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -59,9 +59,11 @@ func (c *buildCmd) AfterApply() error {
 	if ax, err := filepath.Abs(c.AuthExt); err == nil {
 		if axf, err := c.fs.Open(ax); err == nil {
 			defer func() { _ = axf.Close() }()
-			if b, err := io.ReadAll(axf); err == nil {
-				authBE = parser.NewEchoBackend(string(b))
+			b, err := io.ReadAll(axf)
+			if err != nil {
+				return err
 			}
+			authBE = parser.NewEchoBackend(string(b))
 		}
 	}
 

--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -56,13 +56,10 @@ func (c *buildCmd) AfterApply() error {
 	}
 
 	var authBE parser.Backend
-	ax, err := filepath.Abs(c.AuthExt)
-	if err == nil {
-		axf, err := c.fs.Open(ax)
-		if err == nil {
+	if ax, err := filepath.Abs(c.AuthExt); err == nil {
+		if axf, err := c.fs.Open(ax); err == nil {
 			defer func() { _ = axf.Close() }()
-			b, err := io.ReadAll(axf)
-			if err == nil {
+			if b, err := io.ReadAll(axf); err == nil {
 				authBE = parser.NewEchoBackend(string(b))
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/willabides/kongplete v0.3.0
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.9.0
 	k8s.io/api v0.24.3
@@ -217,7 +218,6 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiserver v0.24.3 // indirect
 	k8s.io/cli-runtime v0.24.3 // indirect
 	k8s.io/component-base v0.24.3 // indirect

--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -23,28 +23,41 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
+	v1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
+	"gopkg.in/yaml.v2"
+
+	crd "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 
 	"github.com/upbound/up/internal/xpkg/parser/examples"
 	"github.com/upbound/up/internal/xpkg/parser/linter"
+	"github.com/upbound/up/internal/xpkg/scheme"
 )
 
 const (
-	errParserPackage = "failed to parse package"
-	errParserExample = "failed to parse examples"
-	errLintPackage   = "failed to lint package"
-	errInitBackend   = "failed to initialize package parsing backend"
-	errTarFromStream = "failed to build tarball from stream"
-	errLayerFromTar  = "failed to convert tarball to image layer"
-	errDigestInvalid = "failed to get digest from image layer"
-	errBuildImage    = "failed to build image from layers"
-	errConfigFile    = "failed to get config file from image"
-	errMutateConfig  = "failed to mutate config for image"
+	errParserPackage     = "failed to parse package"
+	errParserExample     = "failed to parse examples"
+	errLintPackage       = "failed to lint package"
+	errInitBackend       = "failed to initialize package parsing backend"
+	errTarFromStream     = "failed to build tarball from stream"
+	errLayerFromTar      = "failed to convert tarball to image layer"
+	errDigestInvalid     = "failed to get digest from image layer"
+	errBuildImage        = "failed to build image from layers"
+	errConfigFile        = "failed to get config file from image"
+	errMutateConfig      = "failed to mutate config for image"
+	errBuildMetaScheme   = "failed to build meta scheme for package parser"
+	errBuildObjectScheme = "failed to build object scheme for package parser"
+	errParseAuth         = "an auth extension was supplied but could not be parsed"
+
+	authMetaAnno   = "auth.upbound.io/group"
+	authObjectAnno = "auth.upbound.io/config"
 )
 
 // annotatedTeeReadCloser is a copy of io.TeeReader that implements
@@ -90,15 +103,17 @@ func (t *teeReader) Annotate() any {
 type Builder struct {
 	pb parser.Backend
 	eb parser.Backend
+	ab parser.Backend
 
 	pp parser.Parser
 	ep *examples.Parser
 }
 
 // New returns a new Builder.
-func New(pkg, ex parser.Backend, pp parser.Parser, ep *examples.Parser) *Builder {
+func New(pkg, ab, ex parser.Backend, pp parser.Parser, ep *examples.Parser) *Builder {
 	return &Builder{
 		pb: pkg,
+		ab: ab,
 		eb: ex,
 		pp: pp,
 		ep: ep,
@@ -118,6 +133,20 @@ func WithController(img v1.Image) BuildOpt {
 	return func(o *buildOpts) {
 		o.base = img
 	}
+}
+
+type AuthExtension struct {
+	Version      string `json:"version"`
+	Discriminant string `json:"discriminant"`
+	Sources      []struct {
+		Name                string `json:"name"`
+		Docs                string `json:"docs"`
+		AdditionalResources []struct {
+			Type string `json:"type"`
+			Ref  string `json:"ref"`
+		} `json:"additionalResources,omitempty"`
+		ShowFields []string `json:"showFields,omitempty"`
+	} `json:"sources"`
 }
 
 // Build compiles a Crossplane package from an on-disk package.
@@ -149,9 +178,7 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 		examplesExist = false
 	}
 
-	// Copy stream once to parse and once write to tarball.
-	pkgBuf := new(bytes.Buffer)
-	pkg, err := b.pp.Parse(ctx, annotatedTeeReadCloser(pkgReader, pkgBuf))
+	pkg, err := b.pp.Parse(ctx, pkgReader)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, errParserPackage)
 	}
@@ -167,6 +194,38 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 	if meta.GetObjectKind().GroupVersionKind().Kind == pkgmetav1.ConfigurationKind {
 		linter = NewConfigurationLinter()
 	} else {
+		if b.ab != nil { // if we have an auth.yaml file
+			if p, ok := meta.(*v1alpha1.Provider); ok {
+				// if has annotation auth.upbound.io/group then look for the object
+				// specified there like aws.upbound.io and annotate that with auth.upbound.io/config
+				// and embed the contents of the auth.yaml file
+				if group, ok := p.ObjectMeta.Annotations[authMetaAnno]; ok {
+					ar, err := b.ab.Init(ctx)
+					if err == nil {
+						// validate the auth.yaml file
+						var auth AuthExtension
+						if err = yaml.NewDecoder(ar).Decode(&auth); err != nil {
+							return nil, nil, errors.Wrap(err, errParseAuth)
+						}
+						if err == nil {
+							for x, o := range pkg.GetObjects() {
+								if c, ok := o.(*crd.CustomResourceDefinition); ok {
+									if c.Spec.Group == group {
+										ab := new(bytes.Buffer)
+										if err = yaml.NewEncoder(ab).Encode(auth); err != nil {
+											return nil, nil, errors.Wrap(err, errParseAuth)
+										}
+										c.Annotations[authObjectAnno] = ab.String()
+										pkg.GetObjects()[x] = c
+									}
+								}
+							}
+						}
+					}
+
+				}
+			}
+		}
 		linter = NewProviderLinter()
 	}
 	if err := linter.Lint(pkg); err != nil {
@@ -182,7 +241,12 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 	cfg := cfgFile.Config
 	cfg.Labels = make(map[string]string)
 
-	pkgLayer, err := Layer(pkgBuf, StreamFile, PackageAnnotation, int64(pkgBuf.Len()), &cfg)
+	pkgBytes, err := Encode(pkg)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, errConfigFile)
+	}
+
+	pkgLayer, err := Layer(pkgBytes, StreamFile, PackageAnnotation, int64(pkgBytes.Len()), &cfg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -215,6 +279,35 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 	}
 
 	return bOpts.base, meta, nil
+}
+
+// Encode encodes a package as a YAML stream.  Does not check meta existence
+// or quantity i.e. it should be linted first to ensure that it is valid.
+func Encode(pkg linter.Package) (*bytes.Buffer, error) {
+	pkgBuf := new(bytes.Buffer)
+	metaScheme, err := scheme.BuildMetaScheme()
+	if err != nil {
+		return nil, errors.New(errBuildMetaScheme)
+	}
+	objScheme, err := scheme.BuildObjectScheme()
+	if err != nil {
+		return nil, errors.New(errBuildObjectScheme)
+	}
+
+	dm := json.NewSerializerWithOptions(json.DefaultMetaFactory, metaScheme, metaScheme, json.SerializerOptions{Yaml: true})
+	do := json.NewSerializerWithOptions(json.DefaultMetaFactory, objScheme, objScheme, json.SerializerOptions{Yaml: true})
+	pkgBuf.WriteString("---\n")
+	if err = dm.Encode(pkg.GetMeta()[0], pkgBuf); err != nil {
+		return nil, errors.Wrap(err, errBuildMetaScheme)
+	}
+	pkgBuf.WriteString("---\n")
+	for _, o := range pkg.GetObjects() {
+		if err = do.Encode(o, pkgBuf); err != nil {
+			return nil, errors.Wrap(err, errBuildObjectScheme)
+		}
+		pkgBuf.WriteString("---\n")
+	}
+	return pkgBuf, nil
 }
 
 // SkipContains supplies a FilterFn that skips paths that contain the give pattern.

--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -136,17 +136,17 @@ func WithController(img v1.Image) BuildOpt {
 }
 
 type AuthExtension struct {
-	Version      string `json:"version"`
-	Discriminant string `json:"discriminant"`
+	Version      string `yaml:"version"`
+	Discriminant string `yaml:"discriminant"`
 	Sources      []struct {
-		Name                string `json:"name"`
-		Docs                string `json:"docs"`
+		Name                string `yaml:"name"`
+		Docs                string `yaml:"docs"`
 		AdditionalResources []struct {
-			Type string `json:"type"`
-			Ref  string `json:"ref"`
-		} `json:"additionalResources,omitempty"`
-		ShowFields []string `json:"showFields,omitempty"`
-	} `json:"sources"`
+			Type string `yaml:"type"`
+			Ref  string `yaml:"ref"`
+		} `yaml:"additionalResources"`
+		ShowFields []string `yaml:"showFields"`
+	} `yaml:"sources"`
 }
 
 // Build compiles a Crossplane package from an on-disk package.

--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -205,7 +205,7 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 
 					// validate the auth.yaml file
 					var auth AuthExtension
-					if err = yaml.NewDecoder(ar).Decode(&auth); err != nil {
+					if err := yaml.NewDecoder(ar).Decode(&auth); err != nil {
 						return nil, nil, errors.Wrap(err, errParseAuth)
 					}
 					annotated := false
@@ -213,12 +213,13 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 						if c, ok := o.(*crd.CustomResourceDefinition); ok {
 							if c.Spec.Group == group && c.Spec.Names.Kind == ProviderConfigKind {
 								ab := new(bytes.Buffer)
-								if err = yaml.NewEncoder(ab).Encode(auth); err != nil {
+								if err := yaml.NewEncoder(ab).Encode(auth); err != nil {
 									return nil, nil, errors.Wrap(err, errParseAuth)
 								}
 								c.Annotations[authObjectAnno] = ab.String()
 								pkg.GetObjects()[x] = c
 								annotated = true
+								break
 							}
 						}
 					}
@@ -243,7 +244,7 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 	cfg := cfgFile.Config
 	cfg.Labels = make(map[string]string)
 
-	pkgBytes, err := Encode(pkg)
+	pkgBytes, err := encode(pkg)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, errConfigFile)
 	}
@@ -283,9 +284,9 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 	return bOpts.base, meta, nil
 }
 
-// Encode encodes a package as a YAML stream.  Does not check meta existence
+// encode encodes a package as a YAML stream.  Does not check meta existence
 // or quantity i.e. it should be linted first to ensure that it is valid.
-func Encode(pkg linter.Package) (*bytes.Buffer, error) {
+func encode(pkg linter.Package) (*bytes.Buffer, error) {
 	pkgBuf := new(bytes.Buffer)
 	objScheme, err := scheme.BuildObjectScheme()
 	if err != nil {

--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -56,8 +56,9 @@ const (
 	errBuildObjectScheme = "failed to build object scheme for package parser"
 	errParseAuth         = "an auth extension was supplied but could not be parsed"
 
-	authMetaAnno   = "auth.upbound.io/group"
-	authObjectAnno = "auth.upbound.io/config"
+	authMetaAnno       = "auth.upbound.io/group"
+	authObjectAnno     = "auth.upbound.io/config"
+	ProviderConfigKind = "ProviderConfig"
 )
 
 // annotatedTeeReadCloser is a copy of io.TeeReader that implements
@@ -210,7 +211,7 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 						if err == nil {
 							for x, o := range pkg.GetObjects() {
 								if c, ok := o.(*crd.CustomResourceDefinition); ok {
-									if c.Spec.Group == group {
+									if c.Spec.Group == group && c.Spec.Names.Kind == ProviderConfigKind {
 										ab := new(bytes.Buffer)
 										if err = yaml.NewEncoder(ab).Encode(auth); err != nil {
 											return nil, nil, errors.Wrap(err, errParseAuth)

--- a/internal/xpkg/build_test.go
+++ b/internal/xpkg/build_test.go
@@ -121,7 +121,7 @@ func TestBuild(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			builder := New(tc.args.be, tc.args.ex, tc.args.p, tc.args.e)
+			builder := New(tc.args.be, nil, tc.args.ex, tc.args.p, tc.args.e)
 
 			_, _, err := builder.Build(context.TODO())
 
@@ -251,7 +251,7 @@ func TestBuildExamples(t *testing.T) {
 				parser.FsFilters(defaultFilters...),
 			)
 
-			builder := New(pkgBe, pkgEx, pkgp, examples.New())
+			builder := New(pkgBe, nil, pkgEx, pkgp, examples.New())
 
 			img, _, err := builder.Build(context.TODO())
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Provides options for defining an external auth config extension location and loads that file (defaults to `auth.yaml`).  If the file exists after parsing the crossplane.yaml file it looks for the auth extension meta annotation and gets the group.  Then iterates the crd's and annotates that object with the object annotation providing the auth config file in that crd.  Lints as normal and then re-serializes the package for output in the image.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #[520](https://github.com/upbound/shimmer/issues/520)

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
run `up xpkg build` with `auth.yaml`
```
version: '2023-01-30'
discriminant: spec.credentials.source
sources:
- name: None
  docs: |
    # None
    Ya don't need anything here!
- name: Secret
  docs: |
    # Secret
    You're going to need some static credentials.
  additionalResources:
  - type: Secret
    ref: spec.credentials.secretRef
  showFields:
  - spec.credentials.secretRef
- name: IRSA
  docs: |
    # IRSA
    If you're not running on EKS, don't even bother.
- name: WebIdentity
  docs: |
    # Web Identity
    Now we are getting fancy.
- name: Upbound
  docs: |
    # Upbound
    This is the stuff ya gotta pay for.
```
next to the `crossplane.yaml`
```
---
apiVersion: meta.pkg.crossplane.io/v1alpha1
kind: Provider
metadata:
  name: provider-aws
  annotations:
    meta.crossplane.io/maintainer: Upbound <support@upbound.io>
    meta.crossplane.io/source: github.com/upbound/provider-aws
    meta.crossplane.io/description: |
      Upbound's official Crossplane provider to manage Amazon Web Services (AWS)
      resources in Kubernetes.
    meta.crossplane.io/readme: |
      Provider AWS is a Crossplane provider for [Amazon Web Services
      (AWS)](https://aws.amazon.com/) developed and supported by Upbound.
      If you encounter an issue please reach out on our support@upbound.io
      email address.
    auth.upbound.io/group: aws.upbound.io
spec:
  controller:
    image: crossplane/provider-aws-controller:v0.20.0
---
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: v0.8.0
  creationTimestamp: null
  name: providerconfigs.aws.upbound.io
spec:
  group: aws.upbound.io
  names:
    categories:
    - crossplane
    - providerconfig
    - aws
    kind: ProviderConfig
    listKind: ProviderConfigList
    plural: providerconfigs
    singular: providerconfig
```
and found that it annotated the output `package.yaml` in the provider-aws.xpkg output layer.
```
---
apiVersion: meta.pkg.crossplane.io/v1alpha1
kind: Provider
metadata:
  annotations:
    auth.upbound.io/group: aws.upbound.io
    meta.crossplane.io/description: |
      Upbound's official Crossplane provider to manage Amazon Web Services (AWS)
      resources in Kubernetes.
    meta.crossplane.io/maintainer: Upbound <support@upbound.io>
    meta.crossplane.io/readme: |
      Provider AWS is a Crossplane provider for [Amazon Web Services
      (AWS)](https://aws.amazon.com/) developed and supported by Upbound.
      If you encounter an issue please reach out on our support@upbound.io
      email address.
    meta.crossplane.io/source: github.com/upbound/provider-aws
  creationTimestamp: null
  name: provider-aws
spec:
  controller:
    image: crossplane/provider-aws-controller:v0.20.0
---
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  annotations:
    auth.upbound.io/config: |
      version: "2023-01-30"
      discriminant: spec.credentials.source
      sources:
      - name: None
        docs: |
          # None
          Ya don't need anything here!
        additionalResources: []
        showFields: []
      - name: Secret
        docs: |
          # Secret
          You're going to need some static credentials.
        additionalResources:
        - type: Secret
          ref: spec.credentials.secretRef
        showFields:
        - spec.credentials.secretRef
      - name: IRSA
        docs: |
          # IRSA
          If you're not running on EKS, don't even bother.
        additionalResources: []
        showFields: []
      - name: WebIdentity
        docs: |
          # Web Identity
          Now we are getting fancy.
        additionalResources: []
        showFields: []
      - name: Upbound
        docs: |-
          # Upbound
          This is the stuff ya gotta pay for.
        additionalResources: []
        showFields: []
    controller-gen.kubebuilder.io/version: v0.8.0
  creationTimestamp: null
  name: providerconfigs.aws.upbound.io
spec:
  group: aws.upbound.io
  names:
    categories:
    - crossplane
    - providerconfig
    - aws
    kind: ProviderConfig
    listKind: ProviderConfigList
    plural: providerconfigs
    singular: providerconfig
  scope: ""
  versions: null
status:
  acceptedNames:
    kind: ""
    plural: ""
  conditions: null
  storedVersions: null
---
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
