### PR TITLE
xpkg batch subcommand to batch process provider packages

### DIFF
--- a/cmd/up/xpkg/batch.go
+++ b/cmd/up/xpkg/batch.go
@@ -1,0 +1,399 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xpkg
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/alecthomas/kong"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+
+	"github.com/upbound/up/internal/upbound"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/parser"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pterm/pterm"
+	"github.com/spf13/afero"
+
+	"github.com/upbound/up/internal/xpkg"
+	"github.com/upbound/up/internal/xpkg/parser/examples"
+	"github.com/upbound/up/internal/xpkg/parser/yaml"
+)
+
+const (
+	errInvalidTemplate    = "service-scoped provider template is not valid"
+	errMetadataBackend    = "failed to initialize the package metadata parser backend"
+	errCRDBackend         = "failed to initialize the CRD parser backend"
+	errTemplateFmt        = "failed to execute the provider metadata template using: %v"
+	errInvalidPlatformFmt = "failed to parse platform name. Expected syntax is <OS>_<arch>: %s"
+	errBuildPackageFmt    = "failed to service-scoped provider package: %s"
+	errGetConfigFmt       = "failed to get config file from %s image for service %q"
+	errMutateConfigFmt    = "failed to mutate config file from %s image for service %q"
+	errGetLayersFmt       = "failed to get layers from %s image for service %q"
+	errGetBaseLayersFmt   = "failed to get base layers from %s image for service %q"
+	errGetDigestFmt       = "failed to get layer's digest from %s image for service %q"
+	errAppendLayersFmt    = "failed to append layers to %s image for service %q"
+	errReadProviderBinFmt = "failed to read %q provider binary for %s platform from path: %s"
+	errNewLayerFmt        = "failed to initialize a new image layer for %s platform for service %q"
+	errAddLayerFmt        = "failed to add the service-scoped provider binary layer for %s platform for service %q"
+	errPushPackageFmt     = "failed to push service-scoped provider package: %s"
+)
+
+// AfterApply constructs and binds Upbound-specific context to any subcommands
+// that have Run() methods that receive it.
+func (c *batchCmd) AfterApply(kongCtx *kong.Context) error {
+	c.fs = afero.NewOsFs()
+	// NOTE(aru): we currently only support fetching family base image from
+	// daemon, but may opt to support additional sources in the future.
+	c.fetch = daemonFetch
+	if c.TemplateVar == nil {
+		c.TemplateVar = make(map[string]string)
+	}
+
+	upCtx, err := upbound.NewFromFlags(c.Flags)
+	if err != nil {
+		return err
+	}
+	kongCtx.Bind(upCtx)
+
+	return nil
+}
+
+// batchCmd builds and pushes a family of Crossplane provider packages.
+type batchCmd struct {
+	fs    afero.Fs
+	fetch fetchFn
+
+	FamilyBaseImage        string   `help:"Family image used as the base for the service-scoped provider packages." required:""`
+	ProviderName           string   `help:"Provider name, such as provider-aws to be used while formatting service-scoped provider package repositories." required:""`
+	FamilyPackageURLFormat string   `help:"Family package URL format to be used for the service-scoped provider packages. Must be a valid OCI image URL with the format specifier \"%s\", which will be substituted with <provider name>-<service name>." required:""`
+	Service                []string `help:"Services to build the scoped provider packages for." default:"monolith"`
+
+	Platform        []string `help:"Platforms to build the packages for. Each platform should use the <OS>_<arch> syntax. An example is: linux_arm64." default:"linux_amd64,linux_arm64"`
+	ProviderBinRoot string   `short:"p" help:"Provider binary paths root. Service-scoped provider binaries should reside under the platform directories in this folder." type:"existingdir"`
+
+	PackageMetadataTemplate string            `help:"Service-scoped provider metadata template. The template variables {{ .Service }} and {{ .Name }} will be substituted when the template is executed among with the supplied template variable substitutions." default:"./package/crossplane.yaml.tmpl" type:"path"`
+	TemplateVar             map[string]string `help:"Service-scoped provider metadata template variables to be used for the specified template."`
+
+	ExamplesGroupOverride map[string]string `help:"Overrides for the location of the example manifests folder of a service-scoped provider." optional:""`
+	CRDGroupOverride      map[string]string `help:"Overrides for the locations of the CRD folders of the service-scoped providers." optional:""`
+	PackageRepoOverride   map[string]string `help:"Overrides for the package repository names of the service-scoped providers." optional:""`
+
+	ExamplesRoot string   `short:"e" help:"Path to package examples directory." default:"./examples" type:"path"`
+	CRDRoot      string   `help:"Path to package CRDs directory." default:"./package/crds" type:"path"`
+	AuthExt      string   `help:"Path to an authentication extension file." default:"./package/auth.yaml" type:"path"`
+	Ignore       []string `help:"Paths to exclude from the service-scoped provider packages."`
+	Create       bool     `help:"Create repository on push if it does not exist."`
+
+	// Common Upbound API configuration
+	Flags upbound.Flags `embed:""`
+}
+
+// Run executes the batch command.
+func (c *batchCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
+	baseImgMap := make(map[string]v1.Image, len(c.Platform))
+	for _, p := range c.Platform {
+		tokens := strings.Split(p, "_")
+		if len(tokens) != 2 {
+			return errors.Errorf(errInvalidPlatformFmt, p)
+		}
+		ref, err := name.ParseReference(fmt.Sprintf("%s-%s", c.FamilyBaseImage, tokens[1]))
+		if err != nil {
+			return err
+		}
+		img, err := c.fetch(context.Background(), ref)
+		if err != nil {
+			return err
+		}
+		baseImgMap[p] = img // assume correct OS
+	}
+
+	for _, s := range c.Service {
+		imgs := make([]v1.Image, 0, len(c.Platform))
+		var addendumLayers []v1.Layer
+		var labels [][2]string
+		for _, p := range c.Platform {
+			var img v1.Image
+			var err error
+			switch {
+			case len(addendumLayers) > 0:
+				img = baseImgMap[p]
+				for _, l := range addendumLayers {
+					img, err = mutate.AppendLayers(img, l)
+					if err != nil {
+						return errors.Wrapf(err, errAppendLayersFmt, p, s)
+					}
+				}
+				cfg, err := img.ConfigFile()
+				if err != nil {
+					return errors.Wrapf(err, errGetConfigFmt, p, s)
+				}
+				if cfg.Config.Labels == nil {
+					cfg.Config.Labels = make(map[string]string, len(labels))
+				}
+				for _, kv := range labels {
+					if kv[1] == "" {
+						continue
+					}
+					cfg.Config.Labels[kv[0]] = kv[1]
+				}
+				img, err = mutate.Config(img, cfg.Config)
+				if err != nil {
+					return errors.Wrapf(err, errMutateConfigFmt, p, s)
+				}
+				img, err = c.addProviderBinaryLayer(img, p, s)
+				if err != nil {
+					return err
+				}
+			default:
+				img, err = c.buildImage(baseImgMap, p, s)
+				if err != nil {
+					return err
+				}
+				// calculate addendum layers to reuse
+				addendumLayers, labels, err = getAddendumLayers(baseImgMap[p], img, p, s)
+				if err != nil {
+					return err
+				}
+			}
+			imgs = append(imgs, img)
+		}
+
+		t := c.getPackageURL(s)
+		p.Printfln("Pushing xpkg to %s", t)
+		if err := PushImages(p, upCtx, imgs, t, c.Create, c.Flags.Profile); err != nil {
+			return errors.Wrapf(err, errPushPackageFmt, s)
+		}
+	}
+	return nil
+}
+
+func (c *batchCmd) getPackageRepo(s string) string {
+	repo := c.PackageRepoOverride[s]
+	if repo == "" {
+		repo = fmt.Sprintf("%s-%s", c.ProviderName, s)
+	}
+	return repo
+}
+
+func (c *batchCmd) getPackageURL(s string) string {
+	return fmt.Sprintf(c.FamilyPackageURLFormat, c.getPackageRepo(s))
+}
+
+func getAddendumLayers(baseImg, img v1.Image, p, s string) ([]v1.Layer, [][2]string, error) {
+	baseLayers, err := baseImg.Layers()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, errGetBaseLayersFmt, p, s)
+	}
+	layers, err := img.Layers()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, errGetLayersFmt, p, s)
+	}
+	addendumLayers := layers[len(baseLayers) : len(layers)-1]
+	// get associated labels from image config
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, errGetConfigFmt, p, s)
+	}
+	labels := make([][2]string, 0, len(addendumLayers))
+	for _, l := range addendumLayers {
+		d, err := l.Digest()
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, errGetDigestFmt, p, s)
+		}
+		label := ""
+		key := xpkg.Label(d.String())
+		for k, v := range cfg.Config.Labels {
+			if key == k {
+				label = v
+				break
+			}
+		}
+		labels = append(labels, [2]string{key, label})
+	}
+	return addendumLayers, labels, nil
+}
+
+func (c *batchCmd) buildImage(baseImgMap map[string]v1.Image, p, s string) (v1.Image, error) {
+	builder, err := c.getBuilder(s)
+	if err != nil {
+		return nil, err
+	}
+	img, _, err := builder.Build(context.Background(), xpkg.WithController(baseImgMap[p]))
+	if err != nil {
+		return nil, errors.Wrapf(err, errBuildPackageFmt, s)
+	}
+	return c.addProviderBinaryLayer(img, p, s)
+}
+
+func (c *batchCmd) addProviderBinaryLayer(img v1.Image, p, s string) (v1.Image, error) {
+	configFile, err := img.ConfigFile()
+	if err != nil {
+		return nil, errors.Wrapf(err, errGetConfigFmt, p, s)
+	}
+	binPath := filepath.Join(c.ProviderBinRoot, p, s)
+	buff, err := os.ReadFile(binPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, errReadProviderBinFmt, s, p, binPath)
+	}
+	l, err := xpkg.Layer(bytes.NewBuffer(buff), "/usr/local/bin/provider", "", int64(len(buff)), &configFile.Config)
+	if err != nil {
+		return nil, errors.Wrapf(err, errNewLayerFmt, p, s)
+	}
+	img, err = mutate.AppendLayers(img, l)
+	return img, errors.Wrapf(err, errAddLayerFmt, p, s)
+}
+
+func (c *batchCmd) getExamplesGroup(service string) string {
+	p := c.ExamplesGroupOverride[service]
+	if p == "" {
+		p = service
+	}
+	return filepath.Join(c.ExamplesRoot, p)
+}
+
+func (c *batchCmd) getBuilder(service string) (*xpkg.Builder, error) {
+	ex, err := filepath.Abs(c.getExamplesGroup(service))
+	if err != nil {
+		return nil, err
+	}
+
+	var authBE parser.Backend
+	if ax, err := filepath.Abs(c.AuthExt); err == nil {
+		if axf, err := c.fs.Open(ax); err == nil {
+			defer func() { _ = axf.Close() }()
+			b, err := io.ReadAll(axf)
+			if err != nil {
+				return nil, err
+			}
+			authBE = parser.NewEchoBackend(string(b))
+		}
+	}
+
+	pp, err := yaml.New()
+	if err != nil {
+		return nil, err
+	}
+
+	packageMetadata, err := c.getPackageMetadata(service)
+	if err != nil {
+		return nil, err
+	}
+
+	return xpkg.New(
+		&batchParserBackend{
+			packageMetadata: packageMetadata,
+			service:         service,
+			crdsRoot:        c.CRDRoot,
+			fs:              c.fs,
+			options: []parser.BackendOption{
+				parser.FsDir(c.CRDRoot),
+				parser.FsFilters(
+					append(
+						buildFilters(c.CRDRoot, c.Ignore),
+						xpkg.SkipContains(c.ExamplesRoot), xpkg.SkipContains(c.AuthExt),
+						func(_ string, info os.FileInfo) (bool, error) {
+							return !strings.HasPrefix(info.Name(), c.getCRDPrefix(service)), nil
+						})...),
+			},
+		},
+		authBE,
+		parser.NewFsBackend(
+			c.fs,
+			parser.FsDir(ex),
+			parser.FsFilters(
+				buildFilters(ex, c.Ignore)...),
+		),
+		pp,
+		examples.New(),
+	), nil
+}
+
+func (c *batchCmd) getCRDPrefix(service string) string {
+	o := c.CRDGroupOverride[service]
+	if o == "" {
+		o = service
+	}
+	return o + "."
+}
+
+func (c *batchCmd) getPackageMetadata(service string) (string, error) {
+	tmpl, err := template.New(filepath.Base(c.PackageMetadataTemplate)).ParseFiles(c.PackageMetadataTemplate)
+	if err != nil {
+		return "", errors.Wrap(err, errInvalidTemplate)
+	}
+
+	// add template var substitutions
+	c.TemplateVar["Service"] = service
+	c.TemplateVar["Name"] = c.getPackageRepo(service)
+
+	buff := &bytes.Buffer{}
+	err = tmpl.Execute(buff, c.TemplateVar)
+	if err != nil {
+		return "", errors.Wrapf(err, errTemplateFmt, c.TemplateVar)
+	}
+	return buff.String(), nil
+}
+
+type batchParserBackend struct {
+	packageMetadata string
+	service         string
+	crdsRoot        string
+	options         []parser.BackendOption
+
+	fs afero.Fs
+}
+
+func (b *batchParserBackend) Init(ctx context.Context, opts ...parser.BackendOption) (io.ReadCloser, error) {
+	rcMetadata, err := parser.NewEchoBackend(b.packageMetadata).Init(ctx, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, errMetadataBackend)
+	}
+	rcCRD, err := parser.NewFsBackend(b.fs, b.options...).Init(ctx, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, errCRDBackend)
+	}
+	return &batchReadCloser{
+		metadataReadCloser: rcMetadata,
+		crdReadCloser:      rcCRD,
+	}, nil
+}
+
+type batchReadCloser struct {
+	metadataReadCloser io.ReadCloser
+	crdReadCloser      io.ReadCloser
+	metadataRead       bool
+}
+
+func (b *batchReadCloser) Read(p []byte) (n int, err error) {
+	if !b.metadataRead {
+		b.metadataRead = true
+		return b.metadataReadCloser.Read(p)
+	}
+	return b.crdReadCloser.Read(p)
+}
+
+func (b *batchReadCloser) Close() error {
+	return b.crdReadCloser.Close() // echo backend's io.Closer implementation is a noop one.
+}

