### PR TITLE
go.mod: update to crossplane v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ For users who wish to use other OCI clients for pushing packages,
 protocol] and can be used as an authentication mechanism for pushing packages by
 adding it your Docker config file.
 
+## Minimum Supported Versions
+
+**github.com/crossplane/crossplane**: `v1.6.0`
+
+Notably, this version does not support the `v1beta1` API versions of `CompositeResourceDefinition` and `Composition` from `apiextensions.crossplane.io`. Please update to use the `v1` equivalent if necessary.
+
 ## Install
 
 Both `up` and `docker-credential-up` can be downloaded by using the official

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -146,7 +146,7 @@ func (c *loginCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { // n
 	if err != nil {
 		return errors.Wrap(err, errLoginFailed)
 	}
-	defer res.Body.Close() // nolint:errcheck
+	defer res.Body.Close() // nolint:gosec,errcheck
 	session, err := extractSession(res, upbound.CookieName)
 	if err != nil {
 		return errors.Wrap(err, errLoginFailed)

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.18
 require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.6.1
-	github.com/crossplane/crossplane v1.5.0
-	github.com/crossplane/crossplane-runtime v0.15.1-0.20210930095326-d5661210733b
+	github.com/crossplane/crossplane v1.6.0
+	github.com/crossplane/crossplane-runtime v0.15.1-0.20211029211307-c72bcdd922eb
 	github.com/crossplane/crossplane/controller/apiextensions v0.0.0-00010101000000-000000000000
 	github.com/crossplane/crossplane/xcrd v0.0.0-00010101000000-000000000000
 	github.com/docker/docker-credential-helpers v0.6.4

--- a/go.sum
+++ b/go.sum
@@ -293,11 +293,10 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane v1.5.0 h1:Aqc8p8uKHvs74VDpqXPtAcrYtJnqhlNJgVeD7AOOWhk=
-github.com/crossplane/crossplane v1.5.0/go.mod h1:ITp98dUSyXQmcHWV+ZtKpnnhbVldgZcQBCa2sEZFU1s=
-github.com/crossplane/crossplane-runtime v0.15.1-0.20210913015452-6a7a44ac50aa/go.mod h1:gKix9Gq5kRzVe/4XOpwlFgG7OurzrYayviJxWZakhw0=
-github.com/crossplane/crossplane-runtime v0.15.1-0.20210930095326-d5661210733b h1:uT3DYSHFvWPilEMNSeR2rcuzPPVf56O0D+NJmnQFXbw=
-github.com/crossplane/crossplane-runtime v0.15.1-0.20210930095326-d5661210733b/go.mod h1:gKix9Gq5kRzVe/4XOpwlFgG7OurzrYayviJxWZakhw0=
+github.com/crossplane/crossplane v1.6.0 h1:F/n3nAGTQY5qktDLUZHhisioFMU4tecsXHXPi1wuVOE=
+github.com/crossplane/crossplane v1.6.0/go.mod h1:V6pjaZ9xRnS6XFesjeBUMs00qqqNN6TnBmHeH1O8sLQ=
+github.com/crossplane/crossplane-runtime v0.15.1-0.20211029211307-c72bcdd922eb h1:l5M88pddkMA4c4UY4isVvfTt9ThzMMasguP9NDerQoM=
+github.com/crossplane/crossplane-runtime v0.15.1-0.20211029211307-c72bcdd922eb/go.mod h1:gKix9Gq5kRzVe/4XOpwlFgG7OurzrYayviJxWZakhw0=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/daixiang0/gci v0.2.9/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=

--- a/internal/auth/registry.go
+++ b/internal/auth/registry.go
@@ -133,7 +133,7 @@ func (u *UpboundRegistry) GetToken(ctx context.Context) (*Response, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, errAuthFailed)
 	}
-	defer res.Body.Close() // nolint:errcheck
+	defer res.Body.Close() // nolint:gosec,errcheck
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/internal/install/helm/registry.go
+++ b/internal/install/helm/registry.go
@@ -116,7 +116,7 @@ func (p *registryPuller) Run(chartName string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, errReadCompressed)
 	}
-	defer read.Close() //nolint:errcheck
+	defer read.Close() // nolint:gosec,errcheck
 	fileName := filepath.Join(p.cacheDir, fmt.Sprintf("%s-%s.tgz", chartName, p.version))
 
 	// TODO(hasheddan): the native helm pull client will build up a string

--- a/internal/license/dmv.go
+++ b/internal/license/dmv.go
@@ -110,7 +110,7 @@ func (d *DMV) GetAccessKey(ctx context.Context, token, version string) (*Respons
 	if err != nil {
 		return nil, errors.Wrap(err, errGetAccessKey)
 	}
-	defer res.Body.Close() // nolint:errcheck
+	defer res.Body.Close() // nolint:gosec,errcheck
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -57,17 +57,17 @@ const (
 // Flags are common flags used by commands that interact with Upbound.
 type Flags struct {
 	// Optional
-	Domain  *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain."`
-	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command." predictor:"profiles"`
-	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command."`
+	Domain  *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain." json:"domain,omitempty"`
+	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command." predictor:"profiles" json:"profile,omitempty"`
+	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command." json:"account,omitempty"`
 
 	// Insecure
-	InsecureSkipTLSVerify bool `env:"UP_INSECURE_SKIP_TLS_VERIFY" help:"[INSECURE] Skip verifying TLS certificates."`
+	InsecureSkipTLSVerify bool `env:"UP_INSECURE_SKIP_TLS_VERIFY" help:"[INSECURE] Skip verifying TLS certificates." json:"insecureSkipTLSVerify,omitempty"`
 
 	// Hidden
-	APIEndpoint      *url.URL `env:"OVERRIDE_API_ENDPOINT" hidden:"" name:"override-api-endpoint" help:"Overrides the default API endpoint."`
-	ProxyEndpoint    *url.URL `env:"OVERRIDE_PROXY_ENDPOINT" hidden:"" name:"override-proxy-endpoint" help:"Overrides the default proxy endpoint."`
-	RegistryEndpoint *url.URL `env:"OVERRIDE_REGISTRY_ENDPOINT" hidden:"" name:"override-registry-endpoint" help:"Overrides the default registry endpoint."`
+	APIEndpoint      *url.URL `env:"OVERRIDE_API_ENDPOINT" hidden:"" name:"override-api-endpoint" help:"Overrides the default API endpoint." json:"apiEndpoint,omitempty"`
+	ProxyEndpoint    *url.URL `env:"OVERRIDE_PROXY_ENDPOINT" hidden:"" name:"override-proxy-endpoint" help:"Overrides the default proxy endpoint." json:"proxyEndpoint,omitempty"`
+	RegistryEndpoint *url.URL `env:"OVERRIDE_REGISTRY_ENDPOINT" hidden:"" name:"override-registry-endpoint" help:"Overrides the default registry endpoint." json:"registryEndpoint,omitempty"`
 }
 
 // Context includes common data that Upbound consumers may utilize.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -123,7 +123,7 @@ func (i *Informer) getCurrent(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close() // nolint:errcheck
+	defer resp.Body.Close() // nolint:gosec,errcheck
 
 	v, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/xpkg/dep/cache/entry.go
+++ b/internal/xpkg/dep/cache/entry.go
@@ -20,15 +20,14 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/spf13/afero"
-
 	v1ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1beta1ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/upbound/up/internal/xpkg"
 	rxpkg "github.com/upbound/up/internal/xpkg/dep/marshaler/xpkg"
 )

--- a/internal/xpkg/dep/cache/entry.go
+++ b/internal/xpkg/dep/cache/entry.go
@@ -29,8 +29,6 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	xpv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
-	"github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
-
 	"github.com/upbound/up/internal/xpkg"
 	rxpkg "github.com/upbound/up/internal/xpkg/dep/marshaler/xpkg"
 )
@@ -238,15 +236,9 @@ func (e *entry) writeObjects(objs []runtime.Object) (*flushstats, error) { // no
 		case *v1ext.CustomResourceDefinition:
 			name = crd.GetName()
 			inc = stats.incCRDs
-		case *v1beta1.CompositeResourceDefinition:
-			name = crd.GetName()
-			inc = stats.incXRDs
 		case *xpv1.CompositeResourceDefinition:
 			name = crd.GetName()
 			inc = stats.incXRDs
-		case *v1beta1.Composition:
-			name = crd.GetName()
-			inc = stats.incComps
 		case *xpv1.Composition:
 			name = crd.GetName()
 			inc = stats.incComps

--- a/internal/xpkg/dep/marshaler/xpkg/marshaler_test.go
+++ b/internal/xpkg/dep/marshaler/xpkg/marshaler_test.go
@@ -99,7 +99,7 @@ func TestFromImage(t *testing.T) {
 						},
 						Spec: xpmetav1alpha1.ProviderSpec{
 							Controller: xpmetav1alpha1.ControllerSpec{
-								Image: "crossplane/provider-aws-controller:v0.20.0",
+								Image: pointer.String("crossplane/provider-aws-controller:v0.20.0"),
 							},
 							MetaSpec: xpmetav1alpha1.MetaSpec{
 								DependsOn: []xpmetav1alpha1.Dependency{
@@ -271,7 +271,7 @@ func TestFromDir(t *testing.T) {
 						},
 						Spec: xpmetav1alpha1.ProviderSpec{
 							Controller: xpmetav1alpha1.ControllerSpec{
-								Image: "crossplane/provider-helm-controller:v0.9.0",
+								Image: pointer.String("crossplane/provider-helm-controller:v0.9.0"),
 							},
 							MetaSpec: xpmetav1alpha1.MetaSpec{
 								DependsOn: []xpmetav1alpha1.Dependency{
@@ -316,7 +316,7 @@ func TestFromDir(t *testing.T) {
 						},
 						Spec: xpmetav1alpha1.ProviderSpec{
 							Controller: xpmetav1alpha1.ControllerSpec{
-								Image: "crossplane/provider-helm-controller:v0.9.0",
+								Image: pointer.String("crossplane/provider-helm-controller:v0.9.0"),
 							},
 							MetaSpec: xpmetav1alpha1.MetaSpec{
 								DependsOn: []xpmetav1alpha1.Dependency{

--- a/internal/xpkg/lint.go
+++ b/internal/xpkg/lint.go
@@ -132,7 +132,7 @@ func IsValidatingWebhookConfiguration(o runtime.Object) error {
 
 // IsXRD checks that an object is a CompositeResourceDefinition.
 func IsXRD(o runtime.Object) error {
-	if _, ok := o.(*v1.CompositeResourceDefinition); ok {
+	if _, ok := o.(*v1.CompositeResourceDefinition); !ok {
 		return errors.New(errNotXRD)
 	}
 	return nil

--- a/internal/xpkg/lint.go
+++ b/internal/xpkg/lint.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
-	"github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	admv1 "k8s.io/api/admissionregistration/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -133,24 +132,16 @@ func IsValidatingWebhookConfiguration(o runtime.Object) error {
 
 // IsXRD checks that an object is a CompositeResourceDefinition.
 func IsXRD(o runtime.Object) error {
-	switch o.(type) {
-	case *v1beta1.CompositeResourceDefinition:
-		return nil
-	case *v1.CompositeResourceDefinition:
-		return nil
-	default:
+	if _, ok := o.(*v1.CompositeResourceDefinition); ok {
 		return errors.New(errNotXRD)
 	}
+	return nil
 }
 
 // IsComposition checks that an object is a Composition.
 func IsComposition(o runtime.Object) error {
-	switch o.(type) {
-	case *v1beta1.Composition:
-		return nil
-	case *v1.Composition:
-		return nil
-	default:
+	if _, ok := o.(*v1.Composition); !ok {
 		return errors.New(errNotComposition)
 	}
+	return nil
 }

--- a/internal/xpkg/meta/meta.go
+++ b/internal/xpkg/meta/meta.go
@@ -88,7 +88,7 @@ func NewProviderXPkg(c xpkg.InitContext) ([]byte, error) {
 		},
 		Spec: metav1.ProviderSpec{
 			Controller: metav1.ControllerSpec{
-				Image: c.CtrlImage,
+				Image: &c.CtrlImage,
 			},
 		},
 	}

--- a/internal/xpkg/meta/meta.go
+++ b/internal/xpkg/meta/meta.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
 	metav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
@@ -88,7 +89,7 @@ func NewProviderXPkg(c xpkg.InitContext) ([]byte, error) {
 		},
 		Spec: metav1.ProviderSpec{
 			Controller: metav1.ControllerSpec{
-				Image: &c.CtrlImage,
+				Image: pointer.String(c.CtrlImage),
 			},
 		},
 	}

--- a/internal/xpkg/scheme/scheme.go
+++ b/internal/xpkg/scheme/scheme.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
-	v1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	pkgmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
 )
@@ -44,9 +43,6 @@ func BuildMetaScheme() (*runtime.Scheme, error) {
 // Crossplane package.
 func BuildObjectScheme() (*runtime.Scheme, error) {
 	objScheme := runtime.NewScheme()
-	if err := v1beta1.AddToScheme(objScheme); err != nil {
-		return nil, err
-	}
 	if err := v1.AddToScheme(objScheme); err != nil {
 		return nil, err
 	}

--- a/internal/xpkg/snapshot/snapshot_test.go
+++ b/internal/xpkg/snapshot/snapshot_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
-	xpextv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 
 	"github.com/upbound/up/internal/xpkg/dep/cache"
@@ -83,7 +82,8 @@ func TestWSLoadValidators(t *testing.T) {
 				return fs
 			}()),
 			validators: map[schema.GroupVersionKind]struct{}{
-				xpextv1.CompositeResourceDefinitionGroupVersionKind: {},
+				schema.FromAPIVersionAndKind("apiextensions.crossplane.io/v1", "CompositeResourceDefinition"):      {},
+				schema.FromAPIVersionAndKind("apiextensions.crossplane.io/v1beta1", "CompositeResourceDefinition"): {},
 			},
 		},
 	}

--- a/internal/xpkg/snapshot/snapshot_test.go
+++ b/internal/xpkg/snapshot/snapshot_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	xpextv1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
-	xpextv1beta1 "github.com/crossplane/crossplane/apis/apiextensions/v1beta1"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 
 	"github.com/upbound/up/internal/xpkg/dep/cache"
@@ -84,8 +83,7 @@ func TestWSLoadValidators(t *testing.T) {
 				return fs
 			}()),
 			validators: map[schema.GroupVersionKind]struct{}{
-				xpextv1.CompositeResourceDefinitionGroupVersionKind:      {},
-				xpextv1beta1.CompositeResourceDefinitionGroupVersionKind: {},
+				xpextv1.CompositeResourceDefinitionGroupVersionKind: {},
 			},
 		},
 	}

--- a/internal/xpkg/workspace/workspace_test.go
+++ b/internal/xpkg/workspace/workspace_test.go
@@ -176,7 +176,7 @@ func TestRWMetaFile(t *testing.T) {
 		},
 		Spec: metav1.ProviderSpec{
 			Controller: metav1.ControllerSpec{
-				Image: "crossplane/provider-aws",
+				Image: pointer.String("crossplane/provider-aws"),
 			},
 			MetaSpec: metav1.MetaSpec{
 				Crossplane: &metav1.CrossplaneConstraints{


### PR DESCRIPTION
### Description of your changes

`up` CLI is still using the old meta API type for `Provider` type which does not have `omitempty` for the `spec.controller` field and this causes it to be initialized with `""` and when Crossplane sees that, it tries to set the corresponding Deployment image to empty string and fails. I'm not entirely sure how we were getting away with this so far.

Fixes https://github.com/upbound/up/issues/321

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Built a provider package and confirmed that when not given, `spec.controller` field does not appear in the built package.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
