### PR TITLE
Re-introduce `up ctp connect` add `up ctp disconnect`

### DIFF
--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -1,9 +1,190 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controlplane
 
-// upbound_acct1_ctp1_kind-kind
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
 
-// use the current context in kubeconfig
-// config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
-// if err != nil {
-// 	panic(err.Error())
-// }
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/upbound/up-sdk-go/service/configurations"
+	cp "github.com/upbound/up-sdk-go/service/controlplanes"
+
+	"github.com/upbound/up/internal/controlplane"
+	"github.com/upbound/up/internal/controlplane/cloud"
+	"github.com/upbound/up/internal/controlplane/space"
+	"github.com/upbound/up/internal/kube"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+var (
+	upboundPrefix = "upbound_"
+
+	errFmtConfigBroken = "config is broken, missing %s: %q"
+)
+
+type ctpConnector interface {
+	GetKubeConfig(ctx context.Context, name string) (*api.Config, error)
+}
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *connectCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+
+	if upCtx.Profile.IsSpace() {
+		kubeconfig, err := upCtx.Profile.GetKubeClientConfig()
+		if err != nil {
+			return err
+		}
+		client, err := dynamic.NewForConfig(kubeconfig)
+		if err != nil {
+			return err
+		}
+		c.client = space.New(client)
+	} else {
+		if c.Token == "" {
+			return fmt.Errorf("--token must be specified")
+		}
+
+		cfg, err := upCtx.BuildSDKConfig()
+		if err != nil {
+			return err
+		}
+		ctpclient := cp.NewClient(cfg)
+		cfgclient := configurations.NewClient(cfg)
+
+		// The cloud client needs the proxy endpoint and a PAT token for
+		// setting up communication with Upbound Cloud.
+		c.client = cloud.New(
+			ctpclient,
+			cfgclient,
+			upCtx.Account,
+			cloud.WithToken(c.Token),
+			cloud.WithProxyEndpoint(upCtx.ProxyEndpoint),
+		)
+	}
+
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+	return nil
+}
+
+// getCmd gets a single control plane in an account on Upbound.
+type connectCmd struct {
+	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
+	Token string `help:"API token used to authenticate. Required for Upbound Cloud; ignored otherwise."`
+
+	client ctpConnector
+}
+
+// Run executes the get command.
+func (c *connectCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
+	if upCtx.Account == "" {
+		return errors.New("error: account is missing from profile")
+	}
+
+	// Load kubeconfig from filesystem.
+	kcloader, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).RawConfig()
+	if err != nil {
+		return err
+	}
+	// Check if the fs kubeconfig is already pointing to a control plane and
+	// return early if so.
+	origContext := kcloader.CurrentContext
+	if strings.HasPrefix(origContext, upboundPrefix) {
+		return nil
+	}
+
+	cfg, err := c.client.GetKubeConfig(context.Background(), c.Name)
+	if controlplane.IsNotFound(err) {
+		p.Printfln("Control plane %s not found", c.Name)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	modifiedCfg, err := updateKubeConfig(*cfg, upCtx.Account, c.Name, origContext)
+	if err != nil {
+		return err
+	}
+	// NOTE(tnthornton) we don't current support supplying files outside of
+	// the default system kubeconfig.
+	if err := kube.ApplyControlPlaneKubeconfig(modifiedCfg, "", upCtx.WrapTransport); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// updateKubeConfig updates the given kubeconfig with new cluster, user, and
+// context keys based on the account, control plane name, and original context
+// that are provided.
+func updateKubeConfig(cfg api.Config, account, ctpName, origContext string) (api.Config, error) {
+	// Grap the context from control plane kubeconfig.
+	sourceKey := defaultContextName(account, ctpName)
+	ctpKey := controlplaneContextName(account, ctpName, origContext)
+
+	// Update the context, cluster, and user names in the control plane
+	// config.
+	cluster, ok := cfg.Clusters[sourceKey]
+	if !ok {
+		return api.Config{}, fmt.Errorf(errFmtConfigBroken, "cluster", sourceKey)
+	}
+	cfg.Clusters[ctpKey] = cluster
+	delete(cfg.Clusters, sourceKey)
+
+	users, ok := cfg.AuthInfos[sourceKey]
+	if !ok {
+		return api.Config{}, fmt.Errorf(errFmtConfigBroken, "user", sourceKey)
+	}
+	cfg.AuthInfos[ctpKey] = users
+	delete(cfg.AuthInfos, sourceKey)
+
+	// Rename context, move under upbound- namespace.
+	context, ok := cfg.Contexts[sourceKey]
+	if !ok {
+		return api.Config{}, fmt.Errorf(errFmtConfigBroken, "context", sourceKey)
+	}
+	context.AuthInfo = ctpKey
+	context.Cluster = ctpKey
+	cfg.Contexts[ctpKey] = context
+	delete(cfg.Contexts, sourceKey)
+
+	// Update current context in the config to the built key. The next step
+	// will update the fs kubeconfig based on these details and without this
+	// step the update will fail due to the current context being set to the
+	// sourceKey value above.
+	cfg.CurrentContext = ctpKey
+	return cfg, nil
+}
+
+func defaultContextName(account, ctpName string) string {
+	return fmt.Sprintf("%s-%s", account, ctpName)
+}
+
+func controlplaneContextName(account, ctpName, origCtx string) string {
+	return fmt.Sprintf("%s%s_%s_%s", upboundPrefix, account, ctpName, origCtx)
+}

--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -1,0 +1,9 @@
+package controlplane
+
+// upbound_acct1_ctp1_kind-kind
+
+// use the current context in kubeconfig
+// config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+// if err != nil {
+// 	panic(err.Error())
+// }

--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -40,7 +40,7 @@ import (
 	"github.com/upbound/up/internal/upterm"
 )
 
-var (
+const (
 	upboundPrefix = "upbound_"
 
 	errFmtConfigBroken = "config is broken, missing %s: %q"

--- a/cmd/up/controlplane/connect_test.go
+++ b/cmd/up/controlplane/connect_test.go
@@ -1,0 +1,27 @@
+package controlplane
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestConnect(t *testing.T) {
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).RawConfig()
+
+	fmt.Println(cfg.CurrentContext)
+	fmt.Println(err)
+
+	// check if current context is for a control plane
+	//
+}
+
+func SwitchContext(kubeConfig *api.Config, otherContext string) error {
+	kubeConfig.CurrentContext = otherContext
+	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), *kubeConfig, false)
+}

