### PR TITLE
Introduce support for `up ctp` (create, get, list, delete) against an Upbound Space 

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -19,9 +19,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/posener/complete"
-	"k8s.io/client-go/dynamic"
 
-	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
 	"github.com/upbound/up/cmd/up/controlplane/pkg"
@@ -43,32 +41,6 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
-
-	var cpCli *cp.Client
-	var cfgCli *configurations.Client
-	// TODO(branden): Replace kubeCli with a custom client type for interacting
-	// with controlplanes in a space. Something like:
-	// import spacesControlPlanes "github.com/upbound/up-sdk-go/service/spaces/controlplanes"
-	// ctpCli := spacesControlplanes.NewClient(kubeconfig)
-	var kubeCli *dynamic.DynamicClient
-	if upCtx.Profile.IsSpace() {
-		kubeconfig, err := upCtx.Profile.GetKubeClientConfig()
-		if err != nil {
-			return err
-		}
-		kubeCli, err = dynamic.NewForConfig(kubeconfig)
-		if err != nil {
-			return err
-		}
-	} else {
-		cfg, err := upCtx.BuildSDKConfig()
-		if err != nil {
-			return err
-		}
-		cpCli = cp.NewClient(cfg)
-		cfgCli = configurations.NewClient(cfg)
-	}
-	kongCtx.Bind(cpCli, cfgCli, kubeCli)
 
 	return nil
 }

