### PR TITLE
Bump the UXP prereq for spaces to v1.13.2-up.2

### DIFF
--- a/cmd/up/space/prerequisites/uxp/uxp.go
+++ b/cmd/up/space/prerequisites/uxp/uxp.go
@@ -36,7 +36,7 @@ var (
 	ns        = "upbound-system"
 	// Chart version to be installed. universal-crossplane does not include a
 	// v prefix.
-	version = "1.12.2-up.2"
+	version = "1.13.2-up.2"
 
 	xrdCRD = "compositeresourcedefinitions.apiextensions.crossplane.io"
 


### PR DESCRIPTION
### Description of your changes
Updating the version of UXP that the `up space init` command will install if there is no previous UXP install in the cluster.

Fixes #392 

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Run `up space init`
2. Verified the crossplane image in the cluster:
```bash
kubectl get pods -A -o json | jq '.items[] | {ns:.metadata.namespace, name:.metadata.name,image:.spec.containers[].image}' | grep upbound/crossplane
  "image": "upbound/crossplane:v1.13.2-up.2"
  "image": "upbound/crossplane:v1.13.2-up.2"
```
