### PR TITLE
fix(spaces): Allow ctrl+c while running up space init

### DIFF
--- a/cmd/up/configuration/delete.go
+++ b/cmd/up/configuration/delete.go
@@ -80,8 +80,8 @@ type deleteCmd struct {
 }
 
 // Run executes the delete command.
-func (c *deleteCmd) Run(p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
-	if err := cc.Delete(context.Background(), upCtx.Account, c.Name); err != nil {
+func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
+	if err := cc.Delete(ctx, upCtx.Account, c.Name); err != nil {
 		return err
 	}
 	p.Printfln("%s deleted", c.Name)

--- a/cmd/up/configuration/get.go
+++ b/cmd/up/configuration/get.go
@@ -30,8 +30,8 @@ type getCmd struct {
 }
 
 // Run executes the get command.
-func (c *getCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
-	cfg, err := cc.Get(context.Background(), upCtx.Account, c.Name)
+func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
+	cfg, err := cc.Get(ctx, upCtx.Account, c.Name)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/configuration/list.go
+++ b/cmd/up/configuration/list.go
@@ -30,8 +30,8 @@ var fieldNames = []string{"NAME", "TEMPLATE ID", "PROVIDER", "REPO", "BRANCH", "
 type listCmd struct{}
 
 // Run executes the list command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
-	cfgList, err := cc.List(context.Background(), upCtx.Account)
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
+	cfgList, err := cc.List(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/configuration/template/list.go
+++ b/cmd/up/configuration/template/list.go
@@ -30,8 +30,8 @@ var fieldNames = []string{"ID", "DESCRIPTION", "REPO"}
 type listCmd struct{}
 
 // Run executes the list command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
-	templateList, err := cc.ListTemplates(context.Background())
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, cc *configurations.Client, upCtx *upbound.Context) error {
+	templateList, err := cc.ListTemplates(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -109,7 +109,7 @@ type connectCmd struct {
 }
 
 // Run executes the get command.
-func (c *connectCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
+func (c *connectCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
 	if upCtx.Account == "" {
 		return errors.New("error: account is missing from profile")
 	}
@@ -129,7 +129,7 @@ func (c *connectCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCt
 		return nil
 	}
 
-	cfg, err := c.client.GetKubeConfig(context.Background(), c.Name)
+	cfg, err := c.client.GetKubeConfig(ctx, c.Name)
 	if controlplane.IsNotFound(err) {
 		p.Printfln("Control plane %s not found", c.Name)
 		return nil

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -76,9 +76,9 @@ func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) er
 }
 
 // Run executes the create command.
-func (c *createCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
 	_, err := c.client.Create(
-		context.Background(),
+		ctx,
 		c.Name,
 		controlplane.Options{
 			SecretName:      c.SecretName,

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -68,8 +68,8 @@ func (c *deleteCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) er
 }
 
 // Run executes the delete command.
-func (c *deleteCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if err := c.client.Delete(context.Background(), c.Name); err != nil {
+func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
+	if err := c.client.Delete(ctx, c.Name); err != nil {
 		if controlplane.IsNotFound(err) {
 			p.Printfln("Control plane %s not found", c.Name)
 			return nil

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -71,8 +71,8 @@ type getCmd struct {
 }
 
 // Run executes the get command.
-func (c *getCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
-	ctp, err := c.client.Get(context.Background(), c.Name)
+func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
+	ctp, err := c.client.Get(ctx, c.Name)
 	if controlplane.IsNotFound(err) {
 		p.Printfln("Control plane %s not found", c.Name)
 		return nil

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -69,8 +69,8 @@ func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) erro
 }
 
 // Run executes the list command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
-	l, err := c.client.List(context.Background())
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
+	l, err := c.client.List(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/controlplane/pkg/install.go
+++ b/cmd/up/controlplane/pkg/install.go
@@ -105,7 +105,7 @@ type installCmd struct {
 }
 
 // Run executes the install command.
-func (c *installCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+func (c *installCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
 	ref, err := name.ParseReference(c.Package, name.WithDefaultRegistry(upCtx.RegistryEndpoint.Hostname()))
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func (c *installCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 			Name: s,
 		}
 	}
-	if _, err := c.r.Create(context.Background(), &unstructured.Unstructured{Object: map[string]interface{}{
+	if _, err := c.r.Create(ctx, &unstructured.Unstructured{Object: map[string]interface{}{
 		"apiVersion": "pkg.crossplane.io/v1",
 		"kind":       c.kind,
 		"metadata": map[string]interface{}{
@@ -141,7 +141,7 @@ func (c *installCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 
 	s, _ := upterm.CheckmarkSuccessSpinner.Start(fmt.Sprintf("%s installed. Waiting to become healthy...", c.Name))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	t := int64(c.Wait.Seconds())
 	errC, err := kube.DynamicWatch(ctx, c.r, &t, func(u *unstructured.Unstructured) (bool, error) {

--- a/cmd/up/controlplane/pullsecret/create.go
+++ b/cmd/up/controlplane/pullsecret/create.go
@@ -85,9 +85,9 @@ type createCmd struct {
 }
 
 // Run executes the pull secret command.
-func (c *createCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
+func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
 	if err := kube.NewImagePullApplicator(kube.NewSecretApplicator(c.kClient)).
-		Apply(context.Background(),
+		Apply(ctx,
 			c.Name,
 			c.Namespace,
 			c.user,

--- a/cmd/up/login.go
+++ b/cmd/up/login.go
@@ -113,7 +113,7 @@ type loginCmd struct {
 }
 
 // Run executes the login command.
-func (c *loginCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { // nolint:gocyclo
+func (c *loginCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error { // nolint:gocyclo
 	if c.Token == "-" {
 		b, err := io.ReadAll(c.stdin)
 		if err != nil {
@@ -128,7 +128,7 @@ func (c *loginCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { // n
 		}
 		c.Password = strings.TrimSpace(string(b))
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	auth, profType, err := constructAuth(c.Username, c.Token, c.Password)
 	if err != nil {

--- a/cmd/up/login_test.go
+++ b/cmd/up/login_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -68,7 +69,7 @@ func TestRun(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.err, tc.cmd.Run(pterm.DefaultBasicText.WithWriter(io.Discard), tc.ctx), test.EquateErrors()); diff != "" {
+			if diff := cmp.Diff(tc.err, tc.cmd.Run(context.TODO(), pterm.DefaultBasicText.WithWriter(io.Discard), tc.ctx), test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nRun(...): -want error, +got error:\n%s", tc.reason, diff)
 			}
 		})

--- a/cmd/up/logout.go
+++ b/cmd/up/logout.go
@@ -59,12 +59,12 @@ type logoutCmd struct {
 }
 
 // Run executes the logout command.
-func (c *logoutCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
+func (c *logoutCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
 		return fmt.Errorf("logout is not supported for space profile %q", upCtx.ProfileName)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 	req, err := c.client.NewRequest(ctx, http.MethodPost, logoutPath, "", nil)
 	if err != nil {

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
@@ -175,5 +176,14 @@ func main() {
 
 	ctx, err := parser.Parse(os.Args[1:])
 	parser.FatalIfErrorf(err)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	go func() {
+		<-sigCh
+		ctx.Exit(1)
+	}()
+
 	ctx.FatalIfErrorf(ctx.Run())
 }

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -174,16 +175,19 @@ func main() {
 		return
 	}
 
-	ctx, err := parser.Parse(os.Args[1:])
+	kongCtx, err := parser.Parse(os.Args[1:])
 	parser.FatalIfErrorf(err)
 
+	ctx, cancel := context.WithCancel(context.Background())
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
 	defer signal.Stop(sigCh)
 	go func() {
+		defer cancel()
 		<-sigCh
-		ctx.Exit(1)
+		kongCtx.Exit(1)
 	}()
 
-	ctx.FatalIfErrorf(ctx.Run())
+	kongCtx.BindTo(ctx, (*context.Context)(nil))
+	kongCtx.FatalIfErrorf(kongCtx.Run())
 }

--- a/cmd/up/organization/create.go
+++ b/cmd/up/organization/create.go
@@ -28,8 +28,8 @@ type createCmd struct {
 }
 
 // Run executes the create command.
-func (c *createCmd) Run(p pterm.TextPrinter, oc *organizations.Client) error {
-	if err := oc.Create(context.Background(), &organizations.OrganizationCreateParameters{
+func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, oc *organizations.Client) error {
+	if err := oc.Create(ctx, &organizations.OrganizationCreateParameters{
 		Name: c.Name,
 		// NOTE(hasheddan): we default display name to the same as name.
 		DisplayName: c.Name,

--- a/cmd/up/organization/delete.go
+++ b/cmd/up/organization/delete.go
@@ -60,12 +60,12 @@ type deleteCmd struct {
 }
 
 // Run executes the delete command.
-func (c *deleteCmd) Run(p pterm.TextPrinter, oc *organizations.Client) error {
-	id, err := oc.GetOrgID(context.Background(), c.Name)
+func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, oc *organizations.Client) error {
+	id, err := oc.GetOrgID(ctx, c.Name)
 	if err != nil {
 		return err
 	}
-	if err := oc.Delete(context.Background(), id); err != nil {
+	if err := oc.Delete(ctx, id); err != nil {
 		return err
 	}
 	p.Printfln("%s deleted", c.Name)

--- a/cmd/up/organization/user/invite.go
+++ b/cmd/up/organization/user/invite.go
@@ -32,13 +32,13 @@ type inviteCmd struct {
 }
 
 // Run executes the invite command.
-func (c *inviteCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
-	orgID, err := oc.GetOrgID(context.Background(), c.OrgName)
+func (c *inviteCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+	orgID, err := oc.GetOrgID(ctx, c.OrgName)
 	if err != nil {
 		return err
 	}
 
-	if err = oc.CreateInvite(context.Background(), orgID, &organizations.OrganizationInviteCreateParameters{
+	if err = oc.CreateInvite(ctx, orgID, &organizations.OrganizationInviteCreateParameters{
 		Email:      c.Email,
 		Permission: c.Permission,
 	}); err != nil {

--- a/cmd/up/organization/user/list.go
+++ b/cmd/up/organization/user/list.go
@@ -51,16 +51,16 @@ type listCmd struct {
 }
 
 // Run executes the list command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
-	orgID, err := oc.GetOrgID(context.Background(), c.OrgName)
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+	orgID, err := oc.GetOrgID(ctx, c.OrgName)
 	if err != nil {
 		return err
 	}
-	members, err := oc.ListMembers(context.Background(), orgID)
+	members, err := oc.ListMembers(ctx, orgID)
 	if err != nil {
 		return err
 	}
-	invites, err := oc.ListInvites(context.Background(), orgID)
+	invites, err := oc.ListInvites(ctx, orgID)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/organization/user/remove.go
+++ b/cmd/up/organization/user/remove.go
@@ -69,16 +69,16 @@ func (c *removeCmd) AfterApply(p pterm.TextPrinter) error {
 }
 
 // Run executes the remove command.
-func (c *removeCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
-	orgID, err := oc.GetOrgID(context.Background(), c.OrgName)
+func (c *removeCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *organizations.Client, upCtx *upbound.Context) error {
+	orgID, err := oc.GetOrgID(ctx, c.OrgName)
 	if err != nil {
 		return err
 	}
 
 	// First try to remove an invite.
-	inviteID, err := findInviteID(oc, orgID, c.User)
+	inviteID, err := findInviteID(ctx, oc, orgID, c.User)
 	if err == nil {
-		if err = oc.DeleteInvite(context.Background(), orgID, inviteID); err != nil {
+		if err = oc.DeleteInvite(ctx, orgID, inviteID); err != nil {
 			return err
 		}
 
@@ -87,9 +87,9 @@ func (c *removeCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *o
 	}
 
 	// If no invite was found, try to remove a member.
-	userID, err := findUserID(oc, orgID, c.User)
+	userID, err := findUserID(ctx, oc, orgID, c.User)
 	if err == nil {
-		if err = oc.RemoveMember(context.Background(), orgID, userID); err != nil {
+		if err = oc.RemoveMember(ctx, orgID, userID); err != nil {
 			return err
 		}
 		p.Printfln("Member %s removed from %s", c.User, c.OrgName)
@@ -100,8 +100,8 @@ func (c *removeCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, oc *o
 }
 
 // findInviteID returns the invite ID for the given email address, if it exists.
-func findInviteID(oc *organizations.Client, orgID uint, email string) (uint, error) {
-	invites, err := oc.ListInvites(context.Background(), orgID)
+func findInviteID(ctx context.Context, oc *organizations.Client, orgID uint, email string) (uint, error) {
+	invites, err := oc.ListInvites(ctx, orgID)
 	if err != nil {
 		return 0, err
 	}
@@ -114,8 +114,8 @@ func findInviteID(oc *organizations.Client, orgID uint, email string) (uint, err
 }
 
 // findUserID returns the user ID for the given username or email address, if it exists.
-func findUserID(oc *organizations.Client, orgID uint, username string) (uint, error) {
-	users, err := oc.ListMembers(context.Background(), orgID)
+func findUserID(ctx context.Context, oc *organizations.Client, orgID uint, username string) (uint, error) {
+	users, err := oc.ListMembers(ctx, orgID)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/up/repository/create.go
+++ b/cmd/up/repository/create.go
@@ -30,8 +30,8 @@ type createCmd struct {
 }
 
 // Run executes the create command.
-func (c *createCmd) Run(p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
-	if err := rc.CreateOrUpdate(context.Background(), upCtx.Account, c.Name); err != nil {
+func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
+	if err := rc.CreateOrUpdate(ctx, upCtx.Account, c.Name); err != nil {
 		return err
 	}
 	p.Printfln("%s/%s created", upCtx.Account, c.Name)

--- a/cmd/up/repository/delete.go
+++ b/cmd/up/repository/delete.go
@@ -61,8 +61,8 @@ type deleteCmd struct {
 }
 
 // Run executes the delete command.
-func (c *deleteCmd) Run(p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
-	if err := rc.Delete(context.Background(), upCtx.Account, c.Name); err != nil {
+func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
+	if err := rc.Delete(ctx, upCtx.Account, c.Name); err != nil {
 		return err
 	}
 	p.Printfln("%s/%s deleted", upCtx.Account, c.Name)

--- a/cmd/up/repository/get.go
+++ b/cmd/up/repository/get.go
@@ -38,8 +38,8 @@ type getCmd struct {
 }
 
 // Run executes the get command.
-func (c *getCmd) Run(printer upterm.ObjectPrinter, rc *repos.Client, upCtx *upbound.Context) error {
-	repo, err := rc.Get(context.Background(), upCtx.Account, c.Name)
+func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, rc *repos.Client, upCtx *upbound.Context) error {
+	repo, err := rc.Get(ctx, upCtx.Account, c.Name)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/repository/list.go
+++ b/cmd/up/repository/list.go
@@ -47,8 +47,8 @@ type listCmd struct{}
 var fieldNames = []string{"NAME", "TYPE", "PUBLIC", "UPDATED"}
 
 // Run executes the list command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
-	rList, err := rc.List(context.Background(), upCtx.Account, common.WithSize(maxItems))
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, rc *repositories.Client, upCtx *upbound.Context) error {
+	rList, err := rc.List(ctx, upCtx.Account, common.WithSize(maxItems))
 	if err != nil {
 		return err
 	}

--- a/cmd/up/robot/create.go
+++ b/cmd/up/robot/create.go
@@ -37,15 +37,15 @@ type createCmd struct {
 }
 
 // Run executes the create command.
-func (c *createCmd) Run(p pterm.TextPrinter, ac *accounts.Client, rc *robots.Client, upCtx *upbound.Context) error {
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, ac *accounts.Client, rc *robots.Client, upCtx *upbound.Context) error {
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
 	if a.Account.Type != accounts.AccountOrganization {
 		return errors.New(errUserAccount)
 	}
-	if _, err := rc.Create(context.Background(), &robots.RobotCreateParameters{
+	if _, err := rc.Create(ctx, &robots.RobotCreateParameters{
 		Attributes: robots.RobotAttributes{
 			Name:        c.Name,
 			Description: c.Description,

--- a/cmd/up/robot/delete.go
+++ b/cmd/up/robot/delete.go
@@ -70,15 +70,15 @@ type deleteCmd struct {
 }
 
 // Run executes the delete command.
-func (c *deleteCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, upCtx *upbound.Context) error { //nolint:gocyclo
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, upCtx *upbound.Context) error { //nolint:gocyclo
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
 	if a.Account.Type != accounts.AccountOrganization {
 		return errors.New(errUserAccount)
 	}
-	rs, err := oc.ListRobots(context.Background(), a.Organization.ID)
+	rs, err := oc.ListRobots(ctx, a.Organization.ID)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (c *deleteCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizati
 		return errors.Errorf(errFindRobotFmt, c.Name, upCtx.Account)
 	}
 
-	if err := rc.Delete(context.Background(), *id); err != nil {
+	if err := rc.Delete(ctx, *id); err != nil {
 		return err
 	}
 	p.Printfln("%s/%s deleted", upCtx.Account, c.Name)

--- a/cmd/up/robot/get.go
+++ b/cmd/up/robot/get.go
@@ -40,8 +40,8 @@ type getCmd struct {
 }
 
 // Run executes the get robot command.
-func (c *getCmd) Run(printer upterm.ObjectPrinter, ac *accounts.Client, oc *organizations.Client, upCtx *upbound.Context) error {
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, ac *accounts.Client, oc *organizations.Client, upCtx *upbound.Context) error {
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (c *getCmd) Run(printer upterm.ObjectPrinter, ac *accounts.Client, oc *orga
 	// The API doesn't guarantee uniqueness, but we just print the first
 	// one we find. If a user wants to list all of them, they can use
 	// the list command.
-	rs, err := oc.ListRobots(context.Background(), a.Organization.ID)
+	rs, err := oc.ListRobots(ctx, a.Organization.ID)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/robot/list.go
+++ b/cmd/up/robot/list.go
@@ -42,15 +42,15 @@ func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) erro
 type listCmd struct{}
 
 // Run executes the list robots command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, upCtx *upbound.Context) error {
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, upCtx *upbound.Context) error {
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
 	if a.Account.Type != accounts.AccountOrganization {
 		return errors.New(errUserAccount)
 	}
-	rs, err := oc.ListRobots(context.Background(), a.Organization.ID)
+	rs, err := oc.ListRobots(ctx, a.Organization.ID)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/robot/token/create.go
+++ b/cmd/up/robot/token/create.go
@@ -42,15 +42,15 @@ type createCmd struct {
 }
 
 // Run executes the create command.
-func (c *createCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
 	if a.Account.Type != accounts.AccountOrganization {
 		return errors.New(errUserAccount)
 	}
-	rs, err := oc.ListRobots(context.Background(), a.Organization.ID)
+	rs, err := oc.ListRobots(ctx, a.Organization.ID)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (c *createCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizati
 	if !found {
 		return errors.Errorf(errFindRobotFmt, c.RobotName, upCtx.Account)
 	}
-	res, err := tc.Create(context.Background(), &tokens.TokenCreateParameters{
+	res, err := tc.Create(ctx, &tokens.TokenCreateParameters{
 		Attributes: tokens.TokenAttributes{
 			Name: c.TokenName,
 		},

--- a/cmd/up/robot/token/delete.go
+++ b/cmd/up/robot/token/delete.go
@@ -67,15 +67,15 @@ type deleteCmd struct {
 }
 
 // Run executes the delete command.
-func (c *deleteCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
 	if a.Account.Type != accounts.AccountOrganization {
 		return errors.New(errUserAccount)
 	}
-	rs, err := oc.ListRobots(context.Background(), a.Organization.ID)
+	rs, err := oc.ListRobots(ctx, a.Organization.ID)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (c *deleteCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizati
 		return errors.Errorf(errFindRobotFmt, c.RobotName, upCtx.Account)
 	}
 
-	ts, err := rc.ListTokens(context.Background(), *rid)
+	ts, err := rc.ListTokens(ctx, *rid)
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func (c *deleteCmd) Run(p pterm.TextPrinter, ac *accounts.Client, oc *organizati
 		return errors.Errorf(errFindTokenFmt, c.TokenName, c.RobotName, upCtx.Account)
 	}
 
-	if err := tc.Delete(context.Background(), *tid); err != nil {
+	if err := tc.Delete(ctx, *tid); err != nil {
 		return err
 	}
 	p.Printfln("%s/%s/%s deleted", upCtx.Account, c.RobotName, c.TokenName)

--- a/cmd/up/robot/token/get.go
+++ b/cmd/up/robot/token/get.go
@@ -46,15 +46,15 @@ type getCmd struct {
 }
 
 // Run executes the get robot token command.
-func (c *getCmd) Run(printer upterm.ObjectPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, tc *tokens.Client, upCtx *upbound.Context) error { //nolint:gocyclo
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
 	if a.Account.Type != accounts.AccountOrganization {
 		return errors.New(errUserAccount)
 	}
-	rs, err := oc.ListRobots(context.Background(), a.Organization.ID)
+	rs, err := oc.ListRobots(ctx, a.Organization.ID)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (c *getCmd) Run(printer upterm.ObjectPrinter, ac *accounts.Client, oc *orga
 		return errors.Errorf(errFindRobotFmt, c.RobotName, upCtx.Account)
 	}
 
-	ts, err := rc.ListTokens(context.Background(), *rid)
+	ts, err := rc.ListTokens(ctx, *rid)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/robot/token/list.go
+++ b/cmd/up/robot/token/list.go
@@ -48,15 +48,15 @@ type listCmd struct {
 }
 
 // Run executes the list robot tokens command.
-func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, upCtx *upbound.Context) error { //nolint:gocyclo
-	a, err := ac.Get(context.Background(), upCtx.Account)
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, ac *accounts.Client, oc *organizations.Client, rc *robots.Client, upCtx *upbound.Context) error { //nolint:gocyclo
+	a, err := ac.Get(ctx, upCtx.Account)
 	if err != nil {
 		return err
 	}
 	if a.Account.Type != accounts.AccountOrganization {
 		return errors.New(errUserAccount)
 	}
-	rs, err := oc.ListRobots(context.Background(), a.Organization.ID)
+	rs, err := oc.ListRobots(ctx, a.Organization.ID)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (c *listCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, ac *acc
 		return errors.Errorf(errFindRobotFmt, c.RobotName, upCtx.Account)
 	}
 
-	ts, err := rc.ListTokens(context.Background(), *rid)
+	ts, err := rc.ListTokens(ctx, *rid)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -143,7 +143,7 @@ func (c *destroyCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 }
 
 // Run executes the uninstall command.
-func (c *destroyCmd) Run(kClient *kubernetes.Clientset, mgr *helm.Installer) error {
+func (c *destroyCmd) Run(ctx context.Context, kClient *kubernetes.Clientset, mgr *helm.Installer) error {
 	if err := mgr.Uninstall(); err != nil {
 		return err
 	}
@@ -154,5 +154,5 @@ func (c *destroyCmd) Run(kClient *kubernetes.Clientset, mgr *helm.Installer) err
 		return nil
 	}
 
-	return kClient.CoreV1().Namespaces().Delete(context.Background(), nsUpboundSystem, v1.DeleteOptions{})
+	return kClient.CoreV1().Namespaces().Delete(ctx, nsUpboundSystem, v1.DeleteOptions{})
 }

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
 	"strings"
 	"time"
 
@@ -210,6 +212,14 @@ func (c *initCmd) AfterApply(kongCtx *kong.Context, quiet config.QuietFlag) erro
 // Run executes the install command.
 func (c *initCmd) Run(upCtx *upbound.Context) error {
 	ctx := context.Background()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	go func() {
+		<-sigCh
+		os.Exit(1)
+	}()
 
 	params, err := c.parser.Parse()
 	if err != nil {

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"os/signal"
 	"strings"
 	"time"
 
@@ -212,14 +210,6 @@ func (c *initCmd) AfterApply(kongCtx *kong.Context, quiet config.QuietFlag) erro
 // Run executes the install command.
 func (c *initCmd) Run(upCtx *upbound.Context) error {
 	ctx := context.Background()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-	defer signal.Stop(sigCh)
-	go func() {
-		<-sigCh
-		os.Exit(1)
-	}()
 
 	params, err := c.parser.Parse()
 	if err != nil {

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -208,9 +208,7 @@ func (c *initCmd) AfterApply(kongCtx *kong.Context, quiet config.QuietFlag) erro
 }
 
 // Run executes the install command.
-func (c *initCmd) Run(upCtx *upbound.Context) error {
-	ctx := context.Background()
-
+func (c *initCmd) Run(ctx context.Context, upCtx *upbound.Context) error {
 	params, err := c.parser.Parse()
 	if err != nil {
 		return errors.Wrap(err, errParseInstallParameters)
@@ -253,7 +251,7 @@ func (c *initCmd) Run(upCtx *upbound.Context) error {
 		return err
 	}
 
-	if err := c.deploySpace(context.Background(), params); err != nil {
+	if err := c.deploySpace(ctx, params); err != nil {
 		return err
 	}
 

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -170,8 +170,8 @@ func (c *upgradeCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 }
 
 // Run executes the upgrade command.
-func (c *upgradeCmd) Run() error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+func (c *upgradeCmd) Run(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
 
 	params, err := c.parser.Parse()

--- a/cmd/up/uxp/install.go
+++ b/cmd/up/uxp/install.go
@@ -87,9 +87,9 @@ type installCmd struct {
 }
 
 // Run executes the install command.
-func (c *installCmd) Run(p pterm.TextPrinter, insCtx *install.Context) error {
+func (c *installCmd) Run(ctx context.Context, p pterm.TextPrinter, insCtx *install.Context) error {
 	// Create namespace if it does not exist.
-	_, err := c.kClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+	_, err := c.kClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: insCtx.Namespace,
 		},

--- a/cmd/up/xpkg/batch.go
+++ b/cmd/up/xpkg/batch.go
@@ -125,7 +125,7 @@ type batchCmd struct {
 }
 
 // Run executes the batch command.
-func (c *batchCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
+func (c *batchCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
 	baseImgMap := make(map[string]v1.Image, len(c.Platform))
 	for _, p := range c.Platform {
 		tokens := strings.Split(p, "_")
@@ -136,7 +136,7 @@ func (c *batchCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //no
 		if err != nil {
 			return err
 		}
-		img, err := c.fetch(context.Background(), ref)
+		img, err := c.fetch(ctx, ref)
 		if err != nil {
 			return err
 		}

--- a/cmd/up/xpkg/build.go
+++ b/cmd/up/xpkg/build.go
@@ -135,20 +135,20 @@ Even more details can be found in the xpkg reference document.`
 }
 
 // Run executes the build command.
-func (c *buildCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
+func (c *buildCmd) Run(ctx context.Context, p pterm.TextPrinter) error { //nolint:gocyclo
 	var buildOpts []xpkg.BuildOpt
 	if c.Controller != "" {
 		ref, err := name.ParseReference(c.Controller)
 		if err != nil {
 			return err
 		}
-		base, err := c.fetch(context.Background(), ref)
+		base, err := c.fetch(ctx, ref)
 		if err != nil {
 			return err
 		}
 		buildOpts = append(buildOpts, xpkg.WithController(base))
 	}
-	img, meta, err := c.builder.Build(context.Background(), buildOpts...)
+	img, meta, err := c.builder.Build(ctx, buildOpts...)
 	if err != nil {
 		return errors.Wrap(err, errBuildPackage)
 	}

--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -133,13 +133,13 @@ type xpExtractCmd struct {
 }
 
 // Run runs the xp extract cmd.
-func (c *xpExtractCmd) Run(p pterm.TextPrinter) error { //nolint:gocyclo
+func (c *xpExtractCmd) Run(ctx context.Context, p pterm.TextPrinter) error { //nolint:gocyclo
 	// NOTE(hasheddan): most of the logic in this method is from the machinery
 	// used in Crossplane's package cache and should be updated to use shared
 	// libraries if moved to crossplane-runtime.
 
 	// Fetch package.
-	img, err := c.fetch(context.Background(), c.name)
+	img, err := c.fetch(ctx, c.name)
 	if err != nil {
 		return errors.Wrap(err, errFetchPackage)
 	}

--- a/cmd/up/xpkg/xpextract_test.go
+++ b/cmd/up/xpkg/xpextract_test.go
@@ -123,7 +123,7 @@ func TestXPExtractRun(t *testing.T) {
 				fetch:  tc.fetch,
 				name:   tc.name,
 				Output: tc.out,
-			}).Run(pterm.DefaultBasicText.WithWriter(io.Discard))
+			}).Run(context.TODO(), pterm.DefaultBasicText.WithWriter(io.Discard))
 			if diff := cmp.Diff(tc.want, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nRun(...): -want error, +got error:\n%s", tc.reason, diff)
 			}

--- a/cmd/up/xpls/serve.go
+++ b/cmd/up/xpls/serve.go
@@ -36,7 +36,7 @@ type serveCmd struct {
 }
 
 // Run runs the language server.
-func (c *serveCmd) Run() error {
+func (c *serveCmd) Run(ctx context.Context) error {
 
 	// cache directory resolution should occur at this level.
 
@@ -50,6 +50,6 @@ func (c *serveCmd) Run() error {
 	}
 
 	// TODO(hasheddan): handle graceful shutdown.
-	<-jsonrpc2.NewConn(context.Background(), jsonrpc2.NewBufferedStream(xpls.StdRWC{}, jsonrpc2.VSCodeObjectCodec{}), h).DisconnectNotify()
+	<-jsonrpc2.NewConn(ctx, jsonrpc2.NewBufferedStream(xpls.StdRWC{}, jsonrpc2.VSCodeObjectCodec{}), h).DisconnectNotify()
 	return nil
 }


### PR DESCRIPTION
### Description of your changes

Allows using ctrl+c to interrupt the `up space init` command to allow stopping the installation without needing to kill the process via `kill -9`. 

Note: this does not allow for re-initialization of the space, killing the process or using ctrl+c could result in the space being in a unstable state. It'll be a bit of work to make the `up space init` rerunnable/idempotent. 

Fixes https://github.com/upbound/mxe/issues/257

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

manually running `up space init` then using ctrl+c to exit the process while prereqs are installing.