--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -142,9 +142,8 @@ func extractSpaceFields(obj any) []string {
 
 func tabularPrint(obj any, printer upterm.ObjectPrinter, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		printer.Print(obj, spacefieldNames, extractSpaceFields)
+		return printer.Print(obj, spacefieldNames, extractSpaceFields)
 	} else {
-		printer.Print(obj, cloudfieldNames, extractCloudFields)
+		return printer.Print(obj, cloudfieldNames, extractCloudFields)
 	}
-	return nil
 }

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -16,13 +16,16 @@ package controlplane
 
 import (
 	"context"
-	"fmt"
 
+	v1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/pterm/pterm"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 
+	"github.com/upbound/up/internal/resources"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -30,14 +33,17 @@ import (
 type createCmd struct {
 	Name string `arg:"" required:"" help:"Name of control plane."`
 
-	ConfigurationName string `required:"" help:"The name of the Configuration."`
+	ConfigurationName string `help:"The name of the Configuration. This property is required for cloud control planes."`
 	Description       string `short:"d" help:"Description for control plane."`
+
+	SecretName      string `default:"kubeconfig-ctp" help:"The name of the control plane's secret. Only applicable for Space control planes."`
+	SecretNamespace string `default:"default" help:"The name of namespace for the control plane's secret. Only applicable for Space control planes."`
 }
 
 // Run executes the create command.
-func (c *createCmd) Run(p pterm.TextPrinter, cc *cp.Client, cfc *configurations.Client, upCtx *upbound.Context) error {
+func (c *createCmd) Run(p pterm.TextPrinter, cc *cp.Client, cfc *configurations.Client, kube *dynamic.DynamicClient, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		return fmt.Errorf("create is not supported for space profile %q", upCtx.ProfileName)
+		return c.runSpaces(kube)
 	}
 
 	// Get the UUID from the Configuration name, if it exists.
@@ -56,4 +62,23 @@ func (c *createCmd) Run(p pterm.TextPrinter, cc *cp.Client, cfc *configurations.
 
 	p.Printfln("%s created", c.Name)
 	return nil
+}
+
+func (c *createCmd) runSpaces(kube *dynamic.DynamicClient) error {
+	ctp := &resources.ControlPlane{}
+	ctp.SetName(c.Name)
+	ctp.SetGroupVersionKind(resources.ControlPlaneGVK)
+	ctp.SetWriteConnectionSecretToReference(&v1.SecretReference{
+		Name:      c.SecretName,
+		Namespace: c.SecretNamespace,
+	})
+
+	_, err := kube.
+		Resource(resources.ControlPlaneGVK.GroupVersion().WithResource("controlplanes")).
+		Create(
+			context.Background(),
+			ctp.GetUnstructured(),
+			metav1.CreateOptions{},
+		)
+	return err
 }

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -27,12 +27,11 @@ import (
 	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/controlplane/cloud"
 	"github.com/upbound/up/internal/controlplane/space"
-	"github.com/upbound/up/internal/resources"
 	"github.com/upbound/up/internal/upbound"
 )
 
 type ctpCreator interface {
-	Create(ctx context.Context, name string, opts controlplane.Options) (*resources.ControlPlane, error)
+	Create(ctx context.Context, name string, opts controlplane.Options) (*controlplane.Response, error)
 }
 
 // createCmd creates a control plane on Upbound.

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -41,7 +41,7 @@ type createCmd struct {
 	ConfigurationName string `help:"The name of the Configuration. This property is required for cloud control planes."`
 	Description       string `short:"d" help:"Description for control plane."`
 
-	SecretName      string `default:"kubeconfig-ctp" help:"The name of the control plane's secret. Only applicable for Space control planes."`
+	SecretName      string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`
 	SecretNamespace string `default:"default" help:"The name of namespace for the control plane's secret. Only applicable for Space control planes."`
 
 	client ctpCreator

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 
+	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/controlplane/cloud"
 	"github.com/upbound/up/internal/controlplane/space"
 	"github.com/upbound/up/internal/upbound"
@@ -69,6 +70,10 @@ func (c *deleteCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) er
 // Run executes the delete command.
 func (c *deleteCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	if err := c.client.Delete(context.Background(), c.Name); err != nil {
+		if controlplane.IsNotFound(err) {
+			p.Printfln("Control plane %s not found", c.Name)
+			return nil
+		}
 		return err
 	}
 	p.Printfln("%s deleted", c.Name)

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -56,7 +56,7 @@ func (c *getCmd) Run(printer upterm.ObjectPrinter, cc *cp.Client, upCtx *upbound
 		return errors.New(errNoConfigurationFound)
 	}
 
-	return printer.Print(*ctp, fieldNames, extractFields)
+	return printer.Print(*ctp, cloudFieldNames, extractCloudFields)
 }
 
 // EmptyControlPlaneConfiguration returns an empty ControlPlaneConfiguration with default values.

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -73,8 +73,13 @@ type getCmd struct {
 }
 
 // Run executes the get command.
-func (c *getCmd) Run(printer upterm.ObjectPrinter, upCtx *upbound.Context) error {
+func (c *getCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
 	ctp, err := c.client.Get(context.Background(), c.Name)
+	if controlplane.IsNotFound(err) {
+		p.Printfln("Control plane %s not found", c.Name)
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -24,9 +24,9 @@ import (
 	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 
+	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/controlplane/cloud"
 	"github.com/upbound/up/internal/controlplane/space"
-	"github.com/upbound/up/internal/resources"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
@@ -34,7 +34,7 @@ import (
 const errNoConfigurationFound = "no configuration associated to this control plane"
 
 type ctpGetter interface {
-	Get(ctx context.Context, name string) (*resources.ControlPlane, error)
+	Get(ctx context.Context, name string) (*controlplane.Response, error)
 }
 
 // AfterApply sets default values in command after assignment and validation.
@@ -79,8 +79,7 @@ func (c *getCmd) Run(printer upterm.ObjectPrinter, upCtx *upbound.Context) error
 		return err
 	}
 
-	printer.Print(*ctp.GetUnstructured(), spacesFieldNames, extractSpacesFields)
-	return nil
+	return tabularPrint(ctp, printer, upCtx)
 }
 
 // EmptyControlPlaneConfiguration returns an empty ControlPlaneConfiguration with default values.

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -31,8 +31,6 @@ import (
 	"github.com/upbound/up/internal/upterm"
 )
 
-const errNoConfigurationFound = "no configuration associated to this control plane"
-
 type ctpGetter interface {
 	Get(ctx context.Context, name string) (*controlplane.Response, error)
 }

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -16,10 +16,13 @@ package controlplane
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/upbound/up-sdk-go/service/common"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
@@ -36,7 +39,8 @@ const (
 	notAvailable = "n/a"
 )
 
-var fieldNames = []string{"NAME", "ID", "STATUS", "DEPLOYED CONFIGURATION", "CONFIGURATION STATUS"}
+var cloudFieldNames = []string{"NAME", "ID", "STATUS", "DEPLOYED CONFIGURATION", "CONFIGURATION STATUS"}
+var spacesFieldNames = []string{"NAME", "ID", "STATUS"}
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
@@ -48,11 +52,14 @@ func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) erro
 type listCmd struct{}
 
 // Run executes the list command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
+func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.Client, kube *dynamic.DynamicClient, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		return fmt.Errorf("list is not supported for space profile %q", upCtx.ProfileName)
+		return c.runSpaces(printer, p, kube, upCtx)
 	}
+	return c.runCloud(printer, p, cc, upCtx)
+}
 
+func (c *listCmd) runCloud(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.Client, upCtx *upbound.Context) error {
 	// TODO(hasheddan): we currently just max out single page size, but we
 	// may opt to support limiting page size and iterating through pages via
 	// flags in the future.
@@ -60,14 +67,46 @@ func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.
 	if err != nil {
 		return err
 	}
+
 	if len(cpList.ControlPlanes) == 0 {
 		p.Printfln("No control planes found in %s", upCtx.Account)
 		return nil
 	}
-	return printer.Print(cpList.ControlPlanes, fieldNames, extractFields)
+	return printer.Print(cpList.ControlPlanes, cloudFieldNames, extractCloudFields)
 }
 
-func extractFields(obj any) []string {
+func (c *listCmd) runSpaces(printer upterm.ObjectPrinter, p pterm.TextPrinter, kube *dynamic.DynamicClient, upCtx *upbound.Context) error {
+	// NOTE: It would be convenient if we could import the ControlPlane types
+	// and SchemeBuilder from upbound/mxe and use them to build a client that
+	// returns structured data, but it's a private repo. Instead we use a dynamic
+	// client and unstructured objects.
+	cpList, err := getControlPlanes(context.Background(), kube)
+	if err != nil {
+		return err
+	}
+	if len(cpList.Items) == 0 {
+		p.Println("No control planes found")
+		return nil
+	}
+	return printer.Print(cpList.Items, spacesFieldNames, extractSpacesFields)
+}
+
+// Hey Taylor -- I was thinking of moving this function to a new package.
+// That was the one thing I wanted to do before putting this up for a PR.
+func getControlPlanes(ctx context.Context, kube *dynamic.DynamicClient) (*unstructured.UnstructuredList, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "spaces.upbound.io",
+		Version:  "v1alpha1",
+		Resource: "controlplanes",
+	}
+	cpList, err := kube.Resource(gvr).List(ctx, v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cpList, nil
+}
+
+func extractCloudFields(obj any) []string {
 	c := obj.(cp.ControlPlaneResponse)
 	var cfgName string
 	var cfgStatus string
@@ -80,4 +119,26 @@ func extractFields(obj any) []string {
 		cfgName, cfgStatus = notAvailable, notAvailable
 	}
 	return []string{c.ControlPlane.Name, c.ControlPlane.ID.String(), string(c.Status), cfgName, cfgStatus}
+}
+
+func extractSpacesFields(obj any) []string {
+	ctp := obj.(unstructured.Unstructured)
+	id, found, err := unstructured.NestedString(ctp.Object, "status", "controlPlaneID")
+	if !found || err != nil {
+		id = "unknown"
+	}
+
+	readyStatus := "unknown"
+	conditions, found, err := unstructured.NestedSlice(ctp.Object, "status", "conditions")
+	if found && err == nil {
+		for _, condition := range conditions {
+			statusType := condition.(map[string]interface{})["type"]
+			if statusType == "Ready" {
+				readyStatus = condition.(map[string]interface{})["status"].(string)
+			}
+		}
+
+	}
+
+	return []string{ctp.GetName(), id, readyStatus}
 }

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -55,7 +55,7 @@ type listCmd struct{}
 // Run executes the list command.
 func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *cp.Client, kube *dynamic.DynamicClient, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		return c.runSpaces(printer, p, kube, upCtx)
+		return c.runSpaces(printer, p, kube)
 	}
 	return c.runCloud(printer, p, cc, upCtx)
 }
@@ -76,7 +76,7 @@ func (c *listCmd) runCloud(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc
 	return printer.Print(cpList.ControlPlanes, cloudFieldNames, extractCloudFields)
 }
 
-func (c *listCmd) runSpaces(printer upterm.ObjectPrinter, p pterm.TextPrinter, kube *dynamic.DynamicClient, upCtx *upbound.Context) error {
+func (c *listCmd) runSpaces(printer upterm.ObjectPrinter, p pterm.TextPrinter, kube *dynamic.DynamicClient) error {
 	// NOTE: It would be convenient if we could import the ControlPlane types
 	// and SchemeBuilder from upbound/mxe and use them to build a client that
 	// returns structured data, but it's a private repo. Instead we use a dynamic

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -1,0 +1,94 @@
+package cloud
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/upbound/up-sdk-go/service/common"
+	"github.com/upbound/up-sdk-go/service/configurations"
+	"github.com/upbound/up-sdk-go/service/controlplanes"
+
+	"github.com/upbound/up/internal/controlplane"
+	"github.com/upbound/up/internal/resources"
+)
+
+const (
+	maxItems = 100
+)
+
+// Client is the client used for interacting with the ControlPlanes API in
+// Upbound Cloud.
+type Client struct {
+	ctp *controlplanes.Client
+	cfg *configurations.Client
+
+	account string
+}
+
+// New instantiates a new Client.
+func New(ctp *controlplanes.Client, cfg *configurations.Client, account string) *Client {
+	return &Client{
+		ctp:     ctp,
+		cfg:     cfg,
+		account: account,
+	}
+}
+
+// Get the ControlPlane corresponding to the given ControlPlane name.
+func (c *Client) Get(ctx context.Context, name string) (*resources.ControlPlane, error) {
+	resp, err := c.ctp.Get(context.Background(), c.account, name)
+	if err != nil {
+		return nil, err
+	}
+
+	ctp := &resources.ControlPlane{}
+	ctp.SetName(resp.ControlPlane.Name)
+	return ctp, nil
+}
+
+// List all ControlPlanes within the Space.
+func (c *Client) List(ctx context.Context) (*resources.ControlPlaneList, error) {
+	l, err := c.ctp.List(context.Background(), c.account, common.WithSize(maxItems))
+	if err != nil {
+		return nil, err
+	}
+	list := []unstructured.Unstructured{}
+	for _, uc := range l.ControlPlanes {
+		ctp := &resources.ControlPlane{}
+		ctp.SetName(uc.ControlPlane.Name)
+		list = append(list, *ctp.GetUnstructured())
+	}
+	return &resources.ControlPlaneList{
+		UnstructuredList: unstructured.UnstructuredList{
+			Items: list,
+		},
+	}, nil
+}
+
+// Create a new ControlPlane with the given name and the supplied Options.
+func (c *Client) Create(ctx context.Context, name string, opts controlplane.Options) (*resources.ControlPlane, error) {
+	// Get the UUID from the Configuration name, if it exists.
+	cfg, err := c.cfg.Get(context.Background(), c.account, opts.ConfigurationName)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.ctp.Create(context.Background(), c.account, &controlplanes.ControlPlaneCreateParameters{
+		Name:            name,
+		Description:     opts.Description,
+		ConfigurationID: cfg.ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ctp := &resources.ControlPlane{}
+	ctp.SetName(resp.ControlPlane.Name)
+	return ctp, nil
+}
+
+// Delete the ControlPlane corresponding to the given ControlPlane name.
+func (c *Client) Delete(ctx context.Context, name string) error {
+	return c.ctp.Delete(context.Background(), c.account, name)
+}

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -75,7 +75,7 @@ func (c *Client) Get(ctx context.Context, name string) (*controlplane.Response, 
 	return convert(resp), nil
 }
 
-// List all ControlPlanes within the Space.
+// List all ControlPlanes within the Upbound Cloud account.
 func (c *Client) List(ctx context.Context) ([]*controlplane.Response, error) {
 	l, err := c.ctp.List(ctx, c.account, common.WithSize(maxItems))
 	if err != nil {

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 
+	sdkerrs "github.com/upbound/up-sdk-go/errors"
 	"github.com/upbound/up-sdk-go/service/common"
 	"github.com/upbound/up-sdk-go/service/configurations"
 	"github.com/upbound/up-sdk-go/service/controlplanes"
@@ -37,6 +38,11 @@ func New(ctp *controlplanes.Client, cfg *configurations.Client, account string) 
 // Get the ControlPlane corresponding to the given ControlPlane name.
 func (c *Client) Get(ctx context.Context, name string) (*controlplane.Response, error) {
 	resp, err := c.ctp.Get(context.Background(), c.account, name)
+
+	if sdkerrs.IsNotFound(err) {
+		return nil, controlplane.NewNotFound(err)
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +85,11 @@ func (c *Client) Create(ctx context.Context, name string, opts controlplane.Opti
 
 // Delete the ControlPlane corresponding to the given ControlPlane name.
 func (c *Client) Delete(ctx context.Context, name string) error {
-	return c.ctp.Delete(context.Background(), c.account, name)
+	err := c.ctp.Delete(context.Background(), c.account, name)
+	if sdkerrs.IsNotFound(err) {
+		return controlplane.NewNotFound(err)
+	}
+	return err
 }
 
 func convert(ctp *controlplanes.ControlPlaneResponse) *controlplane.Response {

--- a/internal/controlplane/cloud/cloud_test.go
+++ b/internal/controlplane/cloud/cloud_test.go
@@ -1,0 +1,367 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"k8s.io/utils/pointer"
+
+	sdkerrs "github.com/upbound/up-sdk-go/errors"
+	"github.com/upbound/up-sdk-go/service/common"
+	"github.com/upbound/up-sdk-go/service/controlplanes"
+
+	"github.com/upbound/up/internal/controlplane"
+)
+
+var (
+	acct = "demo"
+
+	sdkNotFound = &sdkerrs.Error{
+		Status: http.StatusNotFound,
+		Detail: pointer.String(`control plane "ctp-dne" not found`),
+		Title:  http.StatusText(http.StatusNotFound),
+	}
+
+	ctp1 = controlplanes.ControlPlane{
+		Name: "ctp1",
+		ID:   uuid.MustParse("00000000-0000-0000-0000-000000000000"),
+		Configuration: controlplanes.ControlPlaneConfiguration{
+			Name:   pointer.String("cfg1"),
+			Status: controlplanes.ConfigurationReady,
+		},
+	}
+
+	ctp2 = controlplanes.ControlPlane{
+		Name: "ctp2",
+		ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Configuration: controlplanes.ControlPlaneConfiguration{
+			Name:   pointer.String("cfg1"),
+			Status: controlplanes.ConfigurationReady,
+		},
+	}
+
+	ctp1Resp = &controlplane.Response{
+		Name:      "ctp1",
+		ID:        "00000000-0000-0000-0000-000000000000",
+		Cfg:       "cfg1",
+		CfgStatus: string(controlplanes.ConfigurationReady),
+	}
+
+	ctp2Resp = &controlplane.Response{
+		Name:      "ctp2",
+		ID:        "00000000-0000-0000-0000-000000000001",
+		Cfg:       "cfg1",
+		CfgStatus: string(controlplanes.ConfigurationReady),
+	}
+)
+
+type mockCTPClient struct {
+	CreateFn func(ctx context.Context, account string, params *controlplanes.ControlPlaneCreateParameters) (*controlplanes.ControlPlaneResponse, error)
+	DeleteFn func(ctx context.Context, account, name string) error
+	GetFn    func(ctx context.Context, account, name string) (*controlplanes.ControlPlaneResponse, error)
+	ListFn   func(ctx context.Context, account string, opts ...common.ListOption) (*controlplanes.ControlPlaneListResponse, error)
+}
+
+func (m *mockCTPClient) Create(ctx context.Context, account string, params *controlplanes.ControlPlaneCreateParameters) (*controlplanes.ControlPlaneResponse, error) {
+	return m.CreateFn(ctx, account, params)
+}
+
+func (m *mockCTPClient) Delete(ctx context.Context, account, name string) error {
+	return m.DeleteFn(ctx, account, name)
+}
+
+func (m *mockCTPClient) Get(ctx context.Context, account, name string) (*controlplanes.ControlPlaneResponse, error) {
+	return m.GetFn(ctx, account, name)
+}
+
+func (m *mockCTPClient) List(ctx context.Context, account string, opts ...common.ListOption) (*controlplanes.ControlPlaneListResponse, error) {
+	return m.ListFn(ctx, account, opts...)
+}
+
+func TestGet(t *testing.T) {
+	type args struct {
+		ctp  ctpClient
+		cfg  cfgGetter
+		name string
+	}
+	type want struct {
+		resp *controlplane.Response
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrorControlPlaneNotFound": {
+			reason: "If the requested control plane does not exist, a not found error is returned.",
+			args: args{
+				ctp: &mockCTPClient{
+					GetFn: func(ctx context.Context, account, name string) (*controlplanes.ControlPlaneResponse, error) {
+						return nil, sdkNotFound
+					},
+				},
+				name: "ctp-dne",
+			},
+			want: want{
+				err: controlplane.NewNotFound(errors.New(`Not Found: control plane "ctp-dne" not found`)),
+			},
+		},
+		"Success": {
+			reason: "If the control plane exists, a response is returned.",
+			args: args{
+				ctp: &mockCTPClient{
+					GetFn: func(ctx context.Context, account, name string) (*controlplanes.ControlPlaneResponse, error) {
+						return &controlplanes.ControlPlaneResponse{
+							ControlPlane: ctp1,
+						}, nil
+					},
+				},
+				name: "ctp1",
+			},
+			want: want{
+				resp: ctp1Resp,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			c := New(tc.args.ctp, tc.args.cfg, acct)
+			got, err := c.Get(context.Background(), tc.args.name)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	type args struct {
+		ctp  ctpClient
+		cfg  cfgGetter
+		name string
+	}
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrorControlPlaneNotFound": {
+			reason: "If the requested control plane does not exist, a not found error is returned.",
+			args: args{
+				ctp: &mockCTPClient{
+					DeleteFn: func(ctx context.Context, account, name string) error {
+						return sdkNotFound
+					},
+				},
+				name: "ctp-dne",
+			},
+			want: want{
+				err: controlplane.NewNotFound(errors.New(`Not Found: control plane "ctp-dne" not found`)),
+			},
+		},
+		"Success": {
+			reason: "If the control plane exists, no error is returned.",
+			args: args{
+				ctp: &mockCTPClient{
+					DeleteFn: func(ctx context.Context, account, name string) error {
+						return nil
+					},
+				},
+				name: "ctp1",
+			},
+			want: want{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			c := New(tc.args.ctp, tc.args.cfg, acct)
+			err := c.Delete(context.Background(), tc.args.name)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDelete(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	type args struct {
+		ctp ctpClient
+		cfg cfgGetter
+	}
+	type want struct {
+		resp []*controlplane.Response
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NoControlPlanes": {
+			reason: "If there are no control planes, an empty response slice is returned.",
+			args: args{
+				ctp: &mockCTPClient{
+					ListFn: func(ctx context.Context, account string, opts ...common.ListOption) (*controlplanes.ControlPlaneListResponse, error) {
+						return &controlplanes.ControlPlaneListResponse{
+							ControlPlanes: []controlplanes.ControlPlaneResponse{},
+						}, nil
+					},
+				},
+			},
+			want: want{
+				resp: []*controlplane.Response{},
+			},
+		},
+		"SingleControlPlane": {
+			reason: "If a single control plane exists, a response with only the one control plane is returned.",
+			args: args{
+				ctp: &mockCTPClient{
+					ListFn: func(ctx context.Context, account string, opts ...common.ListOption) (*controlplanes.ControlPlaneListResponse, error) {
+						return &controlplanes.ControlPlaneListResponse{
+							ControlPlanes: []controlplanes.ControlPlaneResponse{
+								{
+									ControlPlane: ctp1,
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			want: want{
+				resp: []*controlplane.Response{
+					ctp1Resp,
+				},
+			},
+		},
+		"MultiControlPlanes": {
+			reason: "If multiple control plane exists, a response with each of the control planes is returned.",
+			args: args{
+				ctp: &mockCTPClient{
+					ListFn: func(ctx context.Context, account string, opts ...common.ListOption) (*controlplanes.ControlPlaneListResponse, error) {
+						return &controlplanes.ControlPlaneListResponse{
+							ControlPlanes: []controlplanes.ControlPlaneResponse{
+								{
+									ControlPlane: ctp1,
+								},
+								{
+									ControlPlane: ctp2,
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			want: want{
+				resp: []*controlplane.Response{
+					ctp1Resp,
+					ctp2Resp,
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			c := New(tc.args.ctp, tc.args.cfg, acct)
+			got, err := c.List(context.Background())
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nList(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("\n%s\nList(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestConvert(t *testing.T) {
+	type args struct {
+		ctp *controlplanes.ControlPlaneResponse
+	}
+	type want struct {
+		resp *controlplane.Response
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ConfigurationAssociated": {
+			reason: "If a configuration is associated with the control plane, return response with name and status.",
+			args: args{
+				ctp: &controlplanes.ControlPlaneResponse{
+					ControlPlane: ctp1,
+				},
+			},
+			want: want{
+				resp: ctp1Resp,
+			},
+		},
+		"ConfigurationNotAssociated": {
+			reason: "If a configuration is not associated with the control plane, response has n/a for configuration name and status.",
+			args: args{
+				ctp: &controlplanes.ControlPlaneResponse{
+					ControlPlane: controlplanes.ControlPlane{
+						Name:          "ctp1",
+						ID:            uuid.MustParse("00000000-0000-0000-0000-000000000000"),
+						Configuration: controlplanes.ControlPlaneConfiguration{},
+					},
+				},
+			},
+			want: want{
+				resp: &controlplane.Response{
+					Name:      "ctp1",
+					ID:        "00000000-0000-0000-0000-000000000000",
+					Cfg:       notAvailable,
+					CfgStatus: notAvailable,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			got := convert(tc.args.ctp)
+
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("\n%s\nconvert(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controlplane
 
 // Response is a normalized ControlPlane response.

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -1,0 +1,17 @@
+package controlplane
+
+// Response is a normalized ControlPlane response.
+// NOTE(tnthornton) this is expected to be different in the near future as
+// cloud and spaces APIs converge.
+type Response struct {
+	ID      string
+	Name    string
+	Message string
+	Status  string
+
+	Cfg       string
+	CfgStatus string
+
+	ConnName      string
+	ConnNamespace string
+}

--- a/internal/controlplane/errors.go
+++ b/internal/controlplane/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controlplane
 
 import (

--- a/internal/controlplane/errors.go
+++ b/internal/controlplane/errors.go
@@ -1,0 +1,40 @@
+package controlplane
+
+import (
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+)
+
+// notFoundError is an error indicating the resource is not found.
+type notFoundError struct {
+	err error
+}
+
+// Error calls the underlying error's Error method.
+func (n *notFoundError) Error() string {
+	return fmt.Sprintf("not found: %s", n.err.Error())
+}
+
+// NotFound indicates that this is a not found error.
+func (n *notFoundError) NotFound() bool {
+	return true
+}
+
+// NewNotFound wraps an existing error as a not found error.
+func NewNotFound(err error) error {
+	return &notFoundError{
+		err: err,
+	}
+}
+
+// notFound indicates a resource is not found.
+type notFound interface {
+	NotFound() bool
+}
+
+// IsNotFound checks whether an error implements the notFound interface.
+func IsNotFound(err error) bool {
+	var nferr notFound
+	return errors.As(err, &nferr) && nferr.NotFound()
+}

--- a/internal/controlplane/options.go
+++ b/internal/controlplane/options.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controlplane
 
 type Options struct {

--- a/internal/controlplane/options.go
+++ b/internal/controlplane/options.go
@@ -1,0 +1,12 @@
+package controlplane
+
+type Options struct {
+	// Connection Secret Name
+	SecretName string
+	// Connection Secret Namespace
+	SecretNamespace string
+
+	Description string
+
+	ConfigurationName string
+}

--- a/internal/controlplane/space/space.go
+++ b/internal/controlplane/space/space.go
@@ -1,0 +1,84 @@
+package space
+
+import (
+	"context"
+
+	xpcommonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/upbound/up/internal/controlplane"
+	"github.com/upbound/up/internal/resources"
+)
+
+var (
+	resource = resources.ControlPlaneGVK.GroupVersion().WithResource("controlplanes")
+)
+
+// Client is the client used for interacting with the ControlPlanes API in an
+// Upbound Space.
+type Client struct {
+	c dynamic.Interface
+}
+
+// New instantiates a new Client.
+func New(c dynamic.Interface) *Client {
+	return &Client{
+		c: c,
+	}
+}
+
+// Get the ControlPlane corresponding to the given ControlPlane name.
+func (c *Client) Get(ctx context.Context, name string) (*resources.ControlPlane, error) {
+	u, err := c.c.
+		Resource(resource).
+		Get(
+			ctx,
+			name,
+			metav1.GetOptions{},
+		)
+
+	return &resources.ControlPlane{Unstructured: *u}, err
+}
+
+// List all ControlPlanes within the Space.
+func (c *Client) List(ctx context.Context) (*resources.ControlPlaneList, error) {
+	u, err := c.c.
+		Resource(resource).
+		List(
+			ctx,
+			metav1.ListOptions{},
+		)
+	return &resources.ControlPlaneList{UnstructuredList: *u}, err
+}
+
+// Create a new ControlPlane with the given name and the supplied Options.
+func (c *Client) Create(ctx context.Context, name string, opts controlplane.Options) (*resources.ControlPlane, error) {
+	ctp := &resources.ControlPlane{}
+	ctp.SetName(name)
+	ctp.SetGroupVersionKind(resources.ControlPlaneGVK)
+	ctp.SetWriteConnectionSecretToReference(&xpcommonv1.SecretReference{
+		Name:      opts.SecretName,
+		Namespace: opts.SecretNamespace,
+	})
+
+	u, err := c.c.
+		Resource(resource).
+		Create(
+			ctx,
+			ctp.GetUnstructured(),
+			metav1.CreateOptions{},
+		)
+	return &resources.ControlPlane{Unstructured: *u}, err
+}
+
+// Delete the ControlPlane corresponding to the given ControlPlane name.
+func (c *Client) Delete(ctx context.Context, name string) error {
+	return c.c.
+		Resource(resource).
+		Delete(
+			context.Background(),
+			name,
+			metav1.DeleteOptions{},
+		)
+}

--- a/internal/controlplane/space/space.go
+++ b/internal/controlplane/space/space.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package space
 
 import (
@@ -101,7 +115,7 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 	err := c.c.
 		Resource(resource).
 		Delete(
-			context.Background(),
+			ctx,
 			name,
 			metav1.DeleteOptions{},
 		)

--- a/internal/controlplane/space/space_test.go
+++ b/internal/controlplane/space/space_test.go
@@ -1,0 +1,427 @@
+package space
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	xpcommonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+	cgotesting "k8s.io/client-go/testing"
+
+	"github.com/upbound/up/internal/controlplane"
+	"github.com/upbound/up/internal/resources"
+)
+
+var (
+	ctpresource = "controlplanes"
+
+	controlPlaneGRV = schema.GroupResource{
+		Group:    "spaces.upbound.io",
+		Resource: ctpresource,
+	}
+
+	scheme = runtime.NewScheme()
+)
+
+func TestGet(t *testing.T) {
+	ctp1 := &resources.ControlPlane{}
+	ctp1.SetName("ctp1")
+	ctp1.SetWriteConnectionSecretToReference(&xpcommonv1.SecretReference{
+		Name:      "kubeconfig-ctp1",
+		Namespace: "default",
+	})
+
+	type args struct {
+		client dynamic.Interface
+		name   string
+	}
+	type want struct {
+		resp *controlplane.Response
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrorControlPlaneNotFound": {
+			reason: "If the requested control plane does not exist, a not found error is returned.",
+			args: args{
+				client: func() dynamic.Interface {
+					c := fake.NewSimpleDynamicClient(scheme)
+					c.PrependReactor(
+						"get",
+						ctpresource,
+						func(action cgotesting.Action) (handled bool, ret runtime.Object, err error) {
+							return true, nil, kerrors.NewNotFound(controlPlaneGRV, "ctp-dne")
+						})
+
+					return c
+				}(),
+				name: "ctp-dne",
+			},
+			want: want{
+				err: controlplane.NewNotFound(errors.New(`controlplanes.spaces.upbound.io "ctp-dne" not found`)),
+			},
+		},
+		"Success": {
+			reason: "If the control plane exists, a response is returned.",
+			args: args{
+				client: fake.NewSimpleDynamicClient(scheme, ctp1.GetUnstructured()),
+				name:   "ctp1",
+			},
+			want: want{
+				resp: &controlplane.Response{
+					Name:          "ctp1",
+					ConnName:      "kubeconfig-ctp1",
+					ConnNamespace: "default",
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			c := New(tc.args.client)
+			got, err := c.Get(context.Background(), tc.args.name)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("\n%s\nGet(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	ctp1 := &resources.ControlPlane{}
+	ctp1.SetName("ctp1")
+	ctp1.SetWriteConnectionSecretToReference(&xpcommonv1.SecretReference{
+		Name:      "kubeconfig-ctp1",
+		Namespace: "default",
+	})
+
+	type args struct {
+		client dynamic.Interface
+		name   string
+	}
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrorControlPlaneNotFound": {
+			reason: "If the requested control plane does not exist, a not found error is returned.",
+			args: args{
+				client: func() dynamic.Interface {
+					c := fake.NewSimpleDynamicClient(scheme)
+					c.PrependReactor(
+						"delete",
+						ctpresource,
+						func(action cgotesting.Action) (handled bool, ret runtime.Object, err error) {
+							return true, nil, kerrors.NewNotFound(controlPlaneGRV, "ctp-dne")
+						})
+
+					return c
+				}(),
+				name: "ctp-dne",
+			},
+			want: want{
+				err: controlplane.NewNotFound(errors.New(`controlplanes.spaces.upbound.io "ctp-dne" not found`)),
+			},
+		},
+		"Success": {
+			reason: "If the control plane exists, no error is returned.",
+			args: args{
+				client: fake.NewSimpleDynamicClient(scheme, ctp1.GetUnstructured()),
+				name:   "ctp1",
+			},
+			want: want{},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			c := New(tc.args.client)
+			err := c.Delete(context.Background(), tc.args.name)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nDelete(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group:   "spaces.upbound.io",
+		Version: "v1beta1",
+		Kind:    "ControlPlaneList"},
+		&unstructured.UnstructuredList{},
+	)
+
+	ctp1 := &resources.ControlPlane{}
+	ctp1.SetName("ctp1")
+	ctp1.SetWriteConnectionSecretToReference(&xpcommonv1.SecretReference{
+		Name:      "kubeconfig-ctp1",
+		Namespace: "default",
+	})
+
+	ctp2 := &resources.ControlPlane{}
+	ctp2.SetName("ctp2")
+	ctp2.SetWriteConnectionSecretToReference(&xpcommonv1.SecretReference{
+		Name:      "kubeconfig-ctp2",
+		Namespace: "default",
+	})
+
+	type args struct {
+		client dynamic.Interface
+	}
+	type want struct {
+		resp []*controlplane.Response
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NoControlPlanes": {
+			reason: "If there are no control planes, an empty response slice is returned.",
+			args: args{
+				client: fake.NewSimpleDynamicClient(scheme),
+			},
+			want: want{
+				resp: []*controlplane.Response{},
+			},
+		},
+		"SingleControlPlane": {
+			reason: "If a single control plane exists, a response with only the one control plane is returned.",
+			args: args{
+				client: fake.NewSimpleDynamicClient(
+					scheme,
+					ctp1.GetUnstructured(),
+				),
+			},
+			want: want{
+				resp: []*controlplane.Response{
+					{
+						Name:          "ctp1",
+						ConnName:      "kubeconfig-ctp1",
+						ConnNamespace: "default",
+					},
+				},
+			},
+		},
+		"MultiControlPlanes": {
+			reason: "If multiple control plane exists, a response with each of the control planes is returned.",
+			args: args{
+				client: fake.NewSimpleDynamicClient(
+					scheme,
+					ctp1.GetUnstructured(),
+					ctp2.GetUnstructured(),
+				),
+			},
+			want: want{
+				resp: []*controlplane.Response{
+					{
+						Name:          "ctp1",
+						ConnName:      "kubeconfig-ctp1",
+						ConnNamespace: "default",
+					},
+					{
+						Name:          "ctp2",
+						ConnName:      "kubeconfig-ctp",
+						ConnNamespace: "default",
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			c := New(tc.args.client)
+			got, err := c.List(context.Background())
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nList(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("\n%s\nList(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestCalculateSecret(t *testing.T) {
+	type args struct {
+		name string
+		opts controlplane.Options
+	}
+	type want struct {
+		opts controlplane.Options
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"DefaultSecretName": {
+			reason: "If secretname is not supplied, the default is calculated.",
+			args: args{
+				name: "ctp1",
+				opts: controlplane.Options{},
+			},
+			want: want{
+				opts: controlplane.Options{
+					SecretName: "kubeconfig-ctp1",
+				},
+			},
+		},
+		"SuppliedSecretName": {
+			reason: "If secretname is supplied, the secretname is preserved.",
+			args: args{
+				name: "ctp1",
+				opts: controlplane.Options{
+					SecretName: "supplied",
+				},
+			},
+			want: want{
+				opts: controlplane.Options{
+					SecretName: "supplied",
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			got := calculateSecret(tc.args.name, tc.args.opts)
+
+			if diff := cmp.Diff(tc.want.opts, got); diff != "" {
+				t.Errorf("\n%s\ncalculateSecret(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestConvert(t *testing.T) {
+	type args struct {
+		ctp *resources.ControlPlane
+	}
+	type want struct {
+		resp *controlplane.Response
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ConditionEmptyMessage": {
+			reason: "If the ready condition is has a status of true, the message is empty.",
+			args: args{
+				ctp: func() *resources.ControlPlane {
+					c := &resources.ControlPlane{}
+					c.SetName("ctp1")
+					c.SetControlPlaneID("mxp1")
+					c.SetWriteConnectionSecretToReference(&xpcommonv1.SecretReference{
+						Name:      "kubeconfig-ctp1",
+						Namespace: "default",
+					})
+					c.SetConditions([]xpcommonv1.Condition{xpcommonv1.Available()}...)
+
+					return c
+				}(),
+			},
+			want: want{
+				resp: &controlplane.Response{
+					Name:          "ctp1",
+					ID:            "mxp1",
+					Status:        string(xpcommonv1.Available().Reason),
+					ConnName:      "kubeconfig-ctp1",
+					ConnNamespace: "default",
+				},
+			},
+		},
+		"ConditionHasMessage": {
+			reason: "If the ready condition is has a status of false, the message is not empty.",
+			args: args{
+				ctp: func() *resources.ControlPlane {
+					c := &resources.ControlPlane{}
+					c.SetName("ctp1")
+					c.SetControlPlaneID("mxp1")
+					c.SetWriteConnectionSecretToReference(&xpcommonv1.SecretReference{
+						Name:      "kubeconfig-ctp1",
+						Namespace: "default",
+					})
+					c.SetConditions([]xpcommonv1.Condition{
+						xpcommonv1.Creating().WithMessage("creating..."),
+					}...)
+
+					return c
+				}(),
+			},
+			want: want{
+				resp: &controlplane.Response{
+					Name:          "ctp1",
+					ID:            "mxp1",
+					Status:        string(xpcommonv1.Creating().Reason),
+					Message:       "creating...",
+					ConnName:      "kubeconfig-ctp1",
+					ConnNamespace: "default",
+				},
+			},
+		},
+		"EmptyConnectionSecret": {
+			reason: "If the control plane does not have a connection secret set, connection details are empty in the response.",
+			args: args{
+				ctp: func() *resources.ControlPlane {
+					c := &resources.ControlPlane{}
+					c.SetName("ctp1")
+					c.SetControlPlaneID("mxp1")
+					c.SetConditions([]xpcommonv1.Condition{xpcommonv1.Available()}...)
+
+					return c
+				}(),
+			},
+			want: want{
+				resp: &controlplane.Response{
+					Name:   "ctp1",
+					ID:     "mxp1",
+					Status: string(xpcommonv1.Available().Reason),
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			got := convert(tc.args.ctp)
+
+			if diff := cmp.Diff(tc.want.resp, got); diff != "" {
+				t.Errorf("\n%s\nconvert(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/controlplane/space/space_test.go
+++ b/internal/controlplane/space/space_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package space
 
 import (
@@ -247,7 +261,7 @@ func TestList(t *testing.T) {
 					},
 					{
 						Name:          "ctp2",
-						ConnName:      "kubeconfig-ctp",
+						ConnName:      "kubeconfig-ctp2",
 						ConnNamespace: "default",
 					},
 				},

--- a/internal/resources/controlplane.go
+++ b/internal/resources/controlplane.go
@@ -16,11 +16,6 @@ var (
 		Version: "v1beta1",
 		Kind:    "ControlPlane",
 	}
-	ControlPlaneGVR = schema.GroupVersionResource{
-		Group:    "spaces.upbound.io",
-		Version:  "v1beta1",
-		Resource: "controlplanes",
-	}
 )
 
 // ControlPlane represents the ControlPlane CustomResource and extends an
@@ -29,9 +24,17 @@ type ControlPlane struct {
 	unstructured.Unstructured
 }
 
+type ControlPlaneList struct {
+	unstructured.UnstructuredList
+}
+
 // GetUnstructured returns the underlying *unstructured.Unstructured.
 func (c *ControlPlane) GetUnstructured() *unstructured.Unstructured {
 	return &c.Unstructured
+}
+
+func (cl *ControlPlaneList) GetUnstructured() *unstructured.UnstructuredList {
+	return &cl.UnstructuredList
 }
 
 // GetCondition returns the condition for the given xpv1.ConditionType if it

--- a/internal/resources/controlplane.go
+++ b/internal/resources/controlplane.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (

--- a/internal/resources/controlplane.go
+++ b/internal/resources/controlplane.go
@@ -1,0 +1,39 @@
+package resources
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+)
+
+// ControlPlane represents the ControlPlane CustomResource and extends an
+// unstructured.Unstructured.
+type ControlPlane struct {
+	unstructured.Unstructured
+}
+
+// GetUnstructured returns the underlying *unstructured.Unstructured.
+func (c *ControlPlane) GetUnstructured() *unstructured.Unstructured {
+	return &c.Unstructured
+}
+
+// GetCondition returns the condition for the given xpv1.ConditionType if it
+// exists, otherwise returns nil.
+func (c *ControlPlane) GetCondition(ct xpv1.ConditionType) xpv1.Condition {
+	conditioned := xpv1.ConditionedStatus{}
+	// The path is directly `status` because conditions are inline.
+	if err := fieldpath.Pave(c.Object).GetValueInto("status", &conditioned); err != nil {
+		return xpv1.Condition{}
+	}
+	return conditioned.GetCondition(ct)
+}
+
+// GetControlPlaneID returns the MXP ID associated with the ControlPlane.
+func (c *ControlPlane) GetControlPlaneID() string {
+	id, err := fieldpath.Pave(c.Object).GetString("status.controlPlaneID")
+	if err != nil {
+		return ""
+	}
+	return id
+}

--- a/internal/resources/controlplane.go
+++ b/internal/resources/controlplane.go
@@ -2,9 +2,25 @@ package resources
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+)
+
+var (
+	// ControlPlaneGVK is the GroupVersionKind used for
+	// provider-kubernetes ProviderConfig.
+	ControlPlaneGVK = schema.GroupVersionKind{
+		Group:   "spaces.upbound.io",
+		Version: "v1beta1",
+		Kind:    "ControlPlane",
+	}
+	ControlPlaneGVR = schema.GroupVersionResource{
+		Group:    "spaces.upbound.io",
+		Version:  "v1beta1",
+		Resource: "controlplanes",
+	}
 )
 
 // ControlPlane represents the ControlPlane CustomResource and extends an
@@ -36,4 +52,15 @@ func (c *ControlPlane) GetControlPlaneID() string {
 		return ""
 	}
 	return id
+}
+
+// SetWriteConnectionSecretToReference of this composite resource claim.
+func (c *ControlPlane) SetWriteConnectionSecretToReference(ref *xpv1.SecretReference) {
+	_ = fieldpath.Pave(c.Object).SetValue("spec.writeConnectionSecretToRef", ref)
+}
+
+func (c *ControlPlane) GetConnectionSecretToReference() *xpv1.SecretReference {
+	out := &xpv1.SecretReference{}
+	_ = fieldpath.Pave(c.Object).GetValueInto("spec.writeConnectionSecretToRef", out)
+	return out
 }


### PR DESCRIPTION
### Description of your changes
With Upbound Spaces having been released last month, an obvious short coming was up CLI support for working with a Space. This changeset begins moving in the direction of having consistent support for `up ctp` between Cloud and Spaces by enabling the following actions when using a Space profile:
* Create `up ctp create {name}`
* Delete `up ctp delete {name}`
* Get `up ctp get {name}`
* List `up ctp list`

Of note:
* New clients were added for working with a Space or Cloud.
* Command invocations were simplified by working against given client interface.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
#### New tests added

#### Manual validation
In the cluster:
```bash
kubectl get ctp
No resources found
```

Outside of cluster:
1. No control planes
```bash
./_output/bin/darwin_arm64/up ctp get one
Control plane one not found
```

```bash
./_output/bin/darwin_arm64/up ctp delete one
Control plane one not found
```

```bash
./_output/bin/darwin_arm64/up ctp list
No control planes found
```
3. Create control plane
```bash
./_output/bin/darwin_arm64/up ctp create one
one created
```
```bash
kubectl get ctp
NAME   READY   MESSAGE                AGE
one    False   Waiting for start up   3s
```
```bash
./_output/bin/darwin_arm64/up ctp get one
NAME   ID                                     STATUS     MESSAGE                CONNECTION NAME   CONNECTION NAMESPACE
one    cd47bda5-cf80-44da-92bf-88217e375e82   Creating   Waiting for start up   kubeconfig-one    default
```

Once the control plane is ready:
```bash
./_output/bin/darwin_arm64/up ctp get one
NAME   ID                                     STATUS      MESSAGE   CONNECTION NAME   CONNECTION NAMESPACE
one    cd47bda5-cf80-44da-92bf-88217e375e82   Available             kubeconfig-one    default
```
```bash
./_output/bin/darwin_arm64/up ctp list
NAME   ID                                     STATUS      MESSAGE   CONNECTION NAME   CONNECTION NAMESPACE
one    cd47bda5-cf80-44da-92bf-88217e375e82   Available             kubeconfig-one    default
```
```bash
kubectl get ctp
NAME   READY   MESSAGE   AGE
one    True              4m48s
```
5. Create second control plane
```bash
./_output/bin/darwin_arm64/up ctp create two
two created
```
```bash
kubectl get ctp
NAME   READY   MESSAGE                AGE
one    True                           4m57s
two    False   Waiting for start up   5s
```
```bash
./_output/bin/darwin_arm64/up ctp get two
NAME   ID                                     STATUS     MESSAGE                CONNECTION NAME   CONNECTION NAMESPACE
two    1dbef2a1-b166-4a0b-acff-2b881a5ae3f2   Creating   Waiting for start up   kubeconfig-two    default
```
```bash
./_output/bin/darwin_arm64/up ctp list
NAME   ID                                     STATUS      MESSAGE                CONNECTION NAME   CONNECTION NAMESPACE
one    cd47bda5-cf80-44da-92bf-88217e375e82   Available                          kubeconfig-one    default
two    1dbef2a1-b166-4a0b-acff-2b881a5ae3f2   Creating    Waiting for start up   kubeconfig-two    default
```
6. Delete control plane
```bash
./_output/bin/darwin_arm64/up ctp delete two
two deleted
```
```bash
./_output/bin/darwin_arm64/up ctp list
NAME   ID                                     STATUS      MESSAGE   CONNECTION NAME   CONNECTION NAMESPACE
one    cd47bda5-cf80-44da-92bf-88217e375e82   Available             kubeconfig-one    default
```
```bash
./_output/bin/darwin_arm64/up ctp get two
Control plane two not found
```
```bash
kubectl get ctp
NAME   READY   MESSAGE   AGE
one    True              5m23s
```