### PR TITLE
fix auth annotation not being enabled on v1

### DIFF
--- a/internal/xpkg/build.go
+++ b/internal/xpkg/build.go
@@ -197,39 +197,48 @@ func (b *Builder) Build(ctx context.Context, opts ...BuildOpt) (v1.Image, runtim
 		linter = NewFunctionLinter()
 	case pkgmetav1.ProviderKind:
 		if b.ab != nil { // if we have an auth.yaml file
+			authGroup := ""
 			if p, ok := meta.(*v1alpha1.Provider); ok {
-				// if has annotation auth.upbound.io/group then look for the object
+				if group, ok := p.ObjectMeta.Annotations[authMetaAnno]; ok {
+					authGroup = group
+				}
+			}
+			if p, ok := meta.(*pkgmetav1.Provider); ok {
+				if group, ok := p.ObjectMeta.Annotations[authMetaAnno]; ok {
+					authGroup = group
+				}
+			}
+
+			if authGroup != "" {
+				// if we found an annotation auth.upbound.io/group then look for the object
 				// specified there like aws.upbound.io and annotate that with auth.upbound.io/config
 				// and embed the contents of the auth.yaml file
-				if group, ok := p.ObjectMeta.Annotations[authMetaAnno]; ok {
-					ar, err := b.ab.Init(ctx)
-					if err != nil {
-						return nil, nil, errors.Wrap(err, errParseAuth)
-					}
-
-					// validate the auth.yaml file
-					var auth AuthExtension
-					if err := yaml.NewDecoder(ar).Decode(&auth); err != nil {
-						return nil, nil, errors.Wrap(err, errParseAuth)
-					}
-					annotated := false
-					for x, o := range pkg.GetObjects() {
-						if c, ok := o.(*crd.CustomResourceDefinition); ok {
-							if c.Spec.Group == group && c.Spec.Names.Kind == ProviderConfigKind {
-								ab := new(bytes.Buffer)
-								if err := yaml.NewEncoder(ab).Encode(auth); err != nil {
-									return nil, nil, errors.Wrap(err, errParseAuth)
-								}
-								c.Annotations[authObjectAnno] = ab.String()
-								pkg.GetObjects()[x] = c
-								annotated = true
-								break
+				ar, err := b.ab.Init(ctx)
+				if err != nil {
+					return nil, nil, errors.Wrap(err, errParseAuth)
+				}
+				// validate the auth.yaml file
+				var auth AuthExtension
+				if err := yaml.NewDecoder(ar).Decode(&auth); err != nil {
+					return nil, nil, errors.Wrap(err, errParseAuth)
+				}
+				annotated := false
+				for x, o := range pkg.GetObjects() {
+					if c, ok := o.(*crd.CustomResourceDefinition); ok {
+						if c.Spec.Group == authGroup && c.Spec.Names.Kind == ProviderConfigKind {
+							ab := new(bytes.Buffer)
+							if err := yaml.NewEncoder(ab).Encode(auth); err != nil {
+								return nil, nil, errors.Wrap(err, errParseAuth)
 							}
+							c.Annotations[authObjectAnno] = ab.String()
+							pkg.GetObjects()[x] = c
+							annotated = true
+							break
 						}
 					}
-					if !annotated {
-						return nil, nil, errors.New(errAuthNotAnnotated)
-					}
+				}
+				if !annotated {
+					return nil, nil, errors.New(errAuthNotAnnotated)
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Providers moving from v1alpha1 do not get annotated with the auth configuration.  This change accounts for v1alpha1 and v1 providers annotating the crd with the upbound console config.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #1298

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Tested locally building v1 and v1alpha1 provider with auth extension file, package was annotated correctly in both cases.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
