### PR TITLE
spaces: add bidirectional version constraints

### DIFF
--- a/cmd/up/space/versions.go
+++ b/cmd/up/space/versions.go
@@ -43,11 +43,15 @@ type constraint struct {
 var (
 	// initVersionConstraints is the list of version constraints that are checked
 	// on up init.
-	initVersionConstraints = []constraint{{semver: ">= 1.1", message: "target version must be 1.1 or later. Use up < 0.20.0 to install earlier versions."}}
+	initVersionConstraints = []constraint{
+		{semver: ">= 1.0", message: "target version must be 1.0 or later. Use up < 0.20.0 to install earlier versions."},
+	}
 
 	// upgradeVersionConstraints is the list of version constraints that are
 	// checked on up upgrade.
-	upgradeVersionConstraints = []constraint{{semver: ">= 1.1", message: "target version must be 1.1 or later. Use up < 0.20.0 to install earlier versions."}}
+	upgradeVersionConstraints = []constraint{
+		{semver: ">= 1.0", message: "target version must be 1.0 or later. Use up < 0.20.0 to install earlier versions."},
+	}
 
 	// upgradeFromVersionConstraints is the list of version constraints that are
 	// checked on up upgrade against the installed version on the customer

--- a/cmd/up/space/versions.go
+++ b/cmd/up/space/versions.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package space
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+const (
+	// chartAnnotationUpVersion is the annotation on a chart that is used to
+	// constraint which version of Upbound up can be used to install it.
+	// It's a semicolon-separated list of semver constraints with a message:
+	//
+	// spaces.upbound.io/up-version-constraints: ">= 0.20: up 0.20.0 or later is required; <0.29: up <0.29 is required"
+	chartAnnotationUpConstraints = "spaces.upbound.io/up-version-constraints"
+)
+
+type constraint struct {
+	// semver is the semver constraint to check against.
+	semver string
+
+	// message is the message to display if the constraint is not met. This should
+	// repeat the semver, but in a more human-readable format, and
+	// actionable by the user.
+	message string
+}
+
+var (
+	// initVersionConstraints is the list of version constraints that are checked
+	// on up init.
+	initVersionConstraints = []constraint{{semver: ">= 1.1", message: "target version must be 1.1 or later. Use up < 0.20.0 to install earlier versions."}}
+
+	// upgradeVersionConstraints is the list of version constraints that are
+	// checked on up upgrade.
+	upgradeVersionConstraints = []constraint{{semver: ">= 1.1", message: "target version must be 1.1 or later. Use up < 0.20.0 to install earlier versions."}}
+
+	// upgradeFromVersionConstraints is the list of version constraints that are
+	// checked on up upgrade against the installed version on the customer
+	// host cluster.
+	upgradeFromVersionConstraints = []constraint{}
+)
+
+func parseChartUpConstraints(s string) ([]constraint, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+
+	clauses := strings.Split(s, ";")
+	constraints := make([]constraint, 0, len(clauses))
+	for _, c := range clauses {
+		parts := strings.SplitN(c, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid constraint %q in the chart", c)
+		}
+		constraints = append(constraints, constraint{semver: strings.TrimSpace(parts[0]), message: strings.TrimSpace(parts[1])})
+	}
+	return constraints, nil
+}
+
+func checkVersion(msg string, constraints []constraint, v string) error {
+	sv, err := semver.NewVersion(v)
+	if err != nil {
+		return fmt.Errorf("failed to parse version %q: %w", v, err)
+	}
+
+	for _, vc := range constraints {
+		c, err := semver.NewConstraint(vc.semver)
+		if err != nil {
+			return fmt.Errorf("failed to parse constraint %q: %w", vc.semver, err)
+		}
+
+		if !c.Check(sv) {
+			return fmt.Errorf("%s: %s", msg, vc.message)
+		}
+	}
+
+	return nil
+}

--- a/cmd/up/space/versions_test.go
+++ b/cmd/up/space/versions_test.go
@@ -1,0 +1,121 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package space
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+func TestInitVersionConstraints(t *testing.T) {
+	for _, vc := range initVersionConstraints {
+		_, err := semver.NewConstraint(vc.semver)
+		if err != nil {
+			t.Errorf("failed to parse constraint %q: %v", vc.semver, err)
+		}
+	}
+}
+
+func TestUpgradeVersionConstraints(t *testing.T) {
+	for _, vc := range upgradeVersionConstraints {
+		_, err := semver.NewConstraint(vc.semver)
+		if err != nil {
+			t.Errorf("failed to parse constraint %q: %v", vc.semver, err)
+		}
+	}
+}
+
+func TestUpgradeFromVersionConstraints(t *testing.T) {
+	for _, vc := range upgradeFromVersionConstraints {
+		_, err := semver.NewConstraint(vc.semver)
+		if err != nil {
+			t.Errorf("failed to parse constraint %q: %v", vc.semver, err)
+		}
+	}
+}
+
+func Test_parseChartUpConstraints(t *testing.T) {
+	type want struct {
+		constraints []constraint
+		err         bool
+	}
+	tests := []struct {
+		name string
+		arg  string
+		want want
+	}{
+		{
+			name: "empty",
+			arg:  "",
+			want: want{
+				constraints: nil,
+			},
+		},
+		{
+			name: "one",
+			arg:  ">= 1.10: up 1.10.0 or later is required",
+			want: want{
+				constraints: []constraint{{
+					semver:  ">= 1.10",
+					message: "up 1.10.0 or later is required",
+				}},
+			},
+		},
+		{
+			name: "multiple",
+			arg:  ">= 1.10: up 1.10.0 or later is required;< 1.20: up <1.20 is required",
+			want: want{
+				constraints: []constraint{{
+					semver:  ">= 1.10",
+					message: "up 1.10.0 or later is required",
+				}, {
+					semver:  "< 1.20",
+					message: "up <1.20 is required",
+				}},
+			},
+		},
+		{
+			name: "invalid",
+			arg:  ">= 1.10: up 1.10.0 or later is required;invalid",
+			want: want{
+				err: true,
+			},
+		},
+		{
+			name: "colon",
+			arg:  ">= 1.10: up 1.10.0 or later is required: because reason",
+			want: want{
+				constraints: []constraint{{
+					semver:  ">= 1.10",
+					message: "up 1.10.0 or later is required: because reason",
+				}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseChartUpConstraints(tt.arg)
+			if (err != nil) != tt.want.err {
+				t.Errorf("parseChartUpConstraints() error = %v, want.err %v", err, tt.want.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want.constraints) {
+				t.Errorf("parseChartUpConstraints() got = %v, want.constraints %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/up/xpkg/init.go
+++ b/cmd/up/xpkg/init.go
@@ -18,7 +18,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	v1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	"github.com/pterm/pterm"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
-	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/alecthomas/kong v0.8.0
 	github.com/aws/aws-sdk-go v1.44.313
 	github.com/blang/semver/v4 v4.0.0
@@ -69,7 +69,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -14,12 +14,20 @@
 
 package install
 
+import "helm.sh/helm/v3/pkg/chart"
+
+// InstallOption customizes the behavior of an install.
+type InstallOption func(*chart.Chart) error
+
+// UpgradeOption customizes the behavior of an upgrade.
+type UpgradeOption func(oldVersion string, ch *chart.Chart) error
+
 // Manager can install and manage Upbound software in a Kubernetes cluster.
 // TODO(hasheddan): support custom error types, such as AlreadyExists.
 type Manager interface {
 	GetCurrentVersion() (string, error)
-	Install(version string, parameters map[string]any) error
-	Upgrade(version string, parameters map[string]any) error
+	Install(version string, parameters map[string]any, opts ...InstallOption) error
+	Upgrade(version string, parameters map[string]any, opts ...UpgradeOption) error
 	Uninstall() error
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 )
 

--- a/internal/xpkg/dep/manager/manager.go
+++ b/internal/xpkg/dep/manager/manager.go
@@ -23,7 +23,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/spf13/afero"

--- a/internal/xpkg/dep/resolver/image/resolver.go
+++ b/internal/xpkg/dep/resolver/image/resolver.go
@@ -20,13 +20,12 @@ import (
 	"net/http"
 	"sort"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
-
-	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 )
 
 const (

--- a/internal/xpkg/lint.go
+++ b/internal/xpkg/lint.go
@@ -15,7 +15,7 @@
 package xpkg
 
 import (
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"

--- a/internal/xpkg/snapshot/meta.go
+++ b/internal/xpkg/snapshot/meta.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	metav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	"github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"


### PR DESCRIPTION
1. `cmd/up/space/version.go`: static semver constraints against the chart
2. `spaces.upbound.io/up-version-constraints` annotation on the chart: constraints against `up`.

Fixes https://github.com/upbound/mxe/issues/190.