--- a/cmd/up/controlplane/connect_test.go
+++ b/cmd/up/controlplane/connect_test.go
@@ -1,27 +1,168 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controlplane
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
-	"k8s.io/client-go/tools/clientcmd"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-func TestConnect(t *testing.T) {
-	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{},
-	).RawConfig()
+func TestUpdateKubeConfig(t *testing.T) {
+	type args struct {
+		cfg     api.Config
+		account string
+		ctpName string
+		context string
+	}
+	type want struct {
+		cfg api.Config
+		err error
+	}
 
-	fmt.Println(cfg.CurrentContext)
-	fmt.Println(err)
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrorMissingCluster": {
+			reason: "If the supplied config is missing the expected cluster, an error is returned.",
+			args: args{
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"demo-ctp1": {},
+					},
+					Contexts: map[string]*api.Context{
+						"demo-ctp1": {
+							Cluster:  "demo-ctp1",
+							AuthInfo: "demo-ctp1",
+						},
+					},
+					CurrentContext: "demo-ctp1",
+				},
+				account: "demo",
+				ctpName: "ctp1",
+				context: "kind-kind",
+			},
+			want: want{
+				cfg: api.Config{},
+				err: errors.New(`config is broken, missing cluster: "demo-ctp1"`),
+			},
+		},
+		"ErrorMissingUser": {
+			reason: "If the supplied config is missing the expected user, an error is returned.",
+			args: args{
+				cfg: api.Config{
+					Clusters: map[string]*api.Cluster{
+						"demo-ctp1": {},
+					},
+					Contexts: map[string]*api.Context{
+						"demo-ctp1": {
+							Cluster:  "demo-ctp1",
+							AuthInfo: "demo-ctp1",
+						},
+					},
+					CurrentContext: "demo-ctp1",
+				},
+				account: "demo",
+				ctpName: "ctp1",
+				context: "kind-kind",
+			},
+			want: want{
+				cfg: api.Config{},
+				err: errors.New(`config is broken, missing user: "demo-ctp1"`),
+			},
+		},
+		"ErrorMissingContext": {
+			reason: "If the supplied config is missing the expected context, an error is returned.",
+			args: args{
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"demo-ctp1": {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"demo-ctp1": {},
+					},
+					CurrentContext: "demo-ctp1",
+				},
+				account: "demo",
+				ctpName: "ctp1",
+				context: "kind-kind",
+			},
+			want: want{
+				cfg: api.Config{},
+				err: errors.New(`config is broken, missing context: "demo-ctp1"`),
+			},
+		},
+		"Success": {
+			reason: "Supplying an account, control plane name, and context should update the config.",
+			args: args{
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"demo-ctp1": {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"demo-ctp1": {},
+					},
+					Contexts: map[string]*api.Context{
+						"demo-ctp1": {
+							Cluster:  "demo-ctp1",
+							AuthInfo: "demo-ctp1",
+						},
+					},
+					CurrentContext: "demo-ctp1",
+				},
+				account: "demo",
+				ctpName: "ctp1",
+				context: "kind-kind",
+			},
+			want: want{
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"upbound_demo_ctp1_kind-kind": {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"upbound_demo_ctp1_kind-kind": {},
+					},
+					Contexts: map[string]*api.Context{
+						"upbound_demo_ctp1_kind-kind": {
+							Cluster:  "upbound_demo_ctp1_kind-kind",
+							AuthInfo: "upbound_demo_ctp1_kind-kind",
+						},
+					},
+					CurrentContext: "upbound_demo_ctp1_kind-kind",
+				},
+			},
+		},
+	}
 