--- a/cmd/up/xpkg/batch.go
+++ b/cmd/up/xpkg/batch.go
@@ -61,6 +61,10 @@ const (
 	errPushPackageFmt     = "failed to push service-scoped provider package: %s"
 )
 
+const (
+	wildcard = "*"
+)
+
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
 func (c *batchCmd) AfterApply(kongCtx *kong.Context) error {
@@ -136,7 +140,7 @@ func (c *batchCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //no
 		go func() {
 			defer c.wg.Done()
 			if err := c.processService(p, upCtx, baseImgMap, s); err != nil {
-				p.PrintOnErrorf("Publishing of service-scoped provider package has filed for service %q: %v", s, err)
+				p.PrintOnErrorf("Publishing of service-scoped provider package has failed for service %q: %v", s, err)
 			}
 		}()
 	}
@@ -281,7 +285,9 @@ func (c *batchCmd) addProviderBinaryLayer(img v1.Image, p, s string) (v1.Image, 
 
 func (c *batchCmd) getExamplesGroup(service string) string {
 	p := c.ExamplesGroupOverride[service]
-	if p == "" {
+	if p == wildcard {
+		p = ""
+	} else if p == "" {
 		p = service
 	}
 	return filepath.Join(c.ExamplesRoot, p)
@@ -346,6 +352,9 @@ func (c *batchCmd) getBuilder(service string) (*xpkg.Builder, error) {
 
 func (c *batchCmd) getCRDPrefix(service string) string {
 	o := c.CRDGroupOverride[service]
+	if o == wildcard {
+		return ""
+	}
 	if o == "" {
 		o = service
 	}

--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -17,7 +17,6 @@ package xpkg
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
@@ -100,7 +100,7 @@ func (c *pushCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nol
 	return PushImages(p, upCtx, imgs, c.Tag, c.Create, c.Flags.Profile)
 }
 
-func PushImages(p pterm.TextPrinter, upCtx *upbound.Context, imgs []v1.Image, t string, create bool, profile string) error {
+func PushImages(p pterm.TextPrinter, upCtx *upbound.Context, imgs []v1.Image, t string, create bool, profile string) error { //nolint:gocyclo
 	tag, err := name.NewTag(t, name.WithDefaultRegistry(upCtx.RegistryEndpoint.Hostname()))
 	if err != nil {
 		return err

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -32,4 +32,5 @@ type Cmd struct {
 	Init      initCmd      `cmd:"" help:"Initialize a package."`
 	Dep       depCmd       `cmd:"" help:"Manage package dependencies."`
 	Push      pushCmd      `cmd:"" help:"Push a package."`
+	Batch     batchCmd     `cmd:"" help:"Batch build and push a family of service-scoped provider packages."`
 }

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -32,5 +32,5 @@ type Cmd struct {
 	Init      initCmd      `cmd:"" help:"Initialize a package."`
 	Dep       depCmd       `cmd:"" help:"Manage package dependencies."`
 	Push      pushCmd      `cmd:"" help:"Push a package."`
-	Batch     batchCmd     `cmd:"" help:"Batch build and push a family of service-scoped provider packages." hidden:""`
+	Batch     batchCmd     `cmd:"" maturity:"alpha" help:"Batch build and push a family of service-scoped provider packages."`
 }

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -32,5 +32,5 @@ type Cmd struct {
 	Init      initCmd      `cmd:"" help:"Initialize a package."`
 	Dep       depCmd       `cmd:"" help:"Manage package dependencies."`
 	Push      pushCmd      `cmd:"" help:"Push a package."`
-	Batch     batchCmd     `cmd:"" help:"Batch build and push a family of service-scoped provider packages."`
+	Batch     batchCmd     `cmd:"" help:"Batch build and push a family of service-scoped provider packages." hidden:""`
 }

--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -249,7 +249,7 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 		return nil, nil, errors.Wrap(err, errConfigFile)
 	}
 
-	pkgLayer, err := Layer(pkgBytes, StreamFile, PackageAnnotation, int64(pkgBytes.Len()), &cfg)
+	pkgLayer, err := Layer(pkgBytes, StreamFile, PackageAnnotation, int64(pkgBytes.Len()), StreamFileMode, &cfg)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -262,7 +262,7 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 			return nil, nil, errors.Wrap(err, errParserExample)
 		}
 
-		exLayer, err := Layer(exBuf, XpkgExamplesFile, ExamplesAnnotation, int64(exBuf.Len()), &cfg)
+		exLayer, err := Layer(exBuf, XpkgExamplesFile, ExamplesAnnotation, int64(exBuf.Len()), StreamFileMode, &cfg)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/xpkg/layers.go
+++ b/internal/xpkg/layers.go
@@ -57,8 +57,10 @@ func Layer(r io.Reader, fileName, annotation string, fileSize int64, cfg *v1.Con
 		return nil, errors.Wrap(err, errDigestInvalid)
 	}
 
-	// add annotation label to config
-	cfg.Labels[Label(d.String())] = annotation
+	// add annotation label to config if a non-empty label is specified
+	if annotation != "" {
+		cfg.Labels[Label(d.String())] = annotation
+	}
 
 	return layer, nil
 }

--- a/internal/xpkg/layers.go
+++ b/internal/xpkg/layers.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -27,13 +28,13 @@ import (
 
 // Layer creates a v1.Layer that represetns the layer contents for the xpkg and
 // adds a corresponding label to the image Config for the layer.
-func Layer(r io.Reader, fileName, annotation string, fileSize int64, cfg *v1.Config) (v1.Layer, error) {
+func Layer(r io.Reader, fileName, annotation string, fileSize int64, mode os.FileMode, cfg *v1.Config) (v1.Layer, error) {
 	tarBuf := new(bytes.Buffer)
 	tw := tar.NewWriter(tarBuf)
 
 	exHdr := &tar.Header{
 		Name: fileName,
-		Mode: int64(StreamFileMode),
+		Mode: int64(mode),
 		Size: fileSize,
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
This PR introduces an `xpkg batch` subcommand to batch process a family of provider packages. The `xpkg build` implementation dumps the built packages onto the file system for `xpkg push` to load them from the filesystem and push them to a package registry. These two subcommands should stay as is with this PR and a new `xpkg batch` command is added that does not need to store the built provider packages in the filesystem. The packages are instead directly pushed to the configured registry. `xpkg batch` has batch processing capabilities to streamline the build process of a family of smaller provider packages. An example invocation for the command looks like:
```
up xpkg batch --service monolith,config,acm,rds,ec2 --family-base-image build-e46f4576/provider-aws --provider-name provider-aws --family-package-url-format xpkg.upbound.io/upbound-release-candidates/%s:v0.35.0-rc.0 --package-repo-override monolith=provider-aws --package-repo-override config=provider-family-aws --provider-bin-root .../provider-aws/_output/bin --examples-root .../provider-aws/examples --examples-group-override monolith=* --examples-group-override config=providerconfig --auth-ext .../provider-aws/package/auth.yaml --crd-root .../provider-aws/package/crds --crd-group-override monolith=* --crd-group-override config=aws --package-metadata-template .../provider-aws/package/crossplane.yaml.tmpl --template-var XpkgRegOrg=xpkg.upbound.io/upbound-release-candidates --template-var DepConstraint=">= 0.0.0-0" --concurrency 4
```

All smaller packages built by this command share a common base image and this common base is specified with the `--family-base-image` option. The providers to be built and pushed are specified via the `--service` option. `xpkg batch` adds the `base` and the `upbound` layers as before, as well as a layer containing the provider binary. The `base` and `upbound` labeled layers are shared between all the architectures of a provider's package.

`xpkg batch` builds & pushes the provider packages in parallel with the configured (via the `--concurrency` option) maximum concurrency. 

`xpkg batch` also has a templating engine so that the family of providers being built can share a template provider metadata. The templating engine substitutes the `{{ .Service }}` and `{{ .Name }}` template variables with the service and package repo names, respectively, and further template variables can also be supplied via multiple `--template-var` command-line options. 

The `--family-package-url-format` should specify the package URL format string and must contain a single string specifier, which will be substituted with the repo name of the provider being processed. The provider binaries should reside under `--provider-bin-root` in their respective platform folders. The platforms for which the provider packages will be built can be specified via the `--platform` option. 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Tested both locally and in Github workflows against `upbound/provider-aws` packages.