### PR TITLE
Move `ctp connect` to `ctp connector install`

### DIFF
--- a/cmd/up/controlplane/connector/connector.go
+++ b/cmd/up/controlplane/connector/connector.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"github.com/alecthomas/kong"
+
+	"github.com/upbound/up/internal/feature"
+)
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
+
+// Cmd contains commands for installing mcp-connector into an App Cluster.
+type Cmd struct {
+	Install installCmd `cmd:"" help:"Install mcp-connector into an App Cluster."`
+}

--- a/cmd/up/controlplane/connector/connector.go
+++ b/cmd/up/controlplane/connector/connector.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Upbound Inc
+// Copyright 2023 Upbound Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/up/controlplane/connector/install.go
+++ b/cmd/up/controlplane/connector/install.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controlplane
+package connector
 
 import (
 	"context"
@@ -48,7 +48,7 @@ const (
 )
 
 // AfterApply sets default values in command after assignment and validation.
-func (c *connectCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+func (c *installCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	if c.ClusterName == "" {
 		c.ClusterName = c.Namespace
 	}
@@ -94,9 +94,9 @@ func (c *connectCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) e
 	return nil
 }
 
-// connectCmd connects the current cluster to a control plane in an account on
+// installCmd connects the current cluster to a control plane in an account on
 // Upbound.
-type connectCmd struct {
+type installCmd struct {
 	mgr     install.Manager
 	parser  install.ParameterParser
 	kClient kubernetes.Interface
@@ -113,7 +113,7 @@ type connectCmd struct {
 }
 
 // Run executes the connect command.
-func (c *connectCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+func (c *installCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
 		return fmt.Errorf("connect is not supported for space profile %q", upCtx.ProfileName)
 	}
@@ -147,7 +147,7 @@ func (c *connectCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	return nil
 }
 
-func (c *connectCmd) getToken(p pterm.TextPrinter, upCtx *upbound.Context) (string, error) {
+func (c *installCmd) getToken(p pterm.TextPrinter, upCtx *upbound.Context) (string, error) {
 	if c.Token != "" {
 		return c.Token, nil
 	}

--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -21,6 +21,7 @@ import (
 	"github.com/posener/complete"
 
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
+	"github.com/upbound/up/cmd/up/controlplane/connector"
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
 	"github.com/upbound/up/cmd/up/controlplane/pkg"
 	"github.com/upbound/up/cmd/up/controlplane/pullsecret"
@@ -92,7 +93,7 @@ type Cmd struct {
 	List   listCmd   `cmd:"" help:"List control planes for the account."`
 	Get    getCmd    `cmd:"" help:"Get a single control plane."`
 
-	Connect connectCmd `cmd:"" help:"Connect an App Cluster to a managed control plane."`
+	Connector connector.Cmd `cmd:"" help:"Connect an App Cluster to a managed control plane."`
 
 	Configuration pkg.Cmd `cmd:"" set:"package_type=Configuration" help:"Manage Configurations."`
 	Provider      pkg.Cmd `cmd:"" set:"package_type=Provider" help:"Manage Providers."`


### PR DESCRIPTION
### Description of your changes
This PR shuffles the subcommands around a little. This is in anticipation of some reworking for `ctp connect`.

This changeset builds on #388. #388 should be merged/reviewed prior to this PR.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
```bash
./_output/bin/darwin_arm64/up ctp --help
Usage: up controlplane (ctp) <command>

Interact with control planes.

Flags:
  -h, --help                         Show context-sensitive help.
      --format="default"             Format for get/list commands. Can be: json, yaml, default
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates
                                     ($UP_INSECURE_SKIP_TLS_VERIFY).
  -d, --debug=INT                    [INSECURE] Run with debug logging. Repeat to increase verbosity.
                                     Output might contain confidential data like tokens ($UP_DEBUG).

Commands:
  controlplane (ctp) create           Create a managed control plane.
  controlplane (ctp) delete           Delete a control plane.
  controlplane (ctp) list             List control planes for the account.
  controlplane (ctp) get              Get a single control plane.
  controlplane (ctp) connector        Connect an App Cluster to a managed control plane.
  controlplane (ctp) configuration    Manage Configurations.
  controlplane (ctp) provider         Manage Providers.
  controlplane (ctp) pull-secret      Manage package pull secrets.
  controlplane (ctp) kubeconfig       Manage control plane kubeconfig data.
```
```bash
./_output/bin/darwin_arm64/up ctp connector --help
Usage: up controlplane (ctp) connector <command>

Connect an App Cluster to a managed control plane.

Flags:
  -h, --help                         Show context-sensitive help.
      --format="default"             Format for get/list commands. Can be: json, yaml, default
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates
                                     ($UP_INSECURE_SKIP_TLS_VERIFY).
  -d, --debug=INT                    [INSECURE] Run with debug logging. Repeat to increase verbosity.
                                     Output might contain confidential data like tokens ($UP_DEBUG).

Commands:
  controlplane (ctp) connector install    Install mcp-connector into an App Cluster.
```
