### PR TITLE
Fix `uxp install` error "couldn't find binding"

### DIFF
--- a/cmd/up/uxp/uxp.go
+++ b/cmd/up/uxp/uxp.go
@@ -36,7 +36,11 @@ var (
 
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
-func (c *Cmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
+	upCtx, err := upbound.NewFromFlags(c.Flags)
+	if err != nil {
+		return err
+	}
 	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
 	if err != nil {
 		return err
@@ -59,4 +63,7 @@ type Cmd struct {
 
 	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
 	Namespace  string `short:"n" env:"UXP_NAMESPACE" default:"upbound-system" help:"Kubernetes namespace for UXP."`
+
+	// Common Upbound API configuration
+	Flags upbound.Flags `embed:""`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This PR makes `uxp.installCmd.AfterApply()` create an `*upbound.Context` rather than take it as an arg, since none of its parent commands are binding it.

Fixes #369.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I verified that `up uxp install` makes it past `uxp.installCmd.AfterApply()`:

```
branden@crateria up % go run ./cmd/up uxp install
up: error: uxp.installCmd.Run(): rendered manifests contain a resource that already exists. Unable to continue with install: ServiceAccount "rbac-manager" in namespace "upbound-system" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "universal-crossplane": current value is "uxp"
exit status 1
branden@crateria up %
```

The above error is expected since I have a kubeconfig for a spaces cluster with UXP already installed.