### PR TITLE
Added tab completion for two control plane commands

### DIFF
--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -98,7 +98,7 @@ type connectCmd struct {
 	parser  install.ParameterParser
 	kClient kubernetes.Interface
 
-	Name      string `arg:"" required:"" help:"Name of control plane."`
+	Name      string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
 	Namespace string `arg:"" required:"" help:"Namespace in the control plane where the claims of the cluster will be stored."`
 
 	Token                 string `help:"API token used to authenticate. If not provided, a new robot and a token will be created."`

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -39,7 +39,7 @@ type getCmd struct {
 	File  string `type:"path" short:"f" help:"File to merge kubeconfig."`
 	Token string `required:"" help:"API token used to authenticate."`
 
-	Name string `arg:"" name:"control-plane-name" required:"" help:"Name of control plane."`
+	Name string `arg:"" name:"control-plane-name" required:"" help:"Name of control plane." predictor:"ctps"`
 }
 
 // Run executes the get command.


### PR DESCRIPTION
### Description

Description

Two commands were missing tab completion for control planes:

```
up ctp kubeconfig get ...
up ctp connect ...
```

This adds the missing completer.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Manually