-	// check if current context is for a control plane
-	//
-}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 
-func SwitchContext(kubeConfig *api.Config, otherContext string) error {
-	kubeConfig.CurrentContext = otherContext
-	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), *kubeConfig, false)
+			got, err := updateKubeConfig(tc.args.cfg, tc.args.account, tc.args.ctpName, tc.args.context)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nUpdateKubeConfig(...): -want err, +got err:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.cfg, got); diff != "" {
+				t.Errorf("\n%s\nUpdateKubeConfig(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
 }

--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -88,10 +88,12 @@ func PredictControlPlanes() complete.Predictor {
 
 // Cmd contains commands for interacting with control planes.
 type Cmd struct {
-	Create createCmd `cmd:"" help:"Create a managed control plane."`
-	Delete deleteCmd `cmd:"" help:"Delete a control plane."`
-	List   listCmd   `cmd:"" help:"List control planes for the account."`
-	Get    getCmd    `cmd:"" help:"Get a single control plane."`
+	Connect    connectCmd    `cmd:"" help:"Connect kubectl to control plane."`
+	Disconnect disconnectCmd `cmd:"" help:"Disconnect kubectl from control plane."`
+	Create     createCmd     `cmd:"" help:"Create a managed control plane."`
+	Delete     deleteCmd     `cmd:"" help:"Delete a control plane."`
+	List       listCmd       `cmd:"" help:"List control planes for the account."`
+	Get        getCmd        `cmd:"" help:"Get a single control plane."`
 
 	Connector connector.Cmd `cmd:"" help:"Connect an App Cluster to a managed control plane."`
 
@@ -144,7 +146,6 @@ func extractSpaceFields(obj any) []string {
 func tabularPrint(obj any, printer upterm.ObjectPrinter, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
 		return printer.Print(obj, spacefieldNames, extractSpaceFields)
-	} else {
-		return printer.Print(obj, cloudfieldNames, extractCloudFields)
 	}
+	return printer.Print(obj, cloudfieldNames, extractCloudFields)
 }

--- a/cmd/up/controlplane/disconnect.go
+++ b/cmd/up/controlplane/disconnect.go
@@ -28,7 +28,7 @@ import (
 	"github.com/upbound/up/internal/upterm"
 )
 
-var (
+const (
 	errFmtCurrentContext = "context %q is currently in use"
 	errFmtContextParts   = "given context does not have the correct number of parts, expected: 4, got: %d"
 )

--- a/cmd/up/controlplane/disconnect.go
+++ b/cmd/up/controlplane/disconnect.go
@@ -1,0 +1,105 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+var (
+	errFmtCurrentContext = "context %q is currently in use"
+	errFmtContextParts   = "given context does not have the correct number of parts, expected: 4, got: %d"
+)
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *disconnectCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+
+	return nil
+}
+
+// getCmd gets a single control plane in an account on Upbound.
+type disconnectCmd struct{}
+
+// Run executes the get command.
+func (c *disconnectCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
+	if upCtx.Account == "" {
+		return errors.New("error: account is missing from profile")
+	}
+
+	kcloader, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	).RawConfig()
+	if err != nil {
+		return err
+	}
+
+	cptContext := kcloader.CurrentContext
+	if !strings.HasPrefix(cptContext, upboundPrefix) {
+		return errors.New("current kube context is not a control plane context")
+	}
+
+	target, err := origContext(cptContext)
+	if err != nil {
+		return err
+	}
+
+	if err := switchContext(kcloader, target); err != nil {
+		return err
+	}
+
+	kcloader.CurrentContext = target
+	modifiedCfg, err := removeFromConfig(kcloader, cptContext)
+	if err != nil {
+		return err
+	}
+
+	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), modifiedCfg, false)
+}
+
+func origContext(currentCtx string) (string, error) {
+	parts := strings.Split(currentCtx, "_")
+	if len(parts) != 4 {
+		return "", fmt.Errorf(errFmtContextParts, len(parts))
+	}
+	return parts[len(parts)-1], nil
+}
+
+func switchContext(cfg api.Config, target string) error {
+	cfg.CurrentContext = target
+	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), cfg, false)
+}
+
+func removeFromConfig(cfg api.Config, contextName string) (api.Config, error) {
+	if cfg.CurrentContext == contextName {
+		return api.Config{}, fmt.Errorf(errFmtCurrentContext, contextName)
+	}
+
+	delete(cfg.AuthInfos, contextName)
+	delete(cfg.Clusters, contextName)
+	delete(cfg.Contexts, contextName)
+	return cfg, nil
+}

