### PR TITLE
Check validity of kubeconfig before applying it

### DIFF
--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -53,7 +53,7 @@ func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 		c.Token = strings.TrimSpace(string(b))
 	}
 	mcpConf := kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, path.Join(upCtx.Account, c.Name), c.Token)
-	if err := kube.ApplyControlPlaneKubeconfigIfValid(mcpConf, c.File); err != nil {
+	if err := kube.ApplyControlPlaneKubeconfig(mcpConf, c.File); err != nil {
 		return err
 	}
 	if c.File == "" {

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -53,9 +53,11 @@ func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 		c.Token = strings.TrimSpace(string(b))
 	}
 	mcpConf := kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, path.Join(upCtx.Account, c.Name), c.Token)
-	if err := kube.ApplyControlPlaneKubeconfig(mcpConf, c.File); err != nil {
+	if err := kube.ApplyControlPlaneKubeconfigIfValid(mcpConf, c.File); err != nil {
 		return err
 	}
-	p.Printfln("Current context set to %s", mcpConf.CurrentContext)
+	if c.File == "" {
+		p.Printfln("Current context set to %s", mcpConf.CurrentContext)
+	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Use a client to verify connectivity before applying a kubeconfig and setting it as the current context. Will not change the current context on a failure.

Fixes #323 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Bad token:
```
➜  bin ./up ctp kubeconfig get --token="fake token" my-ctp
up: error: the server has asked for the client to provide credentials
```

Good token, non-existent target:
```
./up ctp kubeconfig get --token=`cat my-token` does-not-exist
up: error: the server could not find the requested resource
```

Oops, wrong Upbound organization:
```
./up ctp kubeconfig get --token=`cat my-token` my-ctp     
up: error: the server could not find the requested resource
```

That's the one!
```
➜  bin ./up ctp kubeconfig get --token=`cat my-token` my-ctp -a upbound
Current context set to upbound-upbound-my-ctp
```
