### PR TITLE
Remove release notes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ under `cmd` folder.
 
 ## Release Process
 
-This is a slimmed-down version of the release process described [here](https://github.com/crossplane/crossplane/blob/master/contributing/release-process.md).
+This is a slimmed-down version of the release process described [here](https://github.com/crossplane/release).
 
 1. **feature freeze**: Merge all completed features into main development branch
    of all repos to begin "feature freeze" period.


### PR DESCRIPTION
### Description of your changes
This simply removes outdated docs.

Fixes #410 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
I went to the contribution markdown and no longer saw the text.
