### PR TITLE
Bare Control Planes: allow for creating control planes without a config

### DIFF
--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -38,7 +38,7 @@ type ctpCreator interface {
 type createCmd struct {
 	Name string `arg:"" required:"" help:"Name of control plane."`
 
-	ConfigurationName string `help:"The name of the Configuration. This property is required for cloud control planes."`
+	ConfigurationName string `help:"The optional name of the Configuration."`
 	Description       string `short:"d" help:"Description for control plane."`
 
 	SecretName      string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -38,8 +38,8 @@ type ctpCreator interface {
 type createCmd struct {
 	Name string `arg:"" required:"" help:"Name of control plane."`
 
-	ConfigurationName string `help:"The optional name of the Configuration."`
-	Description       string `short:"d" help:"Description for control plane."`
+	ConfigurationName *string `help:"The optional name of the Configuration."`
+	Description       string  `short:"d" help:"Description for control plane."`
 
 	SecretName      string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`
 	SecretNamespace string `default:"default" help:"The name of namespace for the control plane's secret. Only applicable for Space control planes."`
@@ -81,8 +81,9 @@ func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound
 		ctx,
 		c.Name,
 		controlplane.Options{
-			SecretName:      c.SecretName,
-			SecretNamespace: c.SecretNamespace,
+			SecretName:        c.SecretName,
+			SecretNamespace:   c.SecretNamespace,
+			ConfigurationName: c.ConfigurationName,
 		},
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/afero v1.10.0
 	github.com/spf13/cobra v1.7.0
-	github.com/upbound/up-sdk-go v0.1.1-0.20230405182644-366f20e6aa5f
+	github.com/upbound/up-sdk-go v0.1.1-0.20240122203953-2d00664aab8e
 	github.com/willabides/kongplete v0.3.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/sync v0.3.0
@@ -270,3 +270,5 @@ replace (
 	github.com/docker/cli => github.com/docker/cli v20.10.19+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.19+incompatible
 )
+
+replace github.com/upbound/up-sdk-go => /Users/ben/src/up-sdk-go

--- a/go.mod
+++ b/go.mod
@@ -270,5 +270,3 @@ replace (
 	github.com/docker/cli => github.com/docker/cli v20.10.19+incompatible
 	github.com/docker/docker => github.com/docker/docker v20.10.19+incompatible
 )
-
-replace github.com/upbound/up-sdk-go => /Users/ben/src/up-sdk-go

--- a/go.sum
+++ b/go.sum
@@ -864,8 +864,8 @@ github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/upbound/up-sdk-go v0.1.1-0.20230405182644-366f20e6aa5f h1:k/beHtZrHDM881FwkwwXycRZSnxwjAS3Bd9Mq/UvwUs=
-github.com/upbound/up-sdk-go v0.1.1-0.20230405182644-366f20e6aa5f/go.mod h1:IDIbYDb9fbedtxCc2CrdGcVRol6la7z2gkKh0VYWVGk=
+github.com/upbound/up-sdk-go v0.1.1-0.20240122203953-2d00664aab8e h1:aNzUuv4ZKH2OT3Qv6dpZxkMPDOfl/6MoS79T/zUzako=
+github.com/upbound/up-sdk-go v0.1.1-0.20240122203953-2d00664aab8e/go.mod h1:IDIbYDb9fbedtxCc2CrdGcVRol6la7z2gkKh0VYWVGk=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -124,9 +124,9 @@ func (c *Client) Create(ctx context.Context, name string, opts controlplane.Opti
 		Name:        name,
 		Description: opts.Description,
 	}
-	if opts.ConfigurationName != "" {
+	if opts.ConfigurationName != nil {
 		// Get the UUID from the Configuration name, if it exists.
-		cfg, err := c.cfg.Get(ctx, c.account, opts.ConfigurationName)
+		cfg, err := c.cfg.Get(ctx, c.account, *opts.ConfigurationName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controlplane/cloud/cloud_test.go
+++ b/internal/controlplane/cloud/cloud_test.go
@@ -44,7 +44,7 @@ var (
 	ctp1 = controlplanes.ControlPlane{
 		Name: "ctp1",
 		ID:   uuid.MustParse("00000000-0000-0000-0000-000000000000"),
-		Configuration: controlplanes.ControlPlaneConfiguration{
+		Configuration: &controlplanes.ControlPlaneConfiguration{
 			Name:   pointer.String("cfg1"),
 			Status: controlplanes.ConfigurationReady,
 		},
@@ -53,7 +53,7 @@ var (
 	ctp2 = controlplanes.ControlPlane{
 		Name: "ctp2",
 		ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-		Configuration: controlplanes.ControlPlaneConfiguration{
+		Configuration: &controlplanes.ControlPlaneConfiguration{
 			Name:   pointer.String("cfg1"),
 			Status: controlplanes.ConfigurationReady,
 		},
@@ -337,9 +337,8 @@ func TestConvert(t *testing.T) {
 			args: args{
 				ctp: &controlplanes.ControlPlaneResponse{
 					ControlPlane: controlplanes.ControlPlane{
-						Name:          "ctp1",
-						ID:            uuid.MustParse("00000000-0000-0000-0000-000000000000"),
-						Configuration: controlplanes.ControlPlaneConfiguration{},
+						Name: "ctp1",
+						ID:   uuid.MustParse("00000000-0000-0000-0000-000000000000"),
 					},
 				},
 			},

--- a/internal/controlplane/options.go
+++ b/internal/controlplane/options.go
@@ -22,5 +22,5 @@ type Options struct {
 
 	Description string
 
-	ConfigurationName string
+	ConfigurationName *string
 }


### PR DESCRIPTION
### Description of your changes

Allow for creating a control plane without a configuration for Cloud.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested locally:
```
minerva:~/src/up $ up ctp create -a upbound bh-horcrux --configuration-name=voldemort-prod
bh-horcrux created
minerva:~/src/up $ up ctp create -a upbound bh-darkarts
bh-darkarts created
minerva:~/src/up $ up ctp list -a upbound
NAME               ID                                     STATUS   CONFIGURATION            CONFIGURATION STATUS
bh-horcrux         7b25c5a7-ef21-41fd-972c-15e8512b3784   ready    voldemort-prod           installationQueued
bh-darkarts        fb8dc677-903b-4b17-bfc2-0bf4eb5976aa   ready    n/a                      n/a

```