--- a/cmd/up/controlplane/disconnect_test.go
+++ b/cmd/up/controlplane/disconnect_test.go
@@ -1,0 +1,231 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestOrigContext(t *testing.T) {
+	type args struct {
+		context string
+	}
+	type want struct {
+		result string
+		err    error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrorInvalidContextName": {
+			reason: "We expect that there are 4 parts in a well formed context.",
+			args: args{
+				context: "demo-ctp1",
+			},
+			want: want{
+				err: errors.New("given context does not have the correct number of parts, expected: 4, got: 1"),
+			},
+		},
+		"Success": {
+			reason: "A well formed context name should be parsed successfully.",
+			args: args{
+				context: "upbound_demo_cpt1_kind-kind",
+			},
+			want: want{
+				result: "kind-kind",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			got, err := origContext(tc.args.context)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nOrigContext(...): -want, +got:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.result, got); diff != "" {
+				t.Errorf("\n%s\nOrigContext(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestRemoveFromConfig(t *testing.T) {
+	type args struct {
+		cfg     api.Config
+		context string
+	}
+	type want struct {
+		cfg api.Config
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ErrorCurrentContext": {
+			reason: "If the current context is equal to the provided context an error is returned.",
+			args: args{
+				context: "upbound_demo_ctp1_kind-kind",
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Contexts: map[string]*api.Context{
+						"upbound_demo_ctp1_kind-kind": {
+							Cluster:  "upbound_demo_ctp1_kind-kind",
+							AuthInfo: "upbound_demo_ctp1_kind-kind",
+						},
+						"kind-kind": {
+							Cluster:  "kind-kind",
+							AuthInfo: "kind-kind",
+						},
+					},
+					CurrentContext: "upbound_demo_ctp1_kind-kind",
+				},
+			},
+			want: want{
+				err: errors.New(`context "upbound_demo_ctp1_kind-kind" is currently in use`),
+			},
+		},
+		"InvalidContextName": {
+			reason: "No change to the config occurs if we're given a context that does not exist.",
+			args: args{
+				context: "upbound_demo_dne_kind-kind",
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Contexts: map[string]*api.Context{
+						"upbound_demo_ctp1_kind-kind": {
+							Cluster:  "upbound_demo_ctp1_kind-kind",
+							AuthInfo: "upbound_demo_ctp1_kind-kind",
+						},
+						"kind-kind": {
+							Cluster:  "kind-kind",
+							AuthInfo: "kind-kind",
+						},
+					},
+					CurrentContext: "kind-kind",
+				},
+			},
+			want: want{
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Contexts: map[string]*api.Context{
+						"upbound_demo_ctp1_kind-kind": {
+							Cluster:  "upbound_demo_ctp1_kind-kind",
+							AuthInfo: "upbound_demo_ctp1_kind-kind",
+						},
+						"kind-kind": {
+							Cluster:  "kind-kind",
+							AuthInfo: "kind-kind",
+						},
+					},
+					CurrentContext: "kind-kind",
+				},
+			},
+		},
+		"Success": {
+			reason: "A well formed context name should be parsed successfully.",
+			args: args{
+				context: "upbound_demo_ctp1_kind-kind",
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"upbound_demo_ctp1_kind-kind": {},
+						"kind-kind":                   {},
+					},
+					Contexts: map[string]*api.Context{
+						"upbound_demo_ctp1_kind-kind": {
+							Cluster:  "upbound_demo_ctp1_kind-kind",
+							AuthInfo: "upbound_demo_ctp1_kind-kind",
+						},
+						"kind-kind": {
+							Cluster:  "kind-kind",
+							AuthInfo: "kind-kind",
+						},
+					},
+					CurrentContext: "kind-kind",
+				},
+			},
+			want: want{
+				cfg: api.Config{
+					AuthInfos: map[string]*api.AuthInfo{
+						"kind-kind": {},
+					},
+					Clusters: map[string]*api.Cluster{
+						"kind-kind": {},
+					},
+					Contexts: map[string]*api.Context{
+						"kind-kind": {
+							Cluster:  "kind-kind",
+							AuthInfo: "kind-kind",
+						},
+					},
+					CurrentContext: "kind-kind",
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			got, err := removeFromConfig(tc.args.cfg, tc.args.context)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nRemoveFromConfig(...): -want, +got:\n%s", tc.reason, diff)
+			}
+
+			if diff := cmp.Diff(tc.want.cfg, got); diff != "" {
+				t.Errorf("\n%s\nRemoveFromConfig(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -77,7 +77,6 @@ func (c *getCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *u
 		p.Printfln("Control plane %s not found", c.Name)
 		return nil
 	}
-
 	if err != nil {
 		return err
 	}

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -58,7 +58,7 @@ func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 		c.Token = strings.TrimSpace(string(b))
 	}
 	mcpConf := kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, path.Join(upCtx.Account, c.Name), c.Token)
-	if err := kube.ApplyControlPlaneKubeconfig(mcpConf, c.File, upCtx.WrapTransport); err != nil {
+	if err := kube.ApplyControlPlaneKubeconfig(*mcpConf, c.File, upCtx.WrapTransport); err != nil {
 		return err
 	}
 	if c.File == "" {

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -57,7 +57,7 @@ func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 		}
 		c.Token = strings.TrimSpace(string(b))
 	}
-	mcpConf := kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, path.Join(upCtx.Account, c.Name), c.Token)
+	mcpConf := kube.BuildControlPlaneKubeconfig(upCtx.ProxyEndpoint, path.Join(upCtx.Account, c.Name), c.Token, true)
 	if err := kube.ApplyControlPlaneKubeconfig(*mcpConf, c.File, upCtx.WrapTransport); err != nil {
 		return err
 	}

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -53,6 +53,7 @@ func (c *spaceCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	}
 
 	prof := profile.Profile{
+		Account:     upCtx.Account,
 		Type:        profile.Space,
 		Kubeconfig:  c.Kube.Kubeconfig,
 		KubeContext: c.Kube.GetContext(),

--- a/cmd/up/space/space.go
+++ b/cmd/up/space/space.go
@@ -51,3 +51,10 @@ func overrideRegistry(candidate string, params map[string]any) {
 		params["registry"] = candidate
 	}
 }
+
+func ensureAccount(params map[string]any) {
+	_, ok := params["account"]
+	if !ok {
+		params["account"] = defaultAcct
+	}
+}

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -153,6 +153,7 @@ func (c *Client) GetKubeConfig(ctx context.Context, name string) (*api.Config, e
 		c.proxy,
 		path.Join(c.account, name),
 		c.token,
+		false,
 	), nil
 }
 

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -69,7 +69,7 @@ func BuildControlPlaneKubeconfig(proxy *url.URL, id string, token string) *api.C
 
 // ApplyControlPlaneKubeconfig applies a control plane kubeconfig to an existing
 // kubeconfig file and sets it as the current context.
-func ApplyControlPlaneKubeconfig(mcpConf *api.Config, existingFilePath string, wrapTransport transport.WrapperFunc) error {
+func ApplyControlPlaneKubeconfig(mcpConf api.Config, existingFilePath string, wrapTransport transport.WrapperFunc) error {
 	po := clientcmd.NewDefaultPathOptions()
 	po.LoadingRules.ExplicitPath = existingFilePath
 	conf, err := po.GetStartingConfig()

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -49,9 +49,12 @@ func GetKubeConfig(path string) (*rest.Config, error) {
 }
 
 // BuildControlPlaneKubeconfig builds a kubeconfig entry for a control plane.
-func BuildControlPlaneKubeconfig(proxy *url.URL, id string, token string) *api.Config { //nolint:interfacer
+func BuildControlPlaneKubeconfig(proxy *url.URL, id string, token string, includePrefix bool) *api.Config { //nolint:interfacer
 	conf := api.NewConfig()
-	key := fmt.Sprintf(UpboundKubeconfigKeyFmt, strings.ReplaceAll(id, "/", "-"))
+	key := strings.ReplaceAll(id, "/", "-")
+	if includePrefix {
+		key = fmt.Sprintf(UpboundKubeconfigKeyFmt, key)
+	}
 	proxy.Path = path.Join(proxy.Path, id, UpboundK8sResource)
 	conf.Clusters[key] = &api.Cluster{
 		Server: proxy.String(),


### PR DESCRIPTION
### Description of your changes
In order to make it easier to interact with a control plane, we're introducing a new command and bringing back a previous command with different behavior.

#### Connect
`up ctp connect {name}` has been reworked to connect the operators local kubeconfig to the target control plane. From a UX perspective, this means that an operator can simply point to a control plane and easily begin working within it.

#### Disconnect
`up ctp disconnect` has been introduced to easily allow the operator to switch back to the previous context they were using before initiating the `connect` command. This makes switching between target a control plane and another kubernetes cluster, quick and frictionless.

Fixes #391 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Introduced new tests
2. Captured the below video working against a local space
https://github.com/upbound/up/assets/2375126/1fbe5e6c-09e6-4289-9d75-a7f8a178aae6

3. Verified functionality was consistent between spaces and cloud.