### PR TITLE
[DevEx] xpkg: add error contexts and print & fail on parse errors

### DIFF
--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -117,31 +117,21 @@ type buildCmd struct {
 
 func (c *buildCmd) Help() string {
 	return `
-A Crossplane package is an opinionated OCI image that contains an additional layer 
-holding meta information to drive the Crossplane package manager. The package manager
-uses this information to install packages into a Crossplane instance.
+The build command creates a xpkg compatible OCI image for a Crossplane package
+from the local file system. It packages the found YAML files containing Kubernetes-like
+object manifests into the meta data layer of the OCI image. The package manager
+will use this information to install the package into a Crossplane instance.
 
-Furthermore, a Crossplane package may contain meta information that describes
-how to represent the package in a user interface. This information is used by
-the Upbound marketplace to display packages and their contents. See the xpkg
-reference linked at the bottom for more information.
+Only configuration and provider packages are supported at this time. 
 
-There are different kinds of Crossplane packages, each with a different set of
-meta information and files in the additional layer. The following kinds are 
-currently supported:
+Example claims can be specified in the examples directory.
 
-- **Provider**: A Crossplane package that contains a Crossplane provider. The layer
-  contains a crossplane.yaml file with a "meta.pkg.crossplane.io/v1alpha1"
-  kind "Provider" manifest, and optionally CRD manifest.
-- **Configuration**: A Crossplane package that contains a Crossplane configuration,
-  with a "meta.pkg.crossplane.io/v1" kind "Configuration" manifest in crossplane.yaml.
-- in newer versions of Crossplane, more kinds will be supported.
-
-For more detailed information on Crossplane packages, see
+For more generic information, see the xpkg parent command help. Also see the
+Crossplane documentation for more information on building packages:
 
   https://docs.crossplane.io/latest/concepts/packages/#building-a-package
 
-Even more details can be found in the xpkg reference.`
+Even more details can be found in the xpkg reference document.`
 }
 
 // Run executes the build command.

--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	errGetNameFromMeta = "failed to get name from crossplane.yaml"
+	errGetNameFromMeta = "failed to get package name from crossplane.yaml"
 	errBuildPackage    = "failed to build package"
 	errImageDigest     = "failed to get package digest"
 	errCreatePackage   = "failed to create package file"

--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -115,6 +115,35 @@ type buildCmd struct {
 	Ignore       []string `help:"Paths, specified relative to --package-root, to exclude from the package."`
 }
 
+func (c *buildCmd) Help() string {
+	return `
+A Crossplane package is an opinionated OCI image that contains an additional layer 
+holding meta information to drive the Crossplane package manager. The package manager
+uses this information to install packages into a Crossplane instance.
+
+Furthermore, a Crossplane package may contain meta information that describes
+how to represent the package in a user interface. This information is used by
+the Upbound marketplace to display packages and their contents. See the xpkg
+reference linked at the bottom for more information.
+
+There are different kinds of Crossplane packages, each with a different set of
+meta information and files in the additional layer. The following kinds are 
+currently supported:
+
+- **Provider**: A Crossplane package that contains a Crossplane provider. The layer
+  contains a crossplane.yaml file with a "meta.pkg.crossplane.io/v1alpha1"
+  kind "Provider" manifest, and optionally CRD manifest.
+- **Configuration**: A Crossplane package that contains a Crossplane configuration,
+  with a "meta.pkg.crossplane.io/v1" kind "Configuration" manifest in crossplane.yaml.
+- in newer versions of Crossplane, more kinds will be supported.
+
+For more detailed information on Crossplane packages, see
+
+  https://docs.crossplane.io/latest/concepts/packages/#building-a-package
+
+Even more details can be found in the xpkg reference.`
+}
+
 // Run executes the build command.
 func (c *buildCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
 	var buildOpts []xpkg.BuildOpt

--- a/cmd/up/xpkg/dep.go
+++ b/cmd/up/xpkg/dep.go
@@ -103,6 +103,18 @@ type depCmd struct {
 	Package string `arg:"" optional:"" help:"Package to be added."`
 }
 
+func (c *depCmd) Help() string {
+	return `
+The dep command manages crossplane package dependencies of the package 
+in the current directory. It caches package information in a local file system
+cache (by default in ~/.up/cache), to be used e.g. for the Crossplane language
+server.
+
+If a package is specified, it will be added to the crossplane.yaml file
+in the current directory.
+`
+}
+
 // Run executes the dep command.
 func (c *depCmd) Run(ctx context.Context, p pterm.TextPrinter, pb *pterm.BulletListPrinter) error {
 	// no need to do anything else if clean cache was called.

--- a/cmd/up/xpkg/dep.go
+++ b/cmd/up/xpkg/dep.go
@@ -110,8 +110,8 @@ in the current directory. It caches package information in a local file system
 cache (by default in ~/.up/cache), to be used e.g. for the Crossplane language
 server.
 
-If a package is specified, it will be added to the crossplane.yaml file
-in the current directory.
+If a package (e.g. provider-foo@v0.42.0 or provider-foo for latest) is specified,
+it will be added to the crossplane.yaml file in the current directory as dependency. 
 `
 }
 

--- a/cmd/up/xpkg/dep.go
+++ b/cmd/up/xpkg/dep.go
@@ -158,7 +158,7 @@ func (c *depCmd) userSuppliedDep(ctx context.Context) error {
 
 	ud, _, err := c.m.AddAll(ctx, d)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "in %s", c.Package)
 	}
 
 	meta := c.ws.View().Meta()

