### PR TITLE
add: TarPath parameter to the build command

### DIFF
--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -92,10 +92,11 @@ func (c *buildCmd) AfterApply() error {
 		examples.New(),
 	)
 
-	// NOTE(hasheddan): we currently only support fetching controller image from
-	// daemon, but may opt to support additional sources in the future.
-	c.fetch = daemonFetch
-
+	if c.TarPath != "" {
+		c.fetch = xpkgFetch(c.TarPath)
+	} else {
+		c.fetch = daemonFetch
+	}
 	return nil
 }
 
@@ -113,6 +114,7 @@ type buildCmd struct {
 	ExamplesRoot string   `short:"e" help:"Path to package examples directory." default:"./examples"`
 	AuthExt      string   `short:"a" help:"Path to an authentication extension file." default:"auth.yaml"`
 	Ignore       []string `help:"Paths, specified relative to --package-root, to exclude from the package."`
+	TarPath      string   `help:"Path to tar file, an alternative to Controller."`
 }
 
 func (c *buildCmd) Help() string {
@@ -137,10 +139,19 @@ Even more details can be found in the xpkg reference document.`
 // Run executes the build command.
 func (c *buildCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
 	var buildOpts []xpkg.BuildOpt
-	if c.Controller != "" {
-		ref, err := name.ParseReference(c.Controller)
-		if err != nil {
-			return err
+	if c.Controller != "" || c.TarPath != "" {
+		var ref name.Reference
+		var err error
+		if c.Controller != "" {
+			ref, err = name.ParseReference(c.Controller)
+			if err != nil {
+				return err
+			}
+		} else {
+			ref, err = name.ParseReference(c.TarPath)
+			if err != nil {
+				return err
+			}
 		}
 		base, err := c.fetch(context.Background(), ref)
 		if err != nil {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -482,6 +482,8 @@ on-disk Crossplane packages.
           examples directory.
         - `--ignore = STRING,...`: Paths, specified relative to --package-root,
           to exclude from the package.
+        - `--tar-path = STRING`: Path to a locally built tar file, an alternative 
+          to the Controller parameter. 
     - Behavior: Builds a Crossplane package (`.xpkg`) that is compatible with
       upstream Crossplane packages and is a valid OCI image. Build will fail if
       package is malformed or contains resources that are not compatible with


### PR DESCRIPTION
### Description of your changes

Add a `--tar-path` parameter, which is an alternative to `--controller`. This allow us to use `podman` in our pipelines. Example working flow:

```
podman build .
      --file ci/docker/Dockerfile
      --tag $IMAGE_NAME:latest
podman save -o local_image.tar $IMAGE_NAME:latest
./up xpkg build
      --package-root package
      --tar-path $IMAGE_NAME:latest
      --output my_provider.xpkg
```


Fixes #385 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

We have tested a locally built binary, uploaded to a private s3 bucket in a GitLab CI pipeline, using `podman`, and it works as expected. 