### PR TITLE
Move up ctp kubeconfig get to stable

### DIFF
--- a/cmd/up/controlplane/kubeconfig/kubeconfig.go
+++ b/cmd/up/controlplane/kubeconfig/kubeconfig.go
@@ -27,5 +27,5 @@ func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
 
 // Cmd contains commands for managing control plane kubeconfig data.
 type Cmd struct {
-	Get getCmd `cmd:"" maturity:"alpha" help:"Get a kubeconfig for a control plane."`
+	Get getCmd `cmd:"" help:"Get a kubeconfig for a control plane."`
 }


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Updates the kubeconfig command for control planes to stable.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
$ go run ./cmd/up/ ctp kubeconfig get -h
Usage: up controlplane (ctp) kubeconfig get --token=STRING <control-plane-name>

Get a kubeconfig for a control plane.

Arguments:
  <control-plane-name>    Name of control plane.

Flags:
  -h, --help                         Show context-sensitive help.
      --format="default"             Format for get/list commands. Can be: json, yaml, default
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).

  -f, --file=STRING                  File to merge kubeconfig.
      --token=STRING                 API token used to authenticate.
```
