### PR TITLE
Ignore direnv's .envrc file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cover.out
 # ignore vscode files (debug config etc...)
 /.vscode
 /.idea
+
+# ignore direnv files
+.envrc


### PR DESCRIPTION
### Description of your changes
Ignore direnv's .envrc file. I like to use it to set my PATH to have the version of up that I've built be first in the PATH. 

Fixes #

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).

### How has this code been tested
I used "git status" to verify that the .envrc file is ignored.