### PR TITLE
Add Spaces profiles

### DIFF
--- a/cmd/up/configuration/create.go
+++ b/cmd/up/configuration/create.go
@@ -57,6 +57,10 @@ type createCmd struct {
 
 // Run executes the create command.
 func (c *createCmd) Run(p pterm.TextPrinter, cc *configurations.Client, gc *gitsources.Client, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	// By default, the repo name is the same as the configuration name
 	// This matches the Console's behavior
 	if c.Repo == "" {

--- a/cmd/up/configuration/create.go
+++ b/cmd/up/configuration/create.go
@@ -57,7 +57,7 @@ type createCmd struct {
 
 // Run executes the create command.
 func (c *createCmd) Run(p pterm.TextPrinter, cc *configurations.Client, gc *gitsources.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/configuration/create.go
+++ b/cmd/up/configuration/create.go
@@ -57,7 +57,7 @@ type createCmd struct {
 
 // Run executes the create command.
 func (c *createCmd) Run(p pterm.TextPrinter, cc *configurations.Client, gc *gitsources.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
+	if upCtx.Profile.IsSpace() {
 		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -114,6 +114,10 @@ type connectCmd struct {
 
 // Run executes the connect command.
 func (c *connectCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("connect is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	token, err := c.getToken(p, upCtx)
 	if err != nil {
 		return errors.Wrap(err, "failed to get token")

--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -114,8 +114,8 @@ type connectCmd struct {
 
 // Run executes the connect command.
 func (c *connectCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("connect is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("connect is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	token, err := c.getToken(p, upCtx)

--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -114,7 +114,7 @@ type connectCmd struct {
 
 // Run executes the connect command.
 func (c *connectCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("connect is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pterm/pterm"
 
@@ -35,6 +36,10 @@ type createCmd struct {
 
 // Run executes the create command.
 func (c *createCmd) Run(p pterm.TextPrinter, cc *cp.Client, cfc *configurations.Client, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	// Get the UUID from the Configuration name, if it exists.
 	cfg, err := cfc.Get(context.Background(), upCtx.Account, c.ConfigurationName)
 	if err != nil {

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -36,7 +36,7 @@ type createCmd struct {
 
 // Run executes the create command.
 func (c *createCmd) Run(p pterm.TextPrinter, cc *cp.Client, cfc *configurations.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -36,8 +36,8 @@ type createCmd struct {
 
 // Run executes the create command.
 func (c *createCmd) Run(p pterm.TextPrinter, cc *cp.Client, cfc *configurations.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("create is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	// Get the UUID from the Configuration name, if it exists.

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -32,8 +32,8 @@ type deleteCmd struct {
 
 // Run executes the delete command.
 func (c *deleteCmd) Run(p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("delete is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("delete is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	if err := cc.Delete(context.Background(), upCtx.Account, c.Name); err != nil {

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -32,7 +32,7 @@ type deleteCmd struct {
 
 // Run executes the delete command.
 func (c *deleteCmd) Run(p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("delete is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -16,10 +16,12 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pterm/pterm"
 
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
+
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -30,6 +32,10 @@ type deleteCmd struct {
 
 // Run executes the delete command.
 func (c *deleteCmd) Run(p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("delete is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	if err := cc.Delete(context.Background(), upCtx.Account, c.Name); err != nil {
 		return err
 	}

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alecthomas/kong"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -42,6 +43,10 @@ type getCmd struct {
 
 // Run executes the get command.
 func (c *getCmd) Run(printer upterm.ObjectPrinter, cc *cp.Client, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("get is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	ctp, err := cc.Get(context.Background(), upCtx.Account, c.Name)
 	if err != nil {
 		return err

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -43,8 +43,8 @@ type getCmd struct {
 
 // Run executes the get command.
 func (c *getCmd) Run(printer upterm.ObjectPrinter, cc *cp.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("get is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("get is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	ctp, err := cc.Get(context.Background(), upCtx.Account, c.Name)

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -43,7 +43,7 @@ type getCmd struct {
 
 // Run executes the get command.
 func (c *getCmd) Run(printer upterm.ObjectPrinter, cc *cp.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("get is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -15,6 +15,7 @@
 package kubeconfig
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -44,6 +45,10 @@ type getCmd struct {
 
 // Run executes the get command.
 func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("get is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	// TODO(hasheddan): consider implementing a custom decoder
 	if c.Token == "-" {
 		b, err := io.ReadAll(c.stdin)

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -45,7 +45,7 @@ type getCmd struct {
 
 // Run executes the get command.
 func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("get is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -45,8 +45,8 @@ type getCmd struct {
 
 // Run executes the get command.
 func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("get is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("get is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	// TODO(hasheddan): consider implementing a custom decoder

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -49,7 +49,7 @@ type listCmd struct{}
 
 // Run executes the list command.
 func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("list is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -49,8 +49,8 @@ type listCmd struct{}
 
 // Run executes the list command.
 func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("list is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("list is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	// TODO(hasheddan): we currently just max out single page size, but we

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
@@ -48,6 +49,10 @@ type listCmd struct{}
 
 // Run executes the list command.
 func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("list is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	// TODO(hasheddan): we currently just max out single page size, but we
 	// may opt to support limiting page size and iterating through pages via
 	// flags in the future.

--- a/cmd/up/controlplane/pullsecret/create.go
+++ b/cmd/up/controlplane/pullsecret/create.go
@@ -16,6 +16,7 @@ package pullsecret
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alecthomas/kong"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
@@ -36,6 +37,10 @@ const (
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
 func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
 	if err != nil {
 		return err

--- a/cmd/up/controlplane/pullsecret/create.go
+++ b/cmd/up/controlplane/pullsecret/create.go
@@ -37,8 +37,8 @@ const (
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
 func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("create is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)

--- a/cmd/up/controlplane/pullsecret/create.go
+++ b/cmd/up/controlplane/pullsecret/create.go
@@ -37,7 +37,7 @@ const (
 // AfterApply constructs and binds Upbound-specific context to any subcommands
 // that have Run() methods that receive it.
 func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("create is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -38,9 +38,8 @@ import (
 )
 
 const (
-	defaultTimeout     = 30 * time.Second
-	defaultProfileName = "default"
-	loginPath          = "/v1/login"
+	defaultTimeout = 30 * time.Second
+	loginPath      = "/v1/login"
 
 	errLoginFailed    = "unable to login"
 	errReadBody       = "unable to read response body"
@@ -158,7 +157,7 @@ func (c *loginCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { // n
 
 	// If profile name was not provided and no default exists, set name to 'default'.
 	if upCtx.ProfileName == "" {
-		upCtx.ProfileName = defaultProfileName
+		upCtx.ProfileName = config.DefaultProfileName
 	}
 
 	// Re-initialize profile for this login.

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -31,9 +31,9 @@ import (
 	"github.com/pterm/pterm"
 
 	"github.com/upbound/up-sdk-go/service/userinfo"
-	"github.com/upbound/up/internal/config"
 	uphttp "github.com/upbound/up/internal/http"
 	"github.com/upbound/up/internal/input"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -157,11 +157,11 @@ func (c *loginCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { // n
 
 	// If profile name was not provided and no default exists, set name to 'default'.
 	if upCtx.ProfileName == "" {
-		upCtx.ProfileName = config.DefaultProfileName
+		upCtx.ProfileName = profile.DefaultName
 	}
 
 	// Re-initialize profile for this login.
-	profile := config.Profile{
+	profile := profile.Profile{
 		Type: profType,
 		ID:   auth.ID,
 		// Set session early so that it can be used to fetch user info if
@@ -208,7 +208,7 @@ type auth struct {
 
 // constructAuth constructs the body of an Upbound Cloud authentication request
 // given the provided credentials.
-func constructAuth(username, token, password string) (*auth, config.ProfileType, error) {
+func constructAuth(username, token, password string) (*auth, profile.Type, error) {
 	if username == "" && token == "" {
 		return nil, "", errors.New(errNoUserOrToken)
 	}
@@ -216,7 +216,7 @@ func constructAuth(username, token, password string) (*auth, config.ProfileType,
 	if err != nil {
 		return nil, "", err
 	}
-	if profType == config.TokenProfileType {
+	if profType == profile.Token {
 		password = token
 	}
 	return &auth{
@@ -227,7 +227,7 @@ func constructAuth(username, token, password string) (*auth, config.ProfileType,
 }
 
 // parseID gets a user ID by either parsing a token or returning the username.
-func parseID(user, token string) (string, config.ProfileType, error) {
+func parseID(user, token string) (string, profile.Type, error) {
 	if token != "" {
 		p := jwt.Parser{}
 		claims := &jwt.StandardClaims{}
@@ -238,9 +238,9 @@ func parseID(user, token string) (string, config.ProfileType, error) {
 		if claims.Id == "" {
 			return "", "", errors.New(errNoIDInToken)
 		}
-		return claims.Id, config.TokenProfileType, nil
+		return claims.Id, profile.Token, nil
 	}
-	return user, config.UserProfileType, nil
+	return user, profile.User, nil
 }
 
 // extractSession extracts the specified cookie from an HTTP response. The

--- a/cmd/up/login_test.go
+++ b/cmd/up/login_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pterm/pterm"
 
-	"github.com/upbound/up/internal/config"
 	"github.com/upbound/up/internal/http/mocks"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -82,7 +82,7 @@ func TestConstructAuth(t *testing.T) {
 		password string
 	}
 	type want struct {
-		pType config.ProfileType
+		pType profile.Type
 		auth  *auth
 	}
 	cases := map[string]struct {
@@ -102,7 +102,7 @@ func TestConstructAuth(t *testing.T) {
 				password: "cool-password",
 			},
 			want: want{
-				pType: config.UserProfileType,
+				pType: profile.User,
 				auth: &auth{
 					ID:       "cool-user",
 					Password: "cool-password",
@@ -116,7 +116,7 @@ func TestConstructAuth(t *testing.T) {
 				token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MTg1MTc5NDMsImV4cCI6MTY1MDA1Mzk0MywiYXVkIjoiaHR0cHM6Ly9kYW5pZWxtYW5ndW0uY29tIiwic3ViIjoiZ2VvcmdlZGFuaWVsbWFuZ3VtQGdtYWlsLmNvbSIsIkpUSSI6Imhhc2hlZGRhbiJ9.zI42wXvwDHiATx9ycECz7JyATTn9P07wN-TRXvtCGcM",
 			},
 			want: want{
-				pType: config.TokenProfileType,
+				pType: profile.Token,
 				auth: &auth{
 					ID:       "hasheddan",
 					Password: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MTg1MTc5NDMsImV4cCI6MTY1MDA1Mzk0MywiYXVkIjoiaHR0cHM6Ly9kYW5pZWxtYW5ndW0uY29tIiwic3ViIjoiZ2VvcmdlZGFuaWVsbWFuZ3VtQGdtYWlsLmNvbSIsIkpUSSI6Imhhc2hlZGRhbiJ9.zI42wXvwDHiATx9ycECz7JyATTn9P07wN-TRXvtCGcM",
@@ -131,7 +131,7 @@ func TestConstructAuth(t *testing.T) {
 				password: "forget-about-me",
 			},
 			want: want{
-				pType: config.TokenProfileType,
+				pType: profile.Token,
 				auth: &auth{
 					ID:       "hasheddan",
 					Password: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2MTg1MTc5NDMsImV4cCI6MTY1MDA1Mzk0MywiYXVkIjoiaHR0cHM6Ly9kYW5pZWxtYW5ndW0uY29tIiwic3ViIjoiZ2VvcmdlZGFuaWVsbWFuZ3VtQGdtYWlsLmNvbSIsIkpUSSI6Imhhc2hlZGRhbiJ9.zI42wXvwDHiATx9ycECz7JyATTn9P07wN-TRXvtCGcM",
@@ -163,7 +163,7 @@ func TestParseID(t *testing.T) {
 	}
 	type want struct {
 		id    string
-		pType config.ProfileType
+		pType profile.Type
 	}
 	cases := map[string]struct {
 		reason string
@@ -192,7 +192,7 @@ func TestParseID(t *testing.T) {
 			},
 			want: want{
 				id:    "hasheddan",
-				pType: config.TokenProfileType,
+				pType: profile.Token,
 			},
 		},
 		"Successful": {
@@ -202,7 +202,7 @@ func TestParseID(t *testing.T) {
 			},
 			want: want{
 				id:    "cool-user",
-				pType: config.UserProfileType,
+				pType: profile.User,
 			},
 		},
 	}

--- a/cmd/up/login_test.go
+++ b/cmd/up/login_test.go
@@ -46,6 +46,7 @@ func TestRun(t *testing.T) {
 		"ErrorNoUserOrToken": {
 			reason: "If neither user or token is provided an error should be returned.",
 			cmd:    &loginCmd{},
+			ctx:    &upbound.Context{},
 			err:    errors.Wrap(errors.New(errNoUserOrToken), errLoginFailed),
 		},
 		"ErrLoginFailed": {

--- a/cmd/up/logout.go
+++ b/cmd/up/logout.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/alecthomas/kong"
@@ -59,6 +60,10 @@ type logoutCmd struct {
 
 // Run executes the logout command.
 func (c *logoutCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+	if upCtx.Profile.IsSpacesProfile() {
+		return fmt.Errorf("logout is not supported for Spaces profile %q", upCtx.ProfileName)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	req, err := c.client.NewRequest(ctx, http.MethodPost, logoutPath, "", nil)

--- a/cmd/up/logout.go
+++ b/cmd/up/logout.go
@@ -60,8 +60,8 @@ type logoutCmd struct {
 
 // Run executes the logout command.
 func (c *logoutCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpaces() {
-		return fmt.Errorf("logout is not supported for Spaces profile %q", upCtx.ProfileName)
+	if upCtx.Profile.IsSpace() {
+		return fmt.Errorf("logout is not supported for space profile %q", upCtx.ProfileName)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)

--- a/cmd/up/logout.go
+++ b/cmd/up/logout.go
@@ -60,7 +60,7 @@ type logoutCmd struct {
 
 // Run executes the logout command.
 func (c *logoutCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpacesProfile() {
+	if upCtx.Profile.IsSpaces() {
 		return fmt.Errorf("logout is not supported for Spaces profile %q", upCtx.ProfileName)
 	}
 

--- a/cmd/up/profile/current.go
+++ b/cmd/up/profile/current.go
@@ -20,25 +20,25 @@ import (
 
 	"github.com/alecthomas/kong"
 
-	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 )
 
 type currentCmd struct{}
 
 type output struct {
-	Name    string                 `json:"name"`
-	Profile config.RedactedProfile `json:"profile"`
+	Name    string           `json:"name"`
+	Profile profile.Redacted `json:"profile"`
 }
 
 // Run executes the current command.
 func (c *currentCmd) Run(ctx *kong.Context, upCtx *upbound.Context) error {
-	name, profile, err := upCtx.Cfg.GetDefaultUpboundProfile()
+	name, prof, err := upCtx.Cfg.GetDefaultUpboundProfile()
 	if err != nil {
 		return err
 	}
 
-	redacted := config.RedactedProfile{Profile: profile}
+	redacted := profile.Redacted{Profile: prof}
 
 	b, err := json.MarshalIndent(output{
 		Name:    name,

--- a/cmd/up/profile/list.go
+++ b/cmd/up/profile/list.go
@@ -64,13 +64,13 @@ func (c *listCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, ctx *kong.Con
 	data := make([][]string, len(redacted)+1)
 	cursor := ""
 
-	data[0] = []string{"CURRENT", "NAME", "TYPE", "ACCOUNT"}
+	data[0] = []string{"CURRENT", "NAME", "TYPE", "ACCOUNT", "KUBECONFIG", "KUBECONTEXT"}
 	for i, name := range profileNames {
 		if name == dprofile {
 			cursor = "*"
 		}
 		prof := redacted[name]
-		data[i+1] = []string{cursor, name, string(prof.Type), prof.Account}
+		data[i+1] = []string{cursor, name, string(prof.Type), prof.Account, prof.Kubeconfig, prof.KubeContext}
 
 		cursor = "" // reset cursor
 	}

--- a/cmd/up/profile/list.go
+++ b/cmd/up/profile/list.go
@@ -20,7 +20,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 
-	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -40,9 +40,9 @@ func (c *listCmd) Run(p pterm.TextPrinter, pt *pterm.TablePrinter, ctx *kong.Con
 		return nil // nolint:nilerr
 	}
 
-	redacted := make(map[string]config.RedactedProfile)
+	redacted := make(map[string]profile.Redacted)
 	for k, v := range profiles {
-		redacted[k] = config.RedactedProfile{Profile: v}
+		redacted[k] = profile.Redacted{Profile: v}
 	}
 	if len(redacted) == 0 {
 		p.Println(errNoProfiles)

--- a/cmd/up/profile/profile.go
+++ b/cmd/up/profile/profile.go
@@ -29,6 +29,7 @@ type Cmd struct {
 	Use     useCmd     `cmd:"" help:"Set the default Upbound Profile to the given Profile."`
 	View    viewCmd    `cmd:"" help:"View the Upbound Profile settings across profiles."`
 	Config  config.Cmd `cmd:"" help:"Interact with the current Upbound Profile's config."`
+	Set     setCmd     `cmd:"" help:"Create an Upbound Profile."`
 
 	Flags upbound.Flags `embed:""`
 }

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -19,7 +19,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
 
-	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -46,12 +46,12 @@ func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	// If profile name was not provided and no default exists, set name to
 	// the default, and set this profile as the default profile.
 	if upCtx.ProfileName == "" {
-		upCtx.ProfileName = config.DefaultProfileName
+		upCtx.ProfileName = profile.DefaultName
 		setDefault = true
 	}
 
-	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.ProfileName, config.Profile{
-		Type:        config.SpaceProfileType,
+	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.ProfileName, profile.Profile{
+		Type:        profile.Space,
 		Kubeconfig:  c.Kube.Kubeconfig,
 		KubeContext: c.Kube.GetContext(),
 		// Carry over existing config.

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"github.com/alecthomas/kong"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/upbound"
+)
+
+const (
+	errSetProfile = "unable to set profile"
+)
+
+type setCmd struct {
+	Space spaceCmd `cmd:"" help:"Create or update a profile for use with a Space."`
+}
+
+type spaceCmd struct {
+	Kube upbound.KubeFlags `embed:""`
+}
+
+func (c *spaceCmd) AfterApply(kongCtx *kong.Context) error {
+	return c.Kube.AfterApply()
+}
+
+func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.ProfileName, config.Profile{
+		Type:        config.SpacesProfileType,
+		Kubeconfig:  c.Kube.Kubeconfig,
+		KubeContext: c.Kube.GetContext(),
+		// Carry over existing config.
+		BaseConfig: upCtx.Profile.BaseConfig,
+	}); err != nil {
+		return err
+	}
+	return errors.Wrap(upCtx.CfgSrc.UpdateConfig(upCtx.Cfg), errSetProfile)
+}

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -41,6 +41,15 @@ func (c *spaceCmd) AfterApply(kongCtx *kong.Context) error {
 }
 
 func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+	setDefault := false
+
+	// If profile name was not provided and no default exists, set name to
+	// the default, and set this profile as the default profile.
+	if upCtx.ProfileName == "" {
+		upCtx.ProfileName = config.DefaultProfileName
+		setDefault = true
+	}
+
 	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.ProfileName, config.Profile{
 		Type:        config.SpacesProfileType,
 		Kubeconfig:  c.Kube.Kubeconfig,
@@ -50,9 +59,21 @@ func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	}); err != nil {
 		return errors.Wrap(err, errSetProfile)
 	}
+
+	if setDefault {
+		if err := upCtx.Cfg.SetDefaultUpboundProfile(upCtx.ProfileName); err != nil {
+			return errors.Wrap(err, errSetProfile)
+		}
+	}
+
 	if err := upCtx.CfgSrc.UpdateConfig(upCtx.Cfg); err != nil {
 		return errors.Wrap(err, errUpdateConfig)
 	}
-	p.Printfln("Profile %q updated", upCtx.ProfileName)
+
+	if setDefault {
+		p.Printfln("Profile %q updated and selected as the default profile", upCtx.ProfileName)
+	} else {
+		p.Printfln("Profile %q updated", upCtx.ProfileName)
+	}
 	return nil
 }

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	errSetProfile = "unable to set profile"
+	errSetProfile   = "unable to set profile"
+	errUpdateConfig = "unable to update config file"
 )
 
 type setCmd struct {
@@ -47,7 +48,7 @@ func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 		// Carry over existing config.
 		BaseConfig: upCtx.Profile.BaseConfig,
 	}); err != nil {
-		return err
+		return errors.Wrap(err, errSetProfile)
 	}
-	return errors.Wrap(upCtx.CfgSrc.UpdateConfig(upCtx.Cfg), errSetProfile)
+	return errors.Wrap(upCtx.CfgSrc.UpdateConfig(upCtx.Cfg), errUpdateConfig)
 }

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -51,7 +51,7 @@ func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	}
 
 	if err := upCtx.Cfg.AddOrUpdateUpboundProfile(upCtx.ProfileName, config.Profile{
-		Type:        config.SpacesProfileType,
+		Type:        config.SpaceProfileType,
 		Kubeconfig:  c.Kube.Kubeconfig,
 		KubeContext: c.Kube.GetContext(),
 		// Carry over existing config.

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -50,5 +50,9 @@ func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	}); err != nil {
 		return errors.Wrap(err, errSetProfile)
 	}
-	return errors.Wrap(upCtx.CfgSrc.UpdateConfig(upCtx.Cfg), errUpdateConfig)
+	if err := upCtx.CfgSrc.UpdateConfig(upCtx.Cfg); err != nil {
+		return errors.Wrap(err, errUpdateConfig)
+	}
+	p.Printfln("Profile %q updated", upCtx.ProfileName)
+	return nil
 }

--- a/cmd/up/profile/view.go
+++ b/cmd/up/profile/view.go
@@ -21,7 +21,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 
-	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -39,9 +39,9 @@ func (c *viewCmd) Run(p pterm.TextPrinter, ctx *kong.Context, upCtx *upbound.Con
 		return nil // nolint:nilerr
 	}
 
-	redacted := make(map[string]config.RedactedProfile)
+	redacted := make(map[string]profile.Redacted)
 	for k, v := range profiles {
-		redacted[k] = config.RedactedProfile{Profile: v}
+		redacted[k] = profile.Redacted{Profile: v}
 	}
 
 	b, err := json.MarshalIndent(redacted, "", "    ")

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -52,12 +52,6 @@ func (c *destroyCmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 
-	// NOTE(tnthornton) we currently only have support for stylized output.
-	pterm.EnableStyling()
-	upterm.DefaultObjPrinter.Pretty = true
-
-	c.confirm()
-
 	upCtx, err := upbound.NewFromFlags(c.Upbound)
 	if err != nil {
 		return err
@@ -91,6 +85,12 @@ func (c *destroyCmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(mgr)
+
+	// NOTE(tnthornton) we currently only have support for stylized output.
+	pterm.EnableStyling()
+	upterm.DefaultObjPrinter.Pretty = true
+
+	c.confirm()
 
 	return nil
 }

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -136,8 +136,8 @@ func (c *destroyCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if c.Kube.Kubeconfig != "" || c.Kube.Context != "" {
 		return c.Kube.GetConfig(), nil
 	}
-	if !upCtx.Profile.IsSpaces() {
-		return nil, fmt.Errorf("destroy is not supported for non-Spaces profile %q", upCtx.ProfileName)
+	if !upCtx.Profile.IsSpace() {
+		return nil, fmt.Errorf("destroy is not supported for non-space profile %q", upCtx.ProfileName)
 	}
 	return upCtx.Profile.GetKubeClientConfig()
 }

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -136,7 +136,7 @@ func (c *destroyCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if c.Kube.Kubeconfig != "" || c.Kube.Context != "" {
 		return c.Kube.GetConfig(), nil
 	}
-	if !upCtx.Profile.IsSpacesProfile() {
+	if !upCtx.Profile.IsSpaces() {
 		return nil, fmt.Errorf("destroy is not supported for non-Spaces profile %q", upCtx.ProfileName)
 	}
 	return upCtx.Profile.GetKubeClientConfig()

--- a/cmd/up/space/flags.go
+++ b/cmd/up/space/flags.go
@@ -9,18 +9,9 @@ import (
 	"os"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"k8s.io/client-go/rest"
 
 	"github.com/upbound/up/internal/input"
-	"github.com/upbound/up/internal/kube"
 )
-
-type kubeFlags struct {
-	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
-
-	// set by AfterApply
-	config *rest.Config
-}
 
 type registryFlags struct {
 	Repository *url.URL `hidden:"" name:"registry-repository" env:"UPBOUND_REGISTRY" default:"us-west1-docker.pkg.dev/orchestration-build/upbound-environments" help:"Set registry for where to pull OCI artifacts from. This is an OCI registry reference, i.e. a URL without the scheme or protocol prefix."`
@@ -33,16 +24,6 @@ type authorizedRegistryFlags struct {
 	TokenFile *os.File `name:"token-file" help:"File containing authentication token."`
 	Username  string   `hidden:"" name:"registry-username" help:"Set the registry username."`
 	Password  string   `hidden:"" name:"registry-password" help:"Set the registry password."`
-}
-
-func (f *kubeFlags) AfterApply() error {
-	restConfig, err := kube.GetKubeConfig(f.Kubeconfig)
-	if err != nil {
-		return err
-	}
-	f.config = restConfig
-
-	return nil
 }
 
 func (p *authorizedRegistryFlags) AfterApply() error {

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -74,8 +74,6 @@ const (
 
 	jsonKey = "_json_key"
 
-	defaultProfileName = "default"
-
 	errReadTokenFile          = "unable to read token file"
 	errReadParametersFile     = "unable to read parameters file"
 	errParseInstallParameters = "unable to parse install parameters"
@@ -268,7 +266,7 @@ func (c *initCmd) createOrUpdateProfile(upCtx *upbound.Context) error {
 	// If profile name was not provided and no default exists, set name to
 	// the default.
 	if upCtx.ProfileName == "" {
-		upCtx.ProfileName = defaultProfileName
+		upCtx.ProfileName = config.DefaultProfileName
 	}
 
 	// Re-initialize active profile for this space.

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -271,7 +271,7 @@ func (c *initCmd) createOrUpdateProfile(upCtx *upbound.Context) error {
 
 	// Re-initialize active profile for this space.
 	profile := config.Profile{
-		Type:        config.SpacesProfileType,
+		Type:        config.SpaceProfileType,
 		Kubeconfig:  c.Kube.Kubeconfig,
 		KubeContext: c.Kube.GetContext(),
 		// Carry over existing config.

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -44,6 +44,7 @@ import (
 	"github.com/upbound/up/internal/install"
 	"github.com/upbound/up/internal/install/helm"
 	"github.com/upbound/up/internal/kube"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/resources"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
@@ -266,12 +267,12 @@ func (c *initCmd) createOrUpdateProfile(upCtx *upbound.Context) error {
 	// If profile name was not provided and no default exists, set name to
 	// the default.
 	if upCtx.ProfileName == "" {
-		upCtx.ProfileName = config.DefaultProfileName
+		upCtx.ProfileName = profile.DefaultName
 	}
 
 	// Re-initialize active profile for this space.
-	profile := config.Profile{
-		Type:        config.SpaceProfileType,
+	profile := profile.Profile{
+		Type:        profile.Space,
 		Kubeconfig:  c.Kube.Kubeconfig,
 		KubeContext: c.Kube.GetContext(),
 		// Carry over existing config.

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -80,7 +80,7 @@ const (
 	errReadParametersFile     = "unable to read parameters file"
 	errParseInstallParameters = "unable to parse install parameters"
 	errCreateImagePullSecret  = "failed to create image pull secret"
-	errFmtCreateNamespace     = "failed to create namespace %s"
+	errFmtCreateNamespace     = "failed to create namespace %q"
 	errUpdateConfig           = "unable to update config file"
 	errUpdateProfile          = "unable to update profile"
 )

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -163,7 +163,7 @@ func (c *upgradeCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if c.Kube.Kubeconfig != "" || c.Kube.Context != "" {
 		return c.Kube.GetConfig(), nil
 	}
-	if !upCtx.Profile.IsSpacesProfile() {
+	if !upCtx.Profile.IsSpaces() {
 		return nil, fmt.Errorf("upgrade is not supported for non-Spaces profile %q", upCtx.ProfileName)
 	}
 	return upCtx.Profile.GetKubeClientConfig()

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -163,8 +163,8 @@ func (c *upgradeCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if c.Kube.Kubeconfig != "" || c.Kube.Context != "" {
 		return c.Kube.GetConfig(), nil
 	}
-	if !upCtx.Profile.IsSpaces() {
-		return nil, fmt.Errorf("upgrade is not supported for non-Spaces profile %q", upCtx.ProfileName)
+	if !upCtx.Profile.IsSpace() {
+		return nil, fmt.Errorf("upgrade is not supported for non-space profile %q", upCtx.ProfileName)
 	}
 	return upCtx.Profile.GetKubeClientConfig()
 }

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pterm/pterm"
 	"helm.sh/helm/v3/pkg/chart"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
 
 	"github.com/upbound/up/internal/config"
@@ -32,6 +33,7 @@ import (
 	"github.com/upbound/up/internal/install"
 	"github.com/upbound/up/internal/install/helm"
 	"github.com/upbound/up/internal/kube"
+	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
 
@@ -44,7 +46,8 @@ const (
 
 // upgradeCmd upgrades Upbound.
 type upgradeCmd struct {
-	Kube     kubeFlags               `embed:""`
+	Upbound  upbound.Flags           `embed:""`
+	Kube     upbound.KubeFlags       `embed:""`
 	Registry authorizedRegistryFlags `embed:""`
 	install.CommonParams
 
@@ -83,14 +86,24 @@ func (c *upgradeCmd) AfterApply(quiet config.QuietFlag) error { //nolint:gocyclo
 	pterm.EnableStyling()
 	upterm.DefaultObjPrinter.Pretty = true
 
-	kClient, err := kubernetes.NewForConfig(c.Kube.config)
+	upCtx, err := upbound.NewFromFlags(c.Upbound)
+	if err != nil {
+		return err
+	}
+
+	kubeconfig, err := c.getKubeconfig(upCtx)
+	if err != nil {
+		return err
+	}
+
+	kClient, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
 		return err
 	}
 	c.kClient = kClient
 	secret := kube.NewSecretApplicator(kClient)
 	c.pullSecret = kube.NewImagePullApplicator(secret)
-	ins, err := helm.NewManager(c.Kube.config,
+	ins, err := helm.NewManager(kubeconfig,
 		spacesChart,
 		c.Registry.Repository,
 		helm.WithNamespace(ns),
@@ -142,6 +155,18 @@ func (c *upgradeCmd) AfterApply(quiet config.QuietFlag) error { //nolint:gocyclo
 	}
 
 	return nil
+}
+
+// getKubeconfig returns the kubeconfig from flags if provided, otherwise the
+// kubeconfig from the active profile.
+func (c *upgradeCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error) {
+	if c.Kube.Kubeconfig != "" || c.Kube.Context != "" {
+		return c.Kube.GetConfig(), nil
+	}
+	if !upCtx.Profile.IsSpacesProfile() {
+		return nil, fmt.Errorf("upgrade is not supported for non-Spaces profile %q", upCtx.ProfileName)
+	}
+	return upCtx.Profile.GetKubeClientConfig()
 }
 
 // Run executes the upgrade command.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,12 +126,12 @@ type Profile struct {
 	BaseConfig map[string]string `json:"base,omitempty"`
 }
 
-func (p Profile) IsSpacesProfile() bool {
+func (p Profile) IsSpaces() bool {
 	return p.Type == SpacesProfileType
 }
 
 func (p Profile) GetKubeClientConfig() (*rest.Config, error) {
-	if !p.IsSpacesProfile() {
+	if !p.IsSpaces() {
 		return nil, fmt.Errorf("kube client not supported for profile type %q", p.Type)
 	}
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -156,7 +156,7 @@ func (p RedactedProfile) MarshalJSON() ([]byte, error) {
 	type profile RedactedProfile
 	pc := profile(p)
 	// Spaces profiles don't have session tokens.
-	if !p.IsSpacesProfile() {
+	if !p.IsSpaces() {
 		s := "NONE"
 		if pc.Session != "" {
 			s = "REDACTED"
@@ -168,7 +168,7 @@ func (p RedactedProfile) MarshalJSON() ([]byte, error) {
 
 // checkProfile ensures a profile does not violate constraints.
 func checkProfile(p Profile) error {
-	if (!p.IsSpacesProfile() && p.ID == "") || p.Type == "" {
+	if (!p.IsSpaces() && p.ID == "") || p.Type == "" {
 		return errors.New(errInvalidProfile)
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,8 @@ import (
 const (
 	ConfigDir  = ".up"
 	ConfigFile = "config.json"
+
+	DefaultProfileName = "default"
 )
 
 const (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,9 +94,9 @@ type ProfileType string
 
 // Types of profiles.
 const (
-	UserProfileType   ProfileType = "user"
-	TokenProfileType  ProfileType = "token"
-	SpacesProfileType ProfileType = "spaces"
+	UserProfileType  ProfileType = "user"
+	TokenProfileType ProfileType = "token"
+	SpaceProfileType ProfileType = "space"
 )
 
 // A Profile is a set of credentials
@@ -128,14 +128,14 @@ type Profile struct {
 	BaseConfig map[string]string `json:"base,omitempty"`
 }
 
-func (p Profile) IsSpaces() bool {
-	return p.Type == SpacesProfileType
+func (p Profile) IsSpace() bool {
+	return p.Type == SpaceProfileType
 }
 
 // GetKubeClientConfig returns a *rest.Config loaded from p.Kubeconfig and
-// p.KubeContext. It returns an error if p.IsSpaces() is false.
+// p.KubeContext. It returns an error if p.IsSpace() is false.
 func (p Profile) GetKubeClientConfig() (*rest.Config, error) {
-	if !p.IsSpaces() {
+	if !p.IsSpace() {
 		return nil, fmt.Errorf("kube client not supported for profile type %q", p.Type)
 	}
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -159,8 +159,8 @@ type RedactedProfile struct {
 func (p RedactedProfile) MarshalJSON() ([]byte, error) {
 	type profile RedactedProfile
 	pc := profile(p)
-	// Spaces profiles don't have session tokens.
-	if !p.IsSpaces() {
+	// Space profiles don't have session tokens.
+	if !p.IsSpace() {
 		s := "NONE"
 		if pc.Session != "" {
 			s = "REDACTED"
@@ -172,7 +172,7 @@ func (p RedactedProfile) MarshalJSON() ([]byte, error) {
 
 // checkProfile ensures a profile does not violate constraints.
 func checkProfile(p Profile) error {
-	if (!p.IsSpaces() && p.ID == "") || p.Type == "" {
+	if (!p.IsSpace() && p.ID == "") || p.Type == "" {
 		return errors.New(errInvalidProfile)
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,12 +111,12 @@ type Profile struct {
 	// Account is the default account to use when this profile is selected.
 	Account string `json:"account,omitempty"`
 
-	// Kubeconfig is the kubeconfig file to use when this profile is selected.
-	// Used when Type is SpacesProfileType.
+	// Kubeconfig is the kubeconfig file path that GetKubeClientConfig() will
+	// read. If empty, it refers to client-go's default kubeconfig location.
 	Kubeconfig string `json:"kubeconfig,omitempty"`
 
-	// KubeContext is the kubeconfig context to use when this profile is
-	// selected. Used when Type is SpacesProfileType.
+	// KubeContext is the context within Kubeconfig that GetKubeClientConfig()
+	// will read. If empty, it refers to the default context.
 	KubeContext string `json:"kube_context,omitempty"`
 
 	// BaseConfig represent persisted settings for this profile.
@@ -130,6 +130,8 @@ func (p Profile) IsSpaces() bool {
 	return p.Type == SpacesProfileType
 }
 
+// GetKubeClientConfig returns a *rest.Config loaded from p.Kubeconfig and
+// p.KubeContext. It returns an error if p.IsSpaces() is false.
 func (p Profile) GetKubeClientConfig() (*rest.Config, error) {
 	if !p.IsSpaces() {
 		return nil, fmt.Errorf("kube client not supported for profile type %q", p.Type)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,18 +21,20 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/upbound/up/internal/profile"
 )
 
 func TestAddOrUpdateUpboundProfile(t *testing.T) {
 	name := "cool-profile"
-	profOne := Profile{
+	profOne := profile.Profile{
 		ID:      "cool-user",
-		Type:    UserProfileType,
+		Type:    profile.User,
 		Account: "cool-org",
 	}
-	profTwo := Profile{
+	profTwo := profile.Profile{
 		ID:      "cool-user",
-		Type:    UserProfileType,
+		Type:    profile.User,
 		Account: "other-org",
 	}
 
@@ -40,7 +42,7 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 		reason string
 		name   string
 		cfg    *Config
-		add    Profile
+		add    profile.Profile
 		want   *Config
 		err    error
 	}{
@@ -51,7 +53,7 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 			add:    profOne,
 			want: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{name: profOne},
+					Profiles: map[string]profile.Profile{name: profOne},
 				},
 			},
 		},
@@ -60,13 +62,13 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 			name:   name,
 			cfg: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{name: profOne},
+					Profiles: map[string]profile.Profile{name: profOne},
 				},
 			},
 			add: profTwo,
 			want: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{name: profTwo},
+					Profiles: map[string]profile.Profile{name: profTwo},
 				},
 			},
 		},
@@ -74,24 +76,24 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 			reason: "Adding an invalid profile should cause an error.",
 			name:   name,
 			cfg:    &Config{},
-			add:    Profile{},
+			add:    profile.Profile{},
 			want:   &Config{},
-			err:    errors.New(errInvalidProfile),
+			err:    errors.New("profile is not valid"),
 		},
 		"AddNewSpaceProfile": {
 			reason: "Adding a new space profile to an empty Config should not cause an error.",
 			name:   "cool-profile",
 			cfg:    &Config{},
-			add: Profile{
-				Type:        SpaceProfileType,
+			add: profile.Profile{
+				Type:        profile.Space,
 				Kubeconfig:  "cool-config",
 				KubeContext: "cool-context",
 			},
 			want: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{
+					Profiles: map[string]profile.Profile{
 						"cool-profile": {
-							Type:        SpaceProfileType,
+							Type:        profile.Space,
 							Kubeconfig:  "cool-config",
 							KubeContext: "cool-context",
 						},
@@ -104,25 +106,25 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 			name:   "cool-profile",
 			cfg: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{
+					Profiles: map[string]profile.Profile{
 						"cool-profile": {
-							Type:        SpaceProfileType,
+							Type:        profile.Space,
 							Kubeconfig:  "cool-config",
 							KubeContext: "cool-context",
 						},
 					},
 				},
 			},
-			add: Profile{
-				Type:        SpaceProfileType,
+			add: profile.Profile{
+				Type:        profile.Space,
 				Kubeconfig:  "other-config",
 				KubeContext: "other-context",
 			},
 			want: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{
+					Profiles: map[string]profile.Profile{
 						"cool-profile": {
-							Type:        SpaceProfileType,
+							Type:        profile.Space,
 							Kubeconfig:  "other-config",
 							KubeContext: "other-context",
 						},
@@ -146,9 +148,9 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 
 func TestGetDefaultUpboundProfile(t *testing.T) {
 	name := "cool-profile"
-	profOne := Profile{
+	profOne := profile.Profile{
 		ID:      "cool-user",
-		Type:    UserProfileType,
+		Type:    profile.User,
 		Account: "cool-org",
 	}
 
@@ -156,13 +158,13 @@ func TestGetDefaultUpboundProfile(t *testing.T) {
 		reason string
 		name   string
 		cfg    *Config
-		want   Profile
+		want   profile.Profile
 		err    error
 	}{
 		"ErrorNoDefault": {
 			reason: "If no default defined an error should be returned.",
 			cfg:    &Config{},
-			want:   Profile{},
+			want:   profile.Profile{},
 			err:    errors.New(errNoDefaultSpecified),
 		},
 		"ErrorDefaultNotExist": {
@@ -172,7 +174,7 @@ func TestGetDefaultUpboundProfile(t *testing.T) {
 					Default: "test",
 				},
 			},
-			want: Profile{},
+			want: profile.Profile{},
 			err:  errors.New(errDefaultNotExist),
 		},
 		"Successful": {
@@ -181,7 +183,7 @@ func TestGetDefaultUpboundProfile(t *testing.T) {
 			cfg: &Config{
 				Upbound: Upbound{
 					Default:  "cool-profile",
-					Profiles: map[string]Profile{name: profOne},
+					Profiles: map[string]profile.Profile{name: profOne},
 				},
 			},
 			want: profOne,
@@ -205,9 +207,9 @@ func TestGetDefaultUpboundProfile(t *testing.T) {
 
 func TestGetUpboundProfile(t *testing.T) {
 	name := "cool-profile"
-	profOne := Profile{
+	profOne := profile.Profile{
 		ID:      "cool-user",
-		Type:    UserProfileType,
+		Type:    profile.User,
 		Account: "cool-org",
 	}
 
@@ -215,14 +217,14 @@ func TestGetUpboundProfile(t *testing.T) {
 		reason string
 		name   string
 		cfg    *Config
-		want   Profile
+		want   profile.Profile
 		err    error
 	}{
 		"ErrorProfileNotExist": {
 			reason: "If profile does not exist an error should be returned.",
 			name:   name,
 			cfg:    &Config{},
-			want:   Profile{},
+			want:   profile.Profile{},
 			err:    errors.Errorf(errProfileNotFoundFmt, "cool-profile"),
 		},
 		"Successful": {
@@ -230,7 +232,7 @@ func TestGetUpboundProfile(t *testing.T) {
 			name:   "cool-profile",
 			cfg: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{name: profOne},
+					Profiles: map[string]profile.Profile{name: profOne},
 				},
 			},
 			want: profOne,
@@ -251,8 +253,8 @@ func TestGetUpboundProfile(t *testing.T) {
 
 func TestSetDefaultUpboundProfile(t *testing.T) {
 	name := "cool-user"
-	profOne := Profile{
-		Type:    UserProfileType,
+	profOne := profile.Profile{
+		Type:    profile.User,
 		Account: "cool-org",
 	}
 
@@ -273,7 +275,7 @@ func TestSetDefaultUpboundProfile(t *testing.T) {
 			name:   "cool-user",
 			cfg: &Config{
 				Upbound: Upbound{
-					Profiles: map[string]Profile{name: profOne},
+					Profiles: map[string]profile.Profile{name: profOne},
 				},
 			},
 		},
@@ -290,13 +292,13 @@ func TestSetDefaultUpboundProfile(t *testing.T) {
 
 func TestGetUpboundProfiles(t *testing.T) {
 	nameOne := "cool-user"
-	profOne := Profile{
-		Type:    UserProfileType,
+	profOne := profile.Profile{
+		Type:    profile.User,
 		Account: "cool-org",
 	}
 	nameTwo := "cool-user2"
-	profTwo := Profile{
-		Type:    UserProfileType,
+	profTwo := profile.Profile{
+		Type:    profile.User,
 		Account: "cool-org2",
 	}
 
@@ -305,7 +307,7 @@ func TestGetUpboundProfiles(t *testing.T) {
 	}
 	type want struct {
 		err      error
-		profiles map[string]Profile
+		profiles map[string]profile.Profile
 	}
 
 	cases := map[string]struct {
@@ -327,7 +329,7 @@ func TestGetUpboundProfiles(t *testing.T) {
 			args: args{
 				cfg: &Config{
 					Upbound: Upbound{
-						Profiles: map[string]Profile{
+						Profiles: map[string]profile.Profile{
 							nameOne: profOne,
 							nameTwo: profTwo,
 						},
@@ -335,7 +337,7 @@ func TestGetUpboundProfiles(t *testing.T) {
 				},
 			},
 			want: want{
-				profiles: map[string]Profile{
+				profiles: map[string]profile.Profile{
 					nameOne: profOne,
 					nameTwo: profTwo,
 				},
@@ -358,16 +360,16 @@ func TestGetUpboundProfiles(t *testing.T) {
 
 func TestGetBaseConfig(t *testing.T) {
 	nameOne := "cool-user"
-	profOne := Profile{
-		Type:    UserProfileType,
+	profOne := profile.Profile{
+		Type:    profile.User,
 		Account: "cool-org",
 		BaseConfig: map[string]string{
 			"key": "value",
 		},
 	}
 	nameTwo := "cool-user2"
-	profTwo := Profile{
-		Type:    UserProfileType,
+	profTwo := profile.Profile{
+		Type:    profile.User,
 		Account: "cool-org2",
 	}
 
@@ -401,7 +403,7 @@ func TestGetBaseConfig(t *testing.T) {
 				profile: nameOne,
 				cfg: &Config{
 					Upbound: Upbound{
-						Profiles: map[string]Profile{
+						Profiles: map[string]profile.Profile{
 							nameOne: profOne,
 							nameTwo: profTwo,
 						},
@@ -429,13 +431,13 @@ func TestGetBaseConfig(t *testing.T) {
 
 func TestAddToBaseConfig(t *testing.T) {
 	nameOne := "cool-user"
-	profOne := Profile{
-		Type:    UserProfileType,
+	profOne := profile.Profile{
+		Type:    profile.User,
 		Account: "cool-org",
 	}
 	nameTwo := "cool-user2"
-	profTwo := Profile{
-		Type:    UserProfileType,
+	profTwo := profile.Profile{
+		Type:    profile.User,
 		Account: "cool-org2",
 	}
 
@@ -473,7 +475,7 @@ func TestAddToBaseConfig(t *testing.T) {
 				value:   "v",
 				cfg: &Config{
 					Upbound: Upbound{
-						Profiles: map[string]Profile{
+						Profiles: map[string]profile.Profile{
 							nameOne: profOne,
 							nameTwo: profTwo,
 						},
@@ -536,9 +538,9 @@ func TestBaseToJSON(t *testing.T) {
 				profile: exists,
 				cfg: &Config{
 					Upbound: Upbound{
-						Profiles: map[string]Profile{
+						Profiles: map[string]profile.Profile{
 							exists: {
-								Type:    UserProfileType,
+								Type:    profile.User,
 								Account: "account",
 								BaseConfig: map[string]string{
 									"k": "v",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,58 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 			want:   &Config{},
 			err:    errors.New(errInvalidProfile),
 		},
+		"AddNewSpacesProfile": {
+			reason: "Adding a new spaces profile to an empty Config should not cause an error.",
+			name:   "cool-profile",
+			cfg:    &Config{},
+			add: Profile{
+				Type:        SpacesProfileType,
+				Kubeconfig:  "cool-config",
+				KubeContext: "cool-context",
+			},
+			want: &Config{
+				Upbound: Upbound{
+					Profiles: map[string]Profile{
+						"cool-profile": {
+							Type:        SpacesProfileType,
+							Kubeconfig:  "cool-config",
+							KubeContext: "cool-context",
+						},
+					},
+				},
+			},
+		},
+		"UpdateExistingSpacesProfile": {
+			reason: "Updating an existing spaces profile in the Config should not cause an error.",
+			name:   "cool-profile",
+			cfg: &Config{
+				Upbound: Upbound{
+					Profiles: map[string]Profile{
+						"cool-profile": {
+							Type:        SpacesProfileType,
+							Kubeconfig:  "cool-config",
+							KubeContext: "cool-context",
+						},
+					},
+				},
+			},
+			add: Profile{
+				Type:        SpacesProfileType,
+				Kubeconfig:  "other-config",
+				KubeContext: "other-context",
+			},
+			want: &Config{
+				Upbound: Upbound{
+					Profiles: map[string]Profile{
+						"cool-profile": {
+							Type:        SpacesProfileType,
+							Kubeconfig:  "other-config",
+							KubeContext: "other-context",
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,12 +78,12 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 			want:   &Config{},
 			err:    errors.New(errInvalidProfile),
 		},
-		"AddNewSpacesProfile": {
-			reason: "Adding a new spaces profile to an empty Config should not cause an error.",
+		"AddNewSpaceProfile": {
+			reason: "Adding a new space profile to an empty Config should not cause an error.",
 			name:   "cool-profile",
 			cfg:    &Config{},
 			add: Profile{
-				Type:        SpacesProfileType,
+				Type:        SpaceProfileType,
 				Kubeconfig:  "cool-config",
 				KubeContext: "cool-context",
 			},
@@ -91,7 +91,7 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 				Upbound: Upbound{
 					Profiles: map[string]Profile{
 						"cool-profile": {
-							Type:        SpacesProfileType,
+							Type:        SpaceProfileType,
 							Kubeconfig:  "cool-config",
 							KubeContext: "cool-context",
 						},
@@ -99,14 +99,14 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 				},
 			},
 		},
-		"UpdateExistingSpacesProfile": {
-			reason: "Updating an existing spaces profile in the Config should not cause an error.",
+		"UpdateExistingSpaceProfile": {
+			reason: "Updating an existing space profile in the Config should not cause an error.",
 			name:   "cool-profile",
 			cfg: &Config{
 				Upbound: Upbound{
 					Profiles: map[string]Profile{
 						"cool-profile": {
-							Type:        SpacesProfileType,
+							Type:        SpaceProfileType,
 							Kubeconfig:  "cool-config",
 							KubeContext: "cool-context",
 						},
@@ -114,7 +114,7 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 				},
 			},
 			add: Profile{
-				Type:        SpacesProfileType,
+				Type:        SpaceProfileType,
 				Kubeconfig:  "other-config",
 				KubeContext: "other-context",
 			},
@@ -122,7 +122,7 @@ func TestAddOrUpdateUpboundProfile(t *testing.T) {
 				Upbound: Upbound{
 					Profiles: map[string]Profile{
 						"cool-profile": {
-							Type:        SpacesProfileType,
+							Type:        SpaceProfileType,
 							Kubeconfig:  "other-config",
 							KubeContext: "other-context",
 						},

--- a/internal/credhelper/credhelper.go
+++ b/internal/credhelper/credhelper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker-credential-helpers/credentials"
 
 	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 )
 
 const (
@@ -118,7 +119,7 @@ func (h *Helper) Get(serverURL string) (string, string, error) {
 	if err != nil {
 		return "", "", errors.Wrap(err, errExtractConfig)
 	}
-	var p config.Profile
+	var p profile.Profile
 	if h.profile == "" {
 		_, p, err = conf.GetDefaultUpboundProfile()
 		if err != nil {

--- a/internal/credhelper/credhelper_test.go
+++ b/internal/credhelper/credhelper_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 )
 
 // TODO(hasheddan): these tests are testing through to the underlying config
@@ -150,7 +151,7 @@ func TestGet(t *testing.T) {
 					GetConfigFn: func() (*config.Config, error) {
 						return &config.Config{
 							Upbound: config.Upbound{
-								Profiles: map[string]config.Profile{
+								Profiles: map[string]profile.Profile{
 									testProfile: {
 										Session: testSecret,
 									},

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Type is a type of Upbound profile.
+type Type string
+
+const (
+	// Types of profiles.
+	User  Type = "user"
+	Token Type = "token"
+	Space Type = "space"
+
+	DefaultName = "default"
+
+	errInvalidProfile = "profile is not valid"
+)
+
+// A Profile is a set of credentials
+type Profile struct {
+	// ID is either a username, email, or token.
+	ID string `json:"id,omitempty"`
+
+	// Type is the type of the profile.
+	Type Type `json:"type"`
+
+	// Session is a session token used to authenticate to Upbound.
+	Session string `json:"session,omitempty"`
+
+	// Account is the default account to use when this profile is selected.
+	Account string `json:"account,omitempty"`
+
+	// Kubeconfig is the kubeconfig file path that GetKubeClientConfig() will
+	// read. If empty, it refers to client-go's default kubeconfig location.
+	Kubeconfig string `json:"kubeconfig,omitempty"`
+
+	// KubeContext is the context within Kubeconfig that GetKubeClientConfig()
+	// will read. If empty, it refers to the default context.
+	KubeContext string `json:"kube_context,omitempty"`
+
+	// BaseConfig represent persisted settings for this profile.
+	// For example:
+	// * flags
+	// * environment variables
+	BaseConfig map[string]string `json:"base,omitempty"`
+}
+
+// Validate returns an error if the profile is invalid.
+func (p Profile) Validate() error {
+	if (!p.IsSpace() && p.ID == "") || p.Type == "" {
+		return errors.New(errInvalidProfile)
+	}
+	return nil
+}
+
+func (p Profile) IsSpace() bool {
+	return p.Type == Space
+}
+
+// GetKubeClientConfig returns a *rest.Config loaded from p.Kubeconfig and
+// p.KubeContext. It returns an error if p.IsSpace() is false.
+func (p Profile) GetKubeClientConfig() (*rest.Config, error) {
+	if !p.IsSpace() {
+		return nil, fmt.Errorf("kube client not supported for profile type %q", p.Type)
+	}
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = p.Kubeconfig
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules,
+		&clientcmd.ConfigOverrides{CurrentContext: p.KubeContext},
+	).ClientConfig()
+}
+
+// Redacted embeds a Upbound Profile for the sole purpose of redacting
+// sensitive information.
+type Redacted struct {
+	Profile
+}
+
+// MarshalJSON overrides the session field with `REDACTED` so as not to leak
+// sensitive information. We're using an explicit copy here instead of updating
+// the underlying Profile struct so as to not modifying the internal state of
+// the struct by accident.
+func (p Redacted) MarshalJSON() ([]byte, error) {
+	type profile Redacted
+	pc := profile(p)
+	// Space profiles don't have session tokens.
+	if !p.IsSpace() {
+		s := "NONE"
+		if pc.Session != "" {
+			s = "REDACTED"
+		}
+		pc.Session = s
+	}
+	return json.Marshal(&pc)
+}

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -55,23 +55,6 @@ const (
 	errProfileNotFoundFmt = "profile not found with identifier: %s"
 )
 
-// Flags are common flags used by commands that interact with Upbound.
-type Flags struct {
-	// Optional
-	Domain  *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain." json:"domain,omitempty"`
-	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command." predictor:"profiles" json:"profile,omitempty"`
-	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command." json:"account,omitempty"`
-
-	// Insecure
-	InsecureSkipTLSVerify bool `env:"UP_INSECURE_SKIP_TLS_VERIFY" help:"[INSECURE] Skip verifying TLS certificates." json:"insecureSkipTLSVerify,omitempty"`
-	Debug                 int  `short:"d" env:"UP_DEBUG" name:"debug" type:"counter" help:"[INSECURE] Run with debug logging. Repeat to increase verbosity. Output might contain confidential data like tokens." json:"debug,omitempty"`
-
-	// Hidden
-	APIEndpoint      *url.URL `env:"OVERRIDE_API_ENDPOINT" hidden:"" name:"override-api-endpoint" help:"Overrides the default API endpoint." json:"apiEndpoint,omitempty"`
-	ProxyEndpoint    *url.URL `env:"OVERRIDE_PROXY_ENDPOINT" hidden:"" name:"override-proxy-endpoint" help:"Overrides the default proxy endpoint." json:"proxyEndpoint,omitempty"`
-	RegistryEndpoint *url.URL `env:"OVERRIDE_REGISTRY_ENDPOINT" hidden:"" name:"override-registry-endpoint" help:"Overrides the default registry endpoint." json:"registryEndpoint,omitempty"`
-}
-
 // Context includes common data that Upbound consumers may utilize.
 type Context struct {
 	ProfileName string

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -30,6 +30,7 @@ import (
 	"github.com/upbound/up-sdk-go"
 
 	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 )
 
 const (
@@ -58,7 +59,7 @@ const (
 // Context includes common data that Upbound consumers may utilize.
 type Context struct {
 	ProfileName string
-	Profile     config.Profile
+	Profile     profile.Profile
 	Token       string
 	Account     string
 	Domain      *url.URL
@@ -123,7 +124,7 @@ func NewFromFlags(f Flags, opts ...Option) (*Context, error) { //nolint:gocyclo
 
 	// If profile identifier is not provided, use the default, or empty if the
 	// default cannot be obtained.
-	c.Profile = config.Profile{}
+	c.Profile = profile.Profile{}
 	if f.Profile == "" {
 		if name, p, err := c.Cfg.GetDefaultUpboundProfile(); err == nil {
 			c.Profile = p

--- a/internal/upbound/context_test.go
+++ b/internal/upbound/context_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/afero"
 
 	"github.com/upbound/up/internal/config"
+	"github.com/upbound/up/internal/profile"
 )
 
 var (
@@ -134,7 +135,7 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:      withURL("https://api.upbound.io"),
 					Cfg:              &config.Config{},
 					Domain:           withURL("https://upbound.io"),
-					Profile:          config.Profile{},
+					Profile:          profile.Profile{},
 					ProxyEndpoint:    withURL("https://proxy.upbound.io/v1/controlPlanes"),
 					RegistryEndpoint: withURL("https://xpkg.upbound.io"),
 				},
@@ -169,7 +170,7 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:      withURL("https://api.upbound.io"),
 					Cfg:              &config.Config{},
 					Domain:           withURL("https://upbound.io"),
-					Profile:          config.Profile{},
+					Profile:          profile.Profile{},
 					ProxyEndpoint:    withURL("https://proxy.upbound.io/v1/controlPlanes"),
 					RegistryEndpoint: withURL("https://xpkg.upbound.io"),
 				},
@@ -191,9 +192,9 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:           withURL("https://api.upbound.io"),
 					Domain:                withURL("https://upbound.io"),
 					InsecureSkipTLSVerify: false,
-					Profile: config.Profile{
+					Profile: profile.Profile{
 						ID:      "someone@upbound.io",
-						Type:    config.UserProfileType,
+						Type:    profile.User,
 						Session: "a token",
 						Account: "",
 					},
@@ -219,9 +220,9 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:           withURL("https://api.local.upbound.io"),
 					Domain:                withURL("https://local.upbound.io"),
 					InsecureSkipTLSVerify: true,
-					Profile: config.Profile{
+					Profile: profile.Profile{
 						ID:      "someone@upbound.io",
-						Type:    config.UserProfileType,
+						Type:    profile.User,
 						Session: "a token",
 						Account: "",
 						BaseConfig: map[string]string{
@@ -257,9 +258,9 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:           withURL("http://not.a.url"),
 					Domain:                withURL("http://a.domain.org"),
 					InsecureSkipTLSVerify: true,
-					Profile: config.Profile{
+					Profile: profile.Profile{
 						ID:      "someone@upbound.io",
-						Type:    config.UserProfileType,
+						Type:    profile.User,
 						Session: "a token",
 						Account: "",
 						BaseConfig: map[string]string{
@@ -288,7 +289,7 @@ func TestNewFromFlags(t *testing.T) {
 					APIEndpoint:      withURL("https://api.upbound.io"),
 					Cfg:              &config.Config{},
 					Domain:           withURL("https://upbound.io"),
-					Profile:          config.Profile{},
+					Profile:          profile.Profile{},
 					ProxyEndpoint:    withURL("https://proxy.upbound.io/v1/controlPlanes"),
 					RegistryEndpoint: withURL("https://xpkg.upbound.io"),
 					DebugLevel:       3,

--- a/internal/upbound/flags.go
+++ b/internal/upbound/flags.go
@@ -1,0 +1,92 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upbound
+
+import (
+	"net/url"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Flags are common flags used by commands that interact with Upbound.
+type Flags struct {
+	// Optional
+	Domain  *url.URL `env:"UP_DOMAIN" default:"https://upbound.io" help:"Root Upbound domain." json:"domain,omitempty"`
+	Profile string   `env:"UP_PROFILE" help:"Profile used to execute command." predictor:"profiles" json:"profile,omitempty"`
+	Account string   `short:"a" env:"UP_ACCOUNT" help:"Account used to execute command." json:"account,omitempty"`
+
+	// Insecure
+	InsecureSkipTLSVerify bool `env:"UP_INSECURE_SKIP_TLS_VERIFY" help:"[INSECURE] Skip verifying TLS certificates." json:"insecureSkipTLSVerify,omitempty"`
+	Debug                 int  `short:"d" env:"UP_DEBUG" name:"debug" type:"counter" help:"[INSECURE] Run with debug logging. Repeat to increase verbosity. Output might contain confidential data like tokens." json:"debug,omitempty"`
+
+	// Hidden
+	APIEndpoint      *url.URL `env:"OVERRIDE_API_ENDPOINT" hidden:"" name:"override-api-endpoint" help:"Overrides the default API endpoint." json:"apiEndpoint,omitempty"`
+	ProxyEndpoint    *url.URL `env:"OVERRIDE_PROXY_ENDPOINT" hidden:"" name:"override-proxy-endpoint" help:"Overrides the default proxy endpoint." json:"proxyEndpoint,omitempty"`
+	RegistryEndpoint *url.URL `env:"OVERRIDE_REGISTRY_ENDPOINT" hidden:"" name:"override-registry-endpoint" help:"Overrides the default registry endpoint." json:"registryEndpoint,omitempty"`
+}
+
+type KubeFlags struct {
+	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
+	Context    string `name:"kubecontext" help:"Override default kubeconfig context."`
+
+	// set by AfterApply
+	config  *rest.Config
+	context string
+}
+
+func (f *KubeFlags) AfterApply() error {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = f.Kubeconfig
+	loader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules,
+		&clientcmd.ConfigOverrides{CurrentContext: f.Context},
+	)
+
+	f.context = f.Context
+	if f.context == "" {
+		// Get the name of the default context so we can set it explicitly.
+		rawConfig, err := loader.RawConfig()
+		if err != nil {
+			return err
+		}
+		f.context = rawConfig.CurrentContext
+	}
+
+	restConfig, err := loader.ClientConfig()
+	if err != nil {
+		return err
+	}
+	f.config = restConfig
+
+	return nil
+}
+
+// GetConfig returns the *rest.Config from KubeFlags. Returns nil unless
+// AfterApply has been called.
+func (f *KubeFlags) GetConfig() *rest.Config {
+	return f.config
+}
+
+// GetContext returns the kubeconfig context from KubeFlags. Returns empty
+// string unless AfterApply has been called. Returns KubeFlags.Context if it's
+// defined, otherwise the name of the default context in the config resolved
+// from KubeFlags.Kubeconfig.
+// NOTE(branden): This ensures that a profile created from this context will
+// continue to work with the same cluster if the kubeconfig's default context
+// is changed.
+func (f *KubeFlags) GetContext() string {
+	return f.context
+}

--- a/internal/upbound/flags.go
+++ b/internal/upbound/flags.go
@@ -39,8 +39,12 @@ type Flags struct {
 }
 
 type KubeFlags struct {
+	// Kubeconfig is the kubeconfig file path to read. If empty, it refers to
+	// client-go's default kubeconfig location.
 	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
-	Context    string `name:"kubecontext" help:"Override default kubeconfig context."`
+	// Context is the context within Kubeconfig to read. If empty, it refers
+	// to the default context.
+	Context string `name:"kubecontext" help:"Override default kubeconfig context."`
 
 	// set by AfterApply
 	config  *rest.Config


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This adds support for profiles that work with a Space.
* `up space init` behaves the same, except it updates the active profile to be a Spaces profile after a successful install, using the kubeconfig it was provided (or default kubeconfig).
* `up space upgrade` and `destroy` build a kubeconfig from the active Spaces profile if `--kubeconfig` and `--kubecontext` flags are not provided. If kube flags are not provided and the active profile is not a Spaces profile, they will exit with an error.
* New command `up profile set space` updates the active profile to be a Spaces profile without needing to install Spaces via `up space init` first. It uses the default kubeconfig and context unless `--kubeconfig` or `--kubecontext` are provided.
* All commands that assume a non-Spaces profile will exit with an error if active profile is for Spaces.

Fixes #373

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

```
branden@crateria kind % up profile list
No profiles found

branden@crateria kind % kubectl config current-context
kind-kind
branden@crateria kind % up space init --token-file="${SPACES_TOKEN_PATH}" "v${SPACES_VERSION}" \
  --set "ingress.host=${SPACES_ROUTER_HOST}" \
  --set "clusterType=${SPACES_CLUSTER_TYPE}" \
  --set "account=${UPBOUND_ACCOUNT}"
 INFO  Setting defaults for vanilla Kubernetes (type kind)
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm

Would you like to install them now? [y/N]: Yes

  √   [1/5]: Installing cert-manager
  √   [2/5]: Installing universal-crossplane
  √   [3/5]: Installing ingress-nginx
  √   [4/5]: Installing provider-kubernetes
  √   [5/5]: Installing provider-helm
 INFO  Required prerequisites met!
 INFO  Proceeding with Upbound Spaces installation...
  √   [1/3]: Creating pull secret upbound-pull-secret
  √   [2/3]: Initializing Space components
  √   [3/3]: Starting Space Components
  🙌  Your Upbound Space is Ready!

  👀  Next Steps 👇

👉 Check out Upbound Spaces docs @ https://docs.upbound.io/concepts/upbound-spaces
branden@crateria kind % up profile list
CURRENT   NAME      TYPE     ACCOUNT   KUBECONFIG   KUBECONTEXT
*         default   spaces                          kind-kind

branden@crateria kind % up profile view
{
    "default": {
        "type": "spaces",
        "kube_context": "kind-kind"
    }
}
branden@crateria kind % kubectl config use-context kind-kuttl-test # set default kubecontext to an old context for a nonexistent cluster to demonstrate that the profile doesn't depend on the default kubecontext
Switched to context "kind-kuttl-test".
branden@crateria kind % up space upgrade --token-file="${SPACES_TOKEN_PATH}" "v${SPACES_VERSION}"

  √   Upgrading Space from v1.0.1 to v1.0.1

branden@crateria kind % up ctp list
up: error: controlplane.listCmd.Run(): list is not supported for Spaces profile "default"
branden@crateria kind % up ctp get foo
up: error: controlplane.getCmd.Run(): get is not supported for Spaces profile "default"
branden@crateria kind % up ctp kubeconfig get --token=whatever foo
up: error: kubeconfig.getCmd.Run(): get is not supported for Spaces profile "default"
branden@crateria kind % up ctp connect foo bar
up: error: controlplane.connectCmd.Run(): connect is not supported for Spaces profile "default"
branden@crateria kind % up ctp create foo --configuration-name=foo
up: error: controlplane.createCmd.Run(): create is not supported for Spaces profile "default"
branden@crateria kind % up ctp pull-secret create
up: error: pullsecret.createCmd.AfterApply(): create is not supported for Spaces profile "default"
branden@crateria kind % up login --token=$UP_TOKEN
3122e6b9-78c3-4264-995f-068364b00051 logged in
branden@crateria kind % up profile list
CURRENT   NAME      TYPE    ACCOUNT   KUBECONFIG   KUBECONTEXT
*         default   token   branden

branden@crateria kind % up profile view
{
    "default": {
        "id": "3122e6b9-78c3-4264-995f-068364b00051",
        "type": "token",
        "session": "REDACTED",
        "account": "branden"
    }
}
branden@crateria kind % up ctp list
up: error: controlplane.listCmd.Run(): Forbidden: {"message":"branden is not an organization and only organizations can manage control planes"}{"controlPlanes":[],"count":0,"page":0,"size":100}
branden@crateria kind % up space upgrade --token-file="${SPACES_TOKEN_PATH}" "v${SPACES_VERSION}"

up: error: space.upgradeCmd.AfterApply(): upgrade is not supported for non-Spaces profile "default"
branden@crateria kind % up space destroy
up: error: space.destroyCmd.AfterApply(): destroy is not supported for non-Spaces profile "default"
branden@crateria kind % up profile set space --kubecontext kind-kind
branden@crateria kind % up profile list
CURRENT   NAME      TYPE     ACCOUNT   KUBECONFIG   KUBECONTEXT
*         default   spaces                          kind-kind

branden@crateria kind % up profile view
{
    "default": {
        "type": "spaces",
        "kube_context": "kind-kind"
    }
}
branden@crateria kind % up space destroy

******************** DESTRUCTIVE COMMAND ********************
********************* DATA-LOSS WARNING *********************

 WARNING  Destroying Spaces is a destructive command that will destroy data and orphan resources.
 WARNING  Before proceeding ensure that Managed Resources in Control Planes have been deleted.
 WARNING  All Spaces components including Control Planes will be destroyed.

 WARNING  If you want to retain data, abort and run 'up space destroy --orphan'

To proceed, type: "CONFIRMED": CONFIRMED
branden@crateria kind % echo $?
0
branden@crateria kind %
```