--- a/cmd/up/xpkg/dep.go
+++ b/cmd/up/xpkg/dep.go
@@ -39,7 +39,7 @@ const (
 
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
-func (c *depCmd) AfterApply(kongCtx *kong.Context) error {
+func (c *depCmd) AfterApply(kongCtx *kong.Context, p pterm.TextPrinter) error {
 	kongCtx.Bind(pterm.DefaultBulletList.WithWriter(kongCtx.Stdout))
 	ctx := context.Background()
 	fs := afero.NewOsFs()
@@ -72,7 +72,7 @@ func (c *depCmd) AfterApply(kongCtx *kong.Context) error {
 			return err
 		}
 
-		ws, err := workspace.New(wd, workspace.WithFS(fs))
+		ws, err := workspace.New(wd, workspace.WithFS(fs), workspace.WithPrinter(p))
 		if err != nil {
 			return err
 		}

--- a/cmd/up/xpkg/init.go
+++ b/cmd/up/xpkg/init.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	errAlreadyExists      = "directory contains pre-existing meta file"
-	errInvalidPackageType = "the provided package type is invalid"
+	errAlreadyExistsFmt   = "directory contains pre-existing meta file: %s"
+	errInvalidPackageType = "the provided package type %q is invalid; valid types: configuration,provider"
 )
 
 // BeforeApply sets default values in init before assignment and validation.
@@ -56,7 +56,7 @@ func (c *initCmd) AfterApply() error {
 
 	// validate provided package type
 	if !xpkg.Package(c.Type).IsValid() {
-		return errors.New(errInvalidPackageType)
+		return errors.Errorf(errInvalidPackageType, c.Type)
 	}
 
 	// common init
@@ -204,7 +204,7 @@ func (c *initCmd) metaFileInRoot() error {
 	}
 
 	if exists {
-		return errors.New(errAlreadyExists)
+		return errors.Errorf(errAlreadyExistsFmt, xpkg.MetaFile)
 	}
 	return nil
 }

--- a/cmd/up/xpkg/init_test.go
+++ b/cmd/up/xpkg/init_test.go
@@ -123,7 +123,7 @@ func TestMetaFileInRoot(t *testing.T) {
 				fs:         afero.NewMemMapFs(),
 			},
 			want: want{
-				err: errors.New(errAlreadyExists),
+				err: errors.Errorf(errAlreadyExistsFmt, xpkg.MetaFile),
 			},
 		},
 	}

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -27,10 +27,17 @@ func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
 
 // Cmd contains commands for interacting with xpkgs.
 type Cmd struct {
-	Build     buildCmd     `cmd:"" help:"Build a package."`
+	Build     buildCmd     `cmd:"" help:"Build a package, by default from the current directory."`
 	XPExtract xpExtractCmd `cmd:"" maturity:"alpha" help:"Extract package contents into a Crossplane cache compatible format. Fetches from a remote registry by default."`
-	Init      initCmd      `cmd:"" help:"Initialize a package."`
-	Dep       depCmd       `cmd:"" help:"Manage package dependencies."`
+	Init      initCmd      `cmd:"" help:"Initialize a package, by default in the current directory."`
+	Dep       depCmd       `cmd:"" help:"Manage package dependencies in the filesystem and populate the cache, e.g. used by the Crossplane Language Server."`
 	Push      pushCmd      `cmd:"" help:"Push a package."`
 	Batch     batchCmd     `cmd:"" maturity:"alpha" help:"Batch build and push a family of service-scoped provider packages."`
+}
+
+func (c *Cmd) Help() string {
+	// Show the detailed help here at the root and in the build command.
+	// The other command are more specific, and we will go into the relevant
+	// details there, omitting the general help text.
+	return c.Build.Help()
 }

