### PR TITLE
Allow pre-release versions of spaces to be installed and upgraded to

### DIFF
--- a/cmd/up/space/versions.go
+++ b/cmd/up/space/versions.go
@@ -44,13 +44,13 @@ var (
 	// initVersionConstraints is the list of version constraints that are checked
 	// on up init.
 	initVersionConstraints = []constraint{
-		{semver: ">= 1.0", message: "target version must be 1.0 or later. Use up < 0.20.0 to install earlier versions."},
+		{semver: ">= 1.0-0", message: "target version must be 1.0 or later. Use up < 0.20.0 to install earlier versions."},
 	}
 
 	// upgradeVersionConstraints is the list of version constraints that are
 	// checked on up upgrade.
 	upgradeVersionConstraints = []constraint{
-		{semver: ">= 1.0", message: "target version must be 1.0 or later. Use up < 0.20.0 to install earlier versions."},
+		{semver: ">= 1.0-0", message: "target version must be 1.0 or later. Use up < 0.20.0 to install earlier versions."},
 	}
 
 	// upgradeFromVersionConstraints is the list of version constraints that are


### PR DESCRIPTION
### Description of your changes
Prior to this change, we were unfortunately blocking pre-release installations. Maybe in the future, we choose to take a different stance, however today, not being able to install pre-release versions is pretty limiting when working on those earlier versions in conjunction with `up` as well as if we need to get a pre-release fix out to an external consumer.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Added new tests that cover the use case I ran into. I verified that the tests failed prior to adjusting the constraints in this changeset.
