### PR TITLE
MCP Connector support for Spaces

### DIFF
--- a/cmd/up/controlplane/connector/connector.go
+++ b/cmd/up/controlplane/connector/connector.go
@@ -27,5 +27,6 @@ func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
 
 // Cmd contains commands for installing mcp-connector into an App Cluster.
 type Cmd struct {
-	Install installCmd `cmd:"" help:"Install mcp-connector into an App Cluster."`
+	Install   installCmd   `cmd:"" help:"Install mcp-connector into an App Cluster."`
+	Uninstall uninstallCmd `cmd:"" help:"Uninstall mcp-connector from an App Cluster."`
 }

--- a/cmd/up/controlplane/connector/install.go
+++ b/cmd/up/controlplane/connector/install.go
@@ -131,7 +131,7 @@ func (c *installCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	// Some of these settings are only applicable if pointing to an Upbound
 	// Cloud control plane. We leave them consistent since they won't impact
 	// our ability to point the connector at Space control plane.
-	params["mcp"] = map[string]string{
+	params["mcp"] = map[string]any{
 		"account":   upCtx.Account,
 		"name":      c.Name,
 		"namespace": c.Namespace,
@@ -144,9 +144,9 @@ func (c *installCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	if c.ControlPlaneSecret != "" {
 		v := params["mcp"]
 		param := v.(map[string]any)
-		param["secret"] = map[string]string{
+		param["secret"] = map[string]any{
 			"name":      c.ControlPlaneSecret,
-			"provision": "false",
+			"provision": false,
 		}
 
 		params["mcp"] = param

--- a/cmd/up/controlplane/connector/uninstall.go
+++ b/cmd/up/controlplane/connector/uninstall.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up/internal/install"
+	"github.com/upbound/up/internal/install/helm"
+	"github.com/upbound/up/internal/kube"
+	"github.com/upbound/up/internal/upbound"
+)
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *uninstallCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	if c.ClusterName == "" {
+		c.ClusterName = c.Namespace
+	}
+	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
+	if err != nil {
+		return err
+	}
+	if upCtx.WrapTransport != nil {
+		kubeconfig.Wrap(upCtx.WrapTransport)
+	}
+
+	mgr, err := helm.NewManager(kubeconfig,
+		connectorName,
+		mcpRepoURL,
+		helm.WithNamespace(c.InstallationNamespace),
+		helm.Wait(),
+	)
+	if err != nil {
+		return err
+	}
+	c.mgr = mgr
+	return nil
+}
+
+// uninstallCmd uninstalls UXP.
+type uninstallCmd struct {
+	mgr install.Manager
+
+	ClusterName           string `help:"Name of the cluster connecting to the control plane. If not provided, the namespace argument value will be used."`
+	Namespace             string `arg:"" required:"" help:"Namespace in the control plane where the claims of the cluster will be stored."`
+	Kubeconfig            string `type:"existingfile" help:"Override the default kubeconfig path."`
+	InstallationNamespace string `short:"n" env:"MCP_CONNECTOR_NAMESPACE" default:"kube-system" help:"Kubernetes namespace for MCP Connector. Default is kube-system."`
+}
+
+// Run executes the uninstall command.
+func (c *uninstallCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
+	if err := c.mgr.Uninstall(); err != nil {
+		return err
+	}
+	p.Printfln("MCP Connector uninstalled")
+	return nil
+}

--- a/cmd/up/controlplane/connector/uninstall.go
+++ b/cmd/up/controlplane/connector/uninstall.go
@@ -61,7 +61,7 @@ type uninstallCmd struct {
 }
 
 // Run executes the uninstall command.
-func (c *uninstallCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
+func (c *uninstallCmd) Run(p pterm.TextPrinter) error {
 	if err := c.mgr.Uninstall(); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description of your changes
We'd like to enable operators to install the mcp-connector into App Clusters pointing to a Space control plane. In order to accomplish that, we needed to slightly extend what the current `up ctp connector install` command is doing and allow passing in:
```
--control-plane-secret={secret name}
```
so that an operator can supply the control plane secret.

In addition, we wanted to make it easier to uninstall the mcp-connector. To accomplish this a new subcommand `up ctp connector uninstall` was introduced.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Verify commands exist
```
./_output/bin/darwin_arm64/up ctp connector --help
Usage: up controlplane (ctp) connector <command>

Connect an App Cluster to a managed control plane.

Flags:
  -h, --help                         Show context-sensitive help.
      --format="default"             Format for get/list commands. Can be: json, yaml, default
  -v, --version                      Print version and exit.
  -q, --quiet                        Suppress all output.
      --pretty                       Pretty print output.

      --domain=https://upbound.io    Root Upbound domain ($UP_DOMAIN).
      --profile=STRING               Profile used to execute command ($UP_PROFILE).
  -a, --account=STRING               Account used to execute command ($UP_ACCOUNT).
      --insecure-skip-tls-verify     [INSECURE] Skip verifying TLS certificates ($UP_INSECURE_SKIP_TLS_VERIFY).
  -d, --debug=INT                    [INSECURE] Run with debug logging. Repeat to increase verbosity. Output
                                     might contain confidential data like tokens ($UP_DEBUG).

Commands:
  controlplane (ctp) connector install      Install mcp-connector into an App Cluster.
  controlplane (ctp) connector uninstall    Uninstall mcp-connector from an App Cluster.
```

2. Installing mcp-connector
```bash
./_output/bin/darwin_arm64/up ctp connector install ctp1 default --control-plane-secret=test

kubectl -n kube-system get pods -o custom-columns="POD_NAME":".metadata.name"
POD_NAME
coredns-565d847f94-5tld8
coredns-565d847f94-92fc9
etcd-kind-control-plane
kindnet-fwmqk
kube-apiserver-kind-control-plane
kube-controller-manager-kind-control-plane
kube-proxy-jztks
kube-scheduler-kind-control-plane
mcp-connector-b88847fb7-mljm8
```

3. Check the volume has 'test' as the secretName:
```
kubectl -n kube-system get deploy mcp-connector -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    meta.helm.sh/release-name: mcp-connector
    meta.helm.sh/release-namespace: kube-system
  creationTimestamp: "2023-10-12T17:16:15Z"
  generation: 1
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: mcp-connector
  name: mcp-connector
  namespace: kube-system
  resourceVersion: "4063"
  uid: 476f5c46-df37-4a30-af8b-d760e0d48f29
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: mcp-connector
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/name: mcp-connector
    spec:
      containers:
      - args:
        - serve
        - --mcp-kubeconfig=/etc/mcp/kubeconfig
        - --mcp-namespace=default
        - --debug
        image: upbound/mcp-connector:v0.3.4
        imagePullPolicy: IfNotPresent
        name: apiserver
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /etc/mcp
          name: mcp-kubeconfig
          readOnly: true
      - args:
        - bind
        - --mcp-kubeconfig=/etc/mcp/kubeconfig
        - --service-name=mcp-connector
        - --service-namespace=kube-system
        - --service-port=443
        - --debug
        image: upbound/mcp-connector:v0.3.4
        imagePullPolicy: IfNotPresent
        name: binder
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /etc/mcp
          name: mcp-kubeconfig
          readOnly: true
      dnsPolicy: ClusterFirst
      initContainers:
      - args:
        - init
        - default
        - --mcp-kubeconfig=/etc/mcp/kubeconfig
        - --debug
        image: upbound/mcp-connector:v0.3.4
        imagePullPolicy: IfNotPresent
        name: init
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /etc/mcp
          name: mcp-kubeconfig
          readOnly: true
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      serviceAccount: mcp-connector
      serviceAccountName: mcp-connector
      terminationGracePeriodSeconds: 30
      volumes:
      - name: mcp-kubeconfig
        secret:
          defaultMode: 420
          secretName: test                                                 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<,
status:
  conditions:
  - lastTransitionTime: "2023-10-12T17:16:15Z"
    lastUpdateTime: "2023-10-12T17:16:15Z"
    message: Deployment does not have minimum availability.
    reason: MinimumReplicasUnavailable
    status: "False"
    type: Available
  - lastTransitionTime: "2023-10-12T17:16:15Z"
    lastUpdateTime: "2023-10-12T17:16:15Z"
    message: ReplicaSet "mcp-connector-b88847fb7" is progressing.
    reason: ReplicaSetUpdated
    status: "True"
    type: Progressing
  observedGeneration: 1
  replicas: 1
  unavailableReplicas: 1
  updatedReplicas: 1
```

4. Uninstall mcp-connector
```bash
./_output/bin/darwin_arm64/up ctp connector uninstall default
MCP Connector uninstalled

kubectl -n kube-system get pods -o custom-columns="POD_NAME":".metadata.name"
POD_NAME
coredns-565d847f94-5tld8
coredns-565d847f94-92fc9
etcd-kind-control-plane
kindnet-fwmqk
kube-apiserver-kind-control-plane
kube-controller-manager-kind-control-plane
kube-proxy-jztks
kube-scheduler-kind-control-plane
```