### PR TITLE
Allow operators to override the registry and registry-endpoint for a spaces install

### DIFF
--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -30,7 +30,7 @@ func (c *destroyCmd) AfterApply(insCtx *install.Context) error {
 
 	mgr, err := helm.NewManager(insCtx.Kubeconfig,
 		spacesChart,
-		c.Repo,
+		c.Registry,
 		helm.WithNamespace(ns),
 		helm.IsOCI())
 	if err != nil {

--- a/cmd/up/space/space.go
+++ b/cmd/up/space/space.go
@@ -25,7 +25,11 @@ import (
 	"github.com/upbound/up/internal/kube"
 )
 
-const spacesChart = "spaces"
+const (
+	spacesChart = "spaces"
+
+	defaultRegistry = "us-west1-docker.pkg.dev/orchestration-build/upbound-environments"
+)
 
 // BeforeReset is the first hook to run.
 func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
@@ -57,7 +61,18 @@ type Cmd struct {
 }
 
 type commonParams struct {
-	Repo *url.URL `hidden:"" env:"UPBOUND_REPO" default:"us-west1-docker.pkg.dev/orchestration-build/upbound-environments" help:"Set repo for Upbound."`
+	Registry *url.URL `hidden:"" env:"UPBOUND_REPO" default:"us-west1-docker.pkg.dev/orchestration-build/upbound-environments" help:"Set repo for Upbound."`
 
-	Registry *url.URL `hidden:"" env:"UPBOUND_REGISTRY_ENDPOINT" default:"https://us-west1-docker.pkg.dev" help:"Set registry for authentication."`
+	RegistryEndpoint *url.URL `hidden:"" env:"UPBOUND_REGISTRY_ENDPOINT" default:"https://us-west1-docker.pkg.dev" help:"Set registry for authentication."`
+}
+
+// overrideRegistry is a common function that takes the candidate registry,
+// compares that against the default registry and if different overrides
+// that property in the params map.
+func overrideRegistry(candidate string, params map[string]any) {
+	// NOTE(tnthornton) this is unfortunately brittle. If the helm chart values
+	// property changes, this won't necessarily account for that.
+	if candidate != defaultRegistry {
+		params["registry"] = candidate
+	}
 }

--- a/cmd/up/space/space.go
+++ b/cmd/up/space/space.go
@@ -61,9 +61,9 @@ type Cmd struct {
 }
 
 type commonParams struct {
-	Registry *url.URL `hidden:"" env:"UPBOUND_REPO" default:"us-west1-docker.pkg.dev/orchestration-build/upbound-environments" help:"Set repo for Upbound."`
+	Registry *url.URL `hidden:"" env:"UPBOUND_REGISTRY" default:"us-west1-docker.pkg.dev/orchestration-build/upbound-environments" help:"Set registry for where to pull OCI artifacts from. This is an OCI registry reference, i.e. a URL without the scheme or protocol prefix."`
 
-	RegistryEndpoint *url.URL `hidden:"" env:"UPBOUND_REGISTRY_ENDPOINT" default:"https://us-west1-docker.pkg.dev" help:"Set registry for authentication."`
+	RegistryEndpoint *url.URL `hidden:"" env:"UPBOUND_REGISTRY_ENDPOINT" default:"https://us-west1-docker.pkg.dev" help:"Set registry endpoint, including scheme, for authentication."`
 }
 
 // overrideRegistry is a common function that takes the candidate registry,

--- a/internal/install/context.go
+++ b/internal/install/context.go
@@ -32,5 +32,5 @@ type CommonParams struct {
 	File   *os.File          `short:"f" help:"Parameters file."`
 	Bundle *os.File          `help:"Local bundle path."`
 
-	TokenFile *os.File `name:"token-file" required:"" help:"File containing authentication token."`
+	TokenFile *os.File `name:"token-file" help:"File containing authentication token."`
 }


### PR DESCRIPTION
### Description of your changes
This is specifically useful for operators working in an airgapped environment.

Unfortunately, given we don't really know what the shape of the pull secret should be, we do our best to prompt for username/password and supply the registry-endpoint value.

Fixes #349 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Ensured that in the default case, installation via `up space init --token-file=key.json version` still works:
```
./_output/bin/darwin_arm64/up space init --token-file=key.json v0.14.0-23.ga50d1a87
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm

Would you like to install them now? [y/N]: Yes

  √   [1/5]: Installing cert-manager
  √   [2/5]: Installing universal-crossplane
  √   [3/5]: Installing ingress-nginx
  √   [4/5]: Installing provider-kubernetes
  √   [5/5]: Installing provider-helm
 INFO  Required prerequisites met!
 INFO  Proceeding with Upbound Spaces installation...
  √   [1/3]: Creating pull secret upbound-pull-secret
  √   [2/3]: Initializing Space components
  √   [3/3]: Starting Space Components
  🙌  Your Upbound Space is Ready!

  👀  Next Steps 👇

👉 Check out Upbound Spaces docs @ https://docs.upbound.io
```
2. Overrode registry and registry-endpoint. Expectation is that the install will fail when attempting to pull helm chart due to bad creds:
```
./_output/bin/darwin_arm64/up space init --token-file=key.json v0.14.0-23.ga50d1a87 --registry=upbound/spaces-install --registry-endpoint=hub.docker.com
Username: username
Password:
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm

Would you like to install them now? [y/N]: Yes

  √   [1/5]: Installing cert-manager
  √   [2/5]: Installing universal-crossplane
  √   [3/5]: Installing ingress-nginx
  √   [4/5]: Installing provider-kubernetes
  √   [5/5]: Installing provider-helm
 INFO  Required prerequisites met!
 INFO  Proceeding with Upbound Spaces installation...
  √   [1/3]: Creating pull secret upbound-pull-secret
▄  [2/3]: Initializing Space components (1s)up: error: space.initCmd.Run(): could not pull chart: failed to get OCI image: GET https://auth.docker.io/token?scope=repository%3Aupbound%2Fspaces-install%2Fspaces%3Apull&service=registry.docker.io: unexpected status code 401 Unauthorized: {"details":"incorrect username or password"}
```
3. Verify that upbound-pull-secret has the correct creds from prompt steps:
```
kubectl -n upbound-system get secrets upbound-pull-secret -o go-template='{{index .data ".dockerconfigjson"}}' | base64 -d
{"auths":{"hub.docker.com":{"username":"username","password":"password","auth":"dXNlcm5hbWU6cGFzc3dvcmQ="}}}%                                                 
```