--- a/cmd/up/xpkg/xpkg.go
+++ b/cmd/up/xpkg/xpkg.go
@@ -36,8 +36,30 @@ type Cmd struct {
 }
 
 func (c *Cmd) Help() string {
-	// Show the detailed help here at the root and in the build command.
-	// The other command are more specific, and we will go into the relevant
-	// details there, omitting the general help text.
-	return c.Build.Help()
+	return `
+A Crossplane package is an opinionated OCI image that contains an additional layer 
+holding meta information to drive the Crossplane package manager. The package manager
+uses this information to install packages into a Crossplane instance.
+
+Furthermore, a Crossplane package may contain meta information that describes
+how to represent the package in a user interface. This information is used by
+the Upbound marketplace to display packages and their contents. See the xpkg
+reference document for more information.
+
+There are different kinds of Crossplane packages, each with a different set of
+meta information and files in the additional layer. The following kinds are 
+currently supported:
+
+- **Provider**: A Crossplane package that contains a Crossplane provider. The layer
+  contains a crossplane.yaml file with a "meta.pkg.crossplane.io/v1alpha1"
+  kind "Provider" manifest, and optionally CRD manifest.
+- **Configuration**: A Crossplane package that contains a Crossplane configuration,
+  with a "meta.pkg.crossplane.io/v1" kind "Configuration" manifest in crossplane.yaml.
+- in newer versions of Crossplane, more kinds will be supported.
+
+For more detailed information on Crossplane packages, see
+
+  https://docs.crossplane.io/latest/concepts/packages/#building-a-package
+
+Even more details can be found in the xpkg reference document.`
 }

--- a/internal/xpkg/dep/manager/manager.go
+++ b/internal/xpkg/dep/manager/manager.go
@@ -345,7 +345,7 @@ func (m *Manager) retrievePkg(ctx context.Context, d v1beta1.Dependency) (*xpkg.
 func (m *Manager) retrieveAndStorePkg(ctx context.Context, d v1beta1.Dependency) (*xpkg.ParsedPackage, error) {
 	// resolve version prior to Get
 	if err := m.finalizeExtDepVersion(ctx, &d); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to resolve %s:%s: %w", d.Package, d.Constraints, err)
 	}
 
 	p, err := m.c.Get(d)

--- a/internal/xpkg/dep/resolver/image/resolver.go
+++ b/internal/xpkg/dep/resolver/image/resolver.go
@@ -81,7 +81,7 @@ func (r *Resolver) ResolveImage(ctx context.Context, dep v1beta1.Dependency) (st
 
 	tag, err := r.ResolveTag(ctx, dep)
 	if err != nil {
-		return "", nil, err
+		return "", nil, errors.Errorf("failed to resolve %s:%s: %w", dep.Package, dep.Constraints, err)
 	}
 
 	remoteImageRef, err := name.ParseReference(FullTag(v1beta1.Dependency{

--- a/internal/xpkg/snapshot/snapshot.go
+++ b/internal/xpkg/snapshot/snapshot.go
@@ -156,7 +156,7 @@ func (f *Factory) New(ctx context.Context, opts ...Option) (*Snapshot, error) {
 
 	// TODO(@tnthornton) see about moving workspace up to Factory
 	// and have the workspace's view returned from the Parse call.
-	w, err := workspace.New(f.workdir, workspace.WithLogger(s.log))
+	w, err := workspace.New(f.workdir, workspace.WithLogger(s.log), workspace.WithPermissiveParser())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/xpkg/workspace/workspace.go
+++ b/internal/xpkg/workspace/workspace.go
@@ -28,6 +28,7 @@ import (
 	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
 	"github.com/golang/tools/span"
+	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -136,6 +137,14 @@ func WithFS(fs afero.Fs) Option {
 func WithLogger(l logging.Logger) Option {
 	return func(w *Workspace) {
 		w.log = l
+	}
+}
+
+// WithPrinter overrides the printer of the Workspace with the supplied
+// printer. By default a Workspace has no printer.
+func WithPrinter(p pterm.TextPrinter) Option {
+	return func(w *Workspace) {
+		w.view.printer = p
 	}
 }
 
@@ -386,6 +395,10 @@ func (v *View) parseMeta(ctx context.Context, pCtx parseContext) error {
 	v.meta = meta.New(p.GetMeta()[0])
 	v.metaPath = pCtx.path
 
+	if v.printer != nil {
+		v.printer.Printf("xpkg loaded package meta information from %s\n", v.relativePath(pCtx.path))
+	}
+
 	return nil
 }
 
@@ -441,6 +454,7 @@ type View struct {
 	xrClaimRefs map[schema.GroupVersionKind]schema.GroupVersionKind
 	// root is the path of the workspace root.
 	root    string
+	printer pterm.TextPrinter
 }
 
 // FileDetails returns the map of file details found within the parsed workspace.

--- a/internal/xpkg/writer.go
+++ b/internal/xpkg/writer.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	errAlreadyExists = "directory contains pre-existing meta file"
+	errAlreadyExistsFmt = "directory contains pre-existing meta file: %s"
 )
 
 // Writer defines a writer that is used for creating package meta files.
@@ -79,7 +79,7 @@ func (w *Writer) NewMetaFile() error {
 		return err
 	}
 	if exists {
-		return errors.New(errAlreadyExists)
+		return errors.Errorf(errAlreadyExistsFmt, w.relativePath(targetFile))
 	}
 
 	exists, err = afero.DirExists(w.fs, w.root)
@@ -95,4 +95,15 @@ func (w *Writer) NewMetaFile() error {
 	}
 
 	return afero.WriteFile(w.fs, targetFile, w.fileBody, StreamFileMode)
+}
+
+func (w *Writer) relativePath(path string) string {
+	if !filepath.IsAbs(path) {
+		return path
+	}
+	rel, err := filepath.Rel(w.root, path)
+	if err != nil {
+		return path
+	}
+	return rel
 }

--- a/internal/xpkg/writer_test.go
+++ b/internal/xpkg/writer_test.go
@@ -52,7 +52,7 @@ func TestNewMetaFile(t *testing.T) {
 				WithFs(fs),
 			),
 			want: want{
-				err: errors.New(errAlreadyExists),
+				err: errors.Errorf(errAlreadyExistsFmt, "crossplane.yaml"),
 			},
 		},
 		"Successful": {


### PR DESCRIPTION
This PR adds errors contexts (e.g. filenames) to errors returned in the xpkg commands. Moreover, it removes the TODO in the workspace loader of missing error handling.