### PR TITLE
Use default font rather than setting a font that may be too light

### DIFF
--- a/internal/upterm/styles.go
+++ b/internal/upterm/styles.go
@@ -32,14 +32,15 @@ var (
 	}
 
 	spinnerStyle = &pterm.Style{pterm.FgDarkGray}
+	msgStyle     = &pterm.Style{pterm.FgDefault}
 
-	CheckmarkSuccessSpinner = pterm.DefaultSpinner.WithStyle(spinnerStyle)
-	EyesInfoSpinner         = pterm.DefaultSpinner.WithStyle(spinnerStyle)
+	CheckmarkSuccessSpinner = pterm.DefaultSpinner.WithStyle(spinnerStyle).WithMessageStyle(msgStyle)
+	EyesInfoSpinner         = pterm.DefaultSpinner.WithStyle(spinnerStyle).WithMessageStyle(msgStyle)
 
 	ComponentText = pterm.DefaultBasicText.WithStyle(&pterm.ThemeDefault.TreeTextStyle)
 
 	cp = &pterm.PrefixPrinter{
-		MessageStyle: &pterm.Style{pterm.FgLightWhite},
+		MessageStyle: &pterm.Style{pterm.FgDefault},
 		Prefix: pterm.Prefix{
 			Style: &pterm.Style{pterm.FgLightMagenta},
 			Text:  " √ ",
@@ -47,7 +48,7 @@ var (
 	}
 
 	ip = &pterm.PrefixPrinter{
-		MessageStyle: &pterm.Style{pterm.FgLightWhite},
+		MessageStyle: &pterm.Style{pterm.FgDefault},
 		Prefix:       EyesPrefix,
 	}
 )


### PR DESCRIPTION
### Description of your changes
Move from earlier UX to fonts that represent better on various backgrounds, see screenshots below:

white background:
![Screenshot 2023-08-14 at 3 00 36 PM](https://github.com/upbound/up/assets/2375126/6940645c-3551-4dd6-afd5-73ce02f09ff2)

black background:
![Screenshot 2023-08-14 at 3 03 09 PM](https://github.com/upbound/up/assets/2375126/b33393b8-80db-454a-8baa-fc37865003ae)


Fixes #354 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Ran through basic init to see what how the text was shown. See screenshots above.
