### PR TITLE
space: unify and deduplicate registry flag logic

### DIFF
--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -34,8 +34,24 @@ const (
 	nsUpboundSystem = "upbound-system"
 )
 
+// destroyCmd uninstalls Upbound.
+type destroyCmd struct {
+	Registry registryFlags `embed:""`
+	Kube     kubeFlags     `embed:""`
+
+	Confirmed bool `name:"yes-really-delete-space-and-all-data" type:"bool" help:"Bypass safety checks and destroy Spaces"`
+	Orphan    bool `name:"orphan" type:"bool" help:"Remove Space components but retain Control Planes and data"`
+
+	mgr     install.Manager
+	kClient kubernetes.Interface
+}
+
 // AfterApply sets default values in command after assignment and validation.
-func (c *destroyCmd) AfterApply(insCtx *install.Context) error {
+func (c *destroyCmd) AfterApply() error {
+	if err := c.Kube.AfterApply(); err != nil {
+		return err
+	}
+
 	// NOTE(tnthornton) we currently only have support for stylized output.
 	pterm.EnableStyling()
 	upterm.DefaultObjPrinter.Pretty = true
@@ -71,7 +87,7 @@ func (c *destroyCmd) AfterApply(insCtx *install.Context) error {
 		}
 	}
 
-	kClient, err := kubernetes.NewForConfig(insCtx.Kubeconfig)
+	kClient, err := kubernetes.NewForConfig(c.Kube.config)
 	if err != nil {
 		return err
 	}
@@ -85,39 +101,30 @@ func (c *destroyCmd) AfterApply(insCtx *install.Context) error {
 		with = append(with, helm.WithNoHooks())
 	}
 
-	mgr, err := helm.NewManager(insCtx.Kubeconfig,
+	mgr, err := helm.NewManager(c.Kube.config,
 		spacesChart,
-		c.Registry,
+		c.Registry.Repository,
 		with...,
 	)
 	if err != nil {
 		return err
 	}
-
 	c.mgr = mgr
+
 	return nil
 }
 
-// destroyCmd uninstalls Upbound.
-type destroyCmd struct {
-	mgr     install.Manager
-	kClient kubernetes.Interface
-
-	commonParams
-
-	Confirmed bool `name:"yes-really-delete-space-and-all-data" type:"bool" help:"Bypass safety checks and destroy Spaces"`
-	Orphan    bool `name:"orphan" type:"bool" help:"Remove Space components but retain Control Planes and data"`
-}
-
 // Run executes the uninstall command.
-func (c *destroyCmd) Run(insCtx *install.Context) error {
+func (c *destroyCmd) Run() error {
 	if err := c.mgr.Uninstall(); err != nil {
 		return err
 	}
+
 	// leave `upbound-system` namespace in place since there are secrets, configmaps, etc,
 	// used by controlplanes
 	if c.Orphan {
 		return nil
 	}
+
 	return c.kClient.CoreV1().Namespaces().Delete(context.Background(), nsUpboundSystem, v1.DeleteOptions{})
 }

--- a/cmd/up/space/flags.go
+++ b/cmd/up/space/flags.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Upbound Inc.
+// All rights reserved
+
+package space
+
+import (
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"k8s.io/client-go/rest"
+
+	"github.com/upbound/up/internal/input"
+	"github.com/upbound/up/internal/kube"
+)
+
+type kubeFlags struct {
+	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
+
+	// set by AfterApply
+	config *rest.Config
+}
+
+type registryFlags struct {
+	Repository *url.URL `hidden:"" name:"registry-repository" env:"UPBOUND_REGISTRY" default:"us-west1-docker.pkg.dev/orchestration-build/upbound-environments" help:"Set registry for where to pull OCI artifacts from. This is an OCI registry reference, i.e. a URL without the scheme or protocol prefix."`
+	Endpoint   *url.URL `hidden:"" name:"registry-endpoint" env:"UPBOUND_REGISTRY_ENDPOINT" default:"https://us-west1-docker.pkg.dev" help:"Set registry endpoint, including scheme, for authentication."`
+}
+
+type authorizedRegistryFlags struct {
+	registryFlags
+
+	TokenFile *os.File `name:"token-file" help:"File containing authentication token."`
+	Username  string   `hidden:"" name:"registry-username" help:"Set the registry username."`
+	Password  string   `hidden:"" name:"registry-password" help:"Set the registry password."`
+}
+
+func (f *kubeFlags) AfterApply() error {
+	restConfig, err := kube.GetKubeConfig(f.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	f.config = restConfig
+
+	return nil
+}
+
+func (p *authorizedRegistryFlags) AfterApply() error {
+	if p.TokenFile == nil && p.Username == "" && p.Password == "" {
+		if p.Repository.String() == defaultRegistry {
+			return errors.New("--token-file is required")
+		}
+
+		prompter := input.NewPrompter()
+		id, err := prompter.Prompt("Username", false)
+		if err != nil {
+			return err
+		}
+		token, err := prompter.Prompt("Password", true)
+		if err != nil {
+			return err
+		}
+		p.Username = id
+		p.Password = token
+
+		return nil
+	}
+
+	if p.Username != "" {
+		return nil
+	}
+
+	b, err := io.ReadAll(p.TokenFile)
+	defer p.TokenFile.Close() // nolint:errcheck
+	if err != nil {
+		return errors.Wrap(err, errReadTokenFile)
+	}
+	p.Username = jsonKey
+	p.Password = string(b)
+
+	return nil
+}

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -51,7 +51,6 @@ import (
 const (
 	hcGroup          = "internal.spaces.upbound.io"
 	hcVersion        = "v1alpha1"
-	hcKind           = "XHostCluster"
 	hcResourcePlural = "xhostclusters"
 )
 
@@ -76,12 +75,7 @@ const (
 	errReadTokenFile          = "unable to read token file"
 	errReadParametersFile     = "unable to read parameters file"
 	errParseInstallParameters = "unable to parse install parameters"
-	errGetRegistryToken       = "failed to acquire auth token"
-	errGetAccessKey           = "failed to acquire access key"
 	errCreateImagePullSecret  = "failed to create image pull secret"
-	errCreateLicenseSecret    = "failed to create license secret"
-	errTimoutExternalIP       = "timed out waiting for externalIP to resolve"
-	errUpdateConfig           = "unable to update config"
 
 	errFmtCreateNamespace = "failed to create namespace %s"
 )

--- a/cmd/up/space/space.go
+++ b/cmd/up/space/space.go
@@ -15,15 +15,10 @@
 package space
 
 import (
-	"net/url"
-
 	"github.com/alecthomas/kong"
 
 	"github.com/upbound/up/cmd/up/space/billing"
-	"github.com/upbound/up/internal/config"
 	"github.com/upbound/up/internal/feature"
-	"github.com/upbound/up/internal/install"
-	"github.com/upbound/up/internal/kube"
 )
 
 const (
@@ -39,22 +34,11 @@ func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
 
 // Cmd contains commands for interacting with spaces.
 type Cmd struct {
-	kubeCmds `embed:""`
-	Billing  billing.Cmd `cmd:""`
-}
-
-type kubeCmds struct {
-	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
-
 	Init    initCmd    `cmd:"" help:"Initialize an Upbound Spaces deployment."`
 	Destroy destroyCmd `cmd:"" help:"Remove the Upbound Spaces deployment."`
 	Upgrade upgradeCmd `cmd:"" help:"Upgrade the Upbound Spaces deployment."`
-}
 
-type commonParams struct {
-	Registry *url.URL `hidden:"" env:"UPBOUND_REGISTRY" default:"us-west1-docker.pkg.dev/orchestration-build/upbound-environments" help:"Set registry for where to pull OCI artifacts from. This is an OCI registry reference, i.e. a URL without the scheme or protocol prefix."`
-
-	RegistryEndpoint *url.URL `hidden:"" env:"UPBOUND_REGISTRY_ENDPOINT" default:"https://us-west1-docker.pkg.dev" help:"Set registry endpoint, including scheme, for authentication."`
+	Billing billing.Cmd `cmd:""`
 }
 
 // overrideRegistry is a common function that takes the candidate registry,
@@ -66,16 +50,4 @@ func overrideRegistry(candidate string, params map[string]any) {
 	if candidate != defaultRegistry {
 		params["registry"] = candidate
 	}
-}
-
-func (c *kubeCmds) AfterApply(kongCtx *kong.Context, quiet config.QuietFlag) error {
-	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
-	if err != nil {
-		return err
-	}
-	kongCtx.Bind(&install.Context{
-		Kubeconfig: kubeconfig,
-	})
-
-	return nil
 }

--- a/internal/install/context.go
+++ b/internal/install/context.go
@@ -31,6 +31,4 @@ type CommonParams struct {
 	Set    map[string]string `help:"Set parameters."`
 	File   *os.File          `short:"f" help:"Parameters file."`
 	Bundle *os.File          `help:"Local bundle path."`
-
-	TokenFile *os.File `name:"token-file" help:"File containing authentication token."`
 }


### PR DESCRIPTION
- move registry logic into central `flags.go`
- add `--registry-username` and `--registry-password`.