### PR TITLE
Fix typo in up space destroy output

### DIFF
--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -64,7 +64,7 @@ func (c *destroyCmd) AfterApply(kongCtx *kong.Context) error {
 			pterm.FgRed.Println("******************** DESTRUCTIVE COMMAND ********************")
 			pterm.FgRed.Println("********************* DATA-LOSS WARNING *********************")
 			pterm.Println()
-			pterm.Warning.Println("Destroying Spaces is a destructive command that will destroy data and oprhan resources.")
+			pterm.Warning.Println("Destroying Spaces is a destructive command that will destroy data and orphan resources.")
 			pterm.Warning.Println("Before proceeding ensure that Managed Resources in Control Planes have been deleted.")
 			pterm.Warning.Println("All Spaces components including Control Planes will be destroyed.")
 			pterm.Println()


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This fixes a small typo in output.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

Ran `up space destroy` and verified that the typo is gone.