### PR TITLE
Added tab completion for two control plane commands.

### DIFF
--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -94,7 +94,7 @@ type connectCmd struct {
 	parser  install.ParameterParser
 	kClient kubernetes.Interface
 
-	Name  string `arg:"" required:"" help:"Name of control plane."`
+	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
 	Token string `required:"" help:"API token used to authenticate."`
 
 	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -39,7 +39,7 @@ type getCmd struct {
 	File  string `type:"path" short:"f" help:"File to merge kubeconfig."`
 	Token string `required:"" help:"API token used to authenticate."`
 
-	Name string `arg:"" name:"control-plane-name" required:"" help:"Name of control plane."`
+	Name string `arg:"" name:"control-plane-name" required:"" help:"Name of control plane." predictor:"ctps"`
 }
 
 // Run executes the get command.


### PR DESCRIPTION
### Description
Two commands were missing tab completion for control planes:

```
up ctp kubeconfig get ...
up ctp connect ...
```

This adds the missing completer. 

git I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Manual testing.