### PR TITLE
cmd/space: fix missing install.Context

### DIFF
--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -15,26 +15,15 @@
 package space
 
 import (
-	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 
 	"github.com/upbound/up/internal/install"
 	"github.com/upbound/up/internal/install/helm"
-	"github.com/upbound/up/internal/kube"
 	"github.com/upbound/up/internal/upterm"
 )
 
 // AfterApply sets default values in command after assignment and validation.
-func (c *destroyCmd) AfterApply(insCtx *install.Context, kongCtx *kong.Context) error {
-	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
-	if err != nil {
-		return err
-	}
-
-	kongCtx.Bind(&install.Context{
-		Kubeconfig: kubeconfig,
-	})
-
+func (c *destroyCmd) AfterApply(insCtx *install.Context) error {
 	// NOTE(tnthornton) we currently only have support for stylized output.
 	pterm.EnableStyling()
 	upterm.DefaultObjPrinter.Pretty = true

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -102,15 +102,6 @@ func (c *initCmd) BeforeApply() error {
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *initCmd) AfterApply(insCtx *install.Context, kongCtx *kong.Context, quiet config.QuietFlag) error { //nolint:gocyclo
-	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
-	if err != nil {
-		return err
-	}
-
-	kongCtx.Bind(&install.Context{
-		Kubeconfig: kubeconfig,
-	})
-
 	// NOTE(tnthornton) we currently only have support for stylized output.
 	pterm.EnableStyling()
 	upterm.DefaultObjPrinter.Pretty = true

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/alecthomas/kong"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
 	"k8s.io/client-go/kubernetes"
@@ -44,16 +43,7 @@ func (c *upgradeCmd) BeforeApply() error {
 }
 
 // AfterApply sets default values in command after assignment and validation.
-func (c *upgradeCmd) AfterApply(insCtx *install.Context, kongCtx *kong.Context, quiet config.QuietFlag) error { //nolint:gocyclo
-	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
-	if err != nil {
-		return err
-	}
-
-	kongCtx.Bind(&install.Context{
-		Kubeconfig: kubeconfig,
-	})
-
+func (c *upgradeCmd) AfterApply(insCtx *install.Context, quiet config.QuietFlag) error { //nolint:gocyclo
 	// NOTE(tnthornton) we currently only have support for stylized output.
 	pterm.EnableStyling()
 	upterm.DefaultObjPrinter.Pretty = true
@@ -139,7 +129,7 @@ type upgradeCmd struct {
 }
 
 // Run executes the upgrade command.
-func (c *upgradeCmd) Run(insCtx *install.Context) error {
+func (c *upgradeCmd) Run() error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 


### PR DESCRIPTION
If the `install.Context` is not provided by the parent command (it isn't, maybe since @branden's billing PR?) we must construct it in the subcommands. Binding there is too late.