### PR TITLE
space/upgrade: validate versions locally

### DIFF
--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -222,9 +222,10 @@ func (c *initCmd) Run() error {
 		}
 
 		if !c.Yes {
-			pterm.DefaultInteractiveConfirm.DefaultText = "Would you like to install them now?"
 			pterm.Println() // Blank line
-			result, _ := pterm.DefaultInteractiveConfirm.Show()
+			confirm := pterm.DefaultInteractiveConfirm
+			confirm.DefaultText = "Would you like to install them now?"
+			result, _ := confirm.Show()
 			pterm.Println() // Blank line
 			if !result {
 				pterm.Error.Println("prerequisites must be met in order to proceed with installation")

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -266,6 +266,8 @@ func (c *initCmd) installPrereqs() error {
 			upterm.CheckmarkSuccessSpinner,
 			p.Install,
 		); err != nil {
+			fmt.Println()
+			fmt.Println()
 			return err
 		}
 	}
@@ -301,6 +303,8 @@ func (c *initCmd) applySecret(ctx context.Context, regFlags *authorizedRegistryF
 		upterm.CheckmarkSuccessSpinner,
 		creatPullSecret,
 	); err != nil {
+		fmt.Println()
+		fmt.Println()
 		return err
 	}
 	return nil
@@ -323,6 +327,8 @@ func (c *initCmd) deploySpace(ctx context.Context, params map[string]any) error 
 		upterm.CheckmarkSuccessSpinner,
 		install,
 	); err != nil {
+		fmt.Println()
+		fmt.Println()
 		return err
 	}
 

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -16,9 +16,11 @@ package space
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
 	"k8s.io/client-go/kubernetes"
@@ -33,7 +35,10 @@ import (
 )
 
 const (
-	errParseUpgradeParameters = "unable to parse upgrade parameters"
+	errParseUpgradeParameters      = "unable to parse upgrade parameters"
+	errFailedGettingCurrentVersion = "failed to retrieve current version"
+	errInvalidVersionFmt           = "invalid version %q"
+	errAborted                     = "aborted"
 )
 
 // upgradeCmd upgrades Upbound.
@@ -54,6 +59,8 @@ type upgradeCmd struct {
 	pullSecret *kube.ImagePullApplicator
 	kClient    kubernetes.Interface
 	quiet      config.QuietFlag
+	oldVersion string
+	downgrade  bool
 }
 
 // BeforeApply sets default values in login before assignment and validation.
@@ -111,6 +118,28 @@ func (c *upgradeCmd) AfterApply(quiet config.QuietFlag) error { //nolint:gocyclo
 	}
 	c.parser = helm.NewParser(base, c.Set)
 	c.quiet = quiet
+	c.oldVersion, err = ins.GetCurrentVersion()
+	if err != nil {
+		return errors.Wrap(err, errFailedGettingCurrentVersion)
+	}
+
+	// validate versions
+	if c.Bundle == nil {
+		from, err := semver.Parse(c.oldVersion)
+		if err != nil {
+			return errors.Wrapf(err, errInvalidVersionFmt, c.oldVersion)
+		}
+		to, err := semver.Parse(strings.TrimPrefix(c.Version, "v"))
+		if err != nil {
+			return errors.Wrapf(err, errInvalidVersionFmt, c.Version)
+		}
+		c.downgrade = from.GT(to)
+
+		if err := c.validateVersions(from, to); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -138,20 +167,58 @@ func (c *upgradeCmd) Run() error {
 }
 
 func (c *upgradeCmd) upgradeUpbound(params map[string]any) error {
+	version := strings.TrimPrefix(c.Version, "v")
 	upgrade := func() error {
-		if err := c.helmMgr.Upgrade(strings.TrimPrefix(c.Version, "v"), params); err != nil {
+		if err := c.helmMgr.Upgrade(version, params); err != nil {
 			return err
 		}
 		return nil
 	}
 
+	verb := "Upgrading"
+	if c.downgrade {
+		verb = "Downgrading"
+	}
+
 	if err := upterm.WrapWithSuccessSpinner(
-		"Upgrading Space",
+		fmt.Sprintf("%s Space from v%s to v%s", verb, c.oldVersion, version),
 		upterm.CheckmarkSuccessSpinner,
 		upgrade,
 	); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func (c *upgradeCmd) validateVersions(from, to semver.Version) error {
+	if c.downgrade {
+		if err := warnAndConfirm("Downgrades are not supported."); err != nil {
+			return err
+		}
+	} else if to.Major > from.Major {
+		if err := warnAndConfirm("Upgrades to a new major version are only supported for explicitly documented releases."); err != nil {
+			return err
+		}
+	} else if to.Minor > from.Minor+1 {
+		if err := warnAndConfirm("Upgrades which skip a minor version are not supported."); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func warnAndConfirm(warning string, args ...any) error {
+	pterm.Println()
+	pterm.Warning.Printfln(warning, args...)
+	pterm.Println() // Blank line
+	confirm := pterm.DefaultInteractiveConfirm
+	confirm.DefaultText = "Are you sure you want to proceed?"
+	result, _ := confirm.Show()
+	pterm.Println() // Blank line
+	if !result {
+		return errors.New(errAborted)
+	}
 	return nil
 }

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -185,6 +185,8 @@ func (c *upgradeCmd) upgradeUpbound(params map[string]any) error {
 		upterm.CheckmarkSuccessSpinner,
 		upgrade,
 	); err != nil {
+		fmt.Println()
+		fmt.Println()
 		return err
 	}
 
@@ -192,18 +194,20 @@ func (c *upgradeCmd) upgradeUpbound(params map[string]any) error {
 }
 
 func (c *upgradeCmd) validateVersions(from, to semver.Version) error {
-	if c.downgrade {
+	switch {
+	case c.downgrade:
 		if err := warnAndConfirm("Downgrades are not supported."); err != nil {
 			return err
 		}
-	} else if to.Major > from.Major {
+	case to.Major > from.Major:
 		if err := warnAndConfirm("Upgrades to a new major version are only supported for explicitly documented releases."); err != nil {
 			return err
 		}
-	} else if to.Minor > from.Minor+1 {
+	case to.Minor > from.Minor+1:
 		if err := warnAndConfirm("Upgrades which skip a minor version are not supported."); err != nil {
 			return err
 		}
+	default:
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/alecthomas/kong v0.8.0
 	github.com/aws/aws-sdk-go v1.44.313
+	github.com/blang/semver/v4 v4.0.0
 	github.com/crossplane/crossplane v1.13.0-rc.0.0.20230701053013-444267e84783
 	github.com/crossplane/crossplane-runtime v0.20.0-rc.0.0.20230622073604-c52ef3ac58c6
 	github.com/crossplane/crossplane/controller/apiextensions v0.0.0-00010101000000-000000000000
@@ -78,7 +79,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect


### PR DESCRIPTION
Check versions for upgrade and downgrade and warn appropriately:
- on downgrade (we don't formally support that yet)
- on skipped minor version upgrade
- on every major version upgrade