### PR TITLE
connect: always create user token if not provided - no creation of robots

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -98,15 +98,15 @@ control planes.
 - `connect <control plane name> <namespace in the control plane>`
     - Flags:
         - `--token = STRING`: Optional token for the connector to use. If not
-          provided, a new one will be generated.
+          provided, a new user token will be created.
         - `--cluster-name = STRING`: Optional name for the cluster that will be
           connected to the control plane. If not provided, namespace argument will
           be used.
         - `--kubeconfig = STRING`: sets `kubeconfig` path. Same defaults as
           `kubectl` are used if not provided.
     - Behavior: Connects the current cluster to the specified control plane's
-      namespace. This means that all claim requests in the cluster will be proxied
-      to the given namespace in the control plane.
+      namespace. This means that all claim APIs in your control plane will be
+      available in your cluster for consumption.
 
 **Group Flags**
 


### PR DESCRIPTION
### Description of your changes

Robots don't have any permissions when created and they need to be member of a team with the right permissions on a control plane for their token to work for MCP Connector. And currently, this is challenging to require from user since assigning control plane permissions to a team is disabled in the UI. Doing that as part of `up ctp connect` would be almost overreaching, i.e. create team, create robot, assign robot to a team, assign permission to the team, create token. Also, it'd have to create a team for every cluster, which is not an ideal default. On the other hand, user tokens have permission for all control planes the user has access, hence we're using that even if the user points to an org with `--account` flag.

Ideally, we'd like a robot to be created for each cluster but that will have to wait for a `default` team created automatically for every organization. In that case, we can just assume that team for the robot if a team name is not given. Granting permission to that team could be an optional flag.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manually.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
