### PR TITLE
Update prerequisite versions for spaces 1.2.0

### DIFF
--- a/cmd/up/space/prerequisites/providers/helm/helm.go
+++ b/cmd/up/space/prerequisites/providers/helm/helm.go
@@ -40,7 +40,7 @@ import (
 var (
 	providerName = "provider-helm"
 	// Package version to be installed
-	version   = "v0.14.0"
+	version   = "v0.16.0"
 	pkgRef, _ = name.ParseReference(fmt.Sprintf("xpkg.upbound.io/crossplane-contrib/provider-helm:%s", version))
 
 	objectsCRD = "releases.helm.crossplane.io"

--- a/cmd/up/space/prerequisites/providers/kubernetes/kubernetes.go
+++ b/cmd/up/space/prerequisites/providers/kubernetes/kubernetes.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	providerName = "provider-kubernetes"
-	version      = "v0.7.0"
+	version      = "v0.11.4"
 	pkgRef, _    = name.ParseReference(fmt.Sprintf("xpkg.upbound.io/crossplane-contrib/provider-kubernetes:%s", version))
 
 	objectsCRD = "objects.kubernetes.crossplane.io"

--- a/cmd/up/space/prerequisites/uxp/uxp.go
+++ b/cmd/up/space/prerequisites/uxp/uxp.go
@@ -36,7 +36,7 @@ var (
 	ns        = "upbound-system"
 	// Chart version to be installed. universal-crossplane does not include a
 	// v prefix.
-	version = "1.13.2-up.2"
+	version = "1.14.5-up.1"
 
 	xrdCRD = "compositeresourcedefinitions.apiextensions.crossplane.io"
 

--- a/cmd/up/space/prerequisites/uxp/uxp.go
+++ b/cmd/up/space/prerequisites/uxp/uxp.go
@@ -105,7 +105,11 @@ func (u *UXP) Install() error {
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, fmt.Sprintf(errFmtCreateNamespace, ns))
 	}
-	return u.mgr.Install(version, map[string]any{})
+	return u.mgr.Install(version, map[string]any{
+		"args": []string{
+			"--enable-usages",
+		},
+	})
 }
 
 // IsInstalled checks if UXP has been installed in the target cluster.


### PR DESCRIPTION
### Description of your changes
With Spaces 1.2.0 a few of the prerequisites had version changes. This updated `up` to target those versions.

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Attempted `up space init` and was able to successfully install 1.2.0-rc.1
```
./_output/bin/darwin_arm64/up space init --token-file=key.json "v1.2.0-rc.1" --set account=taylort
 INFO  Setting defaults for vanilla Kubernetes (type kind)
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm

Would you like to install them now? [y/N]: Yes

  ✓   [1/5]: Installing cert-manager
  ✓   [2/5]: Installing universal-crossplane
  ✓   [3/5]: Installing ingress-nginx
  ✓   [4/5]: Installing provider-kubernetes
  ✓   [5/5]: Installing provider-helm
 INFO  Required prerequisites met!
 INFO  Proceeding with Upbound Spaces installation...
  ✓   [1/3]: Creating pull secret upbound-pull-secret
  ✓   [2/3]: Initializing Space components
  ✓   [3/3]: Starting Space Components
  🙌  Your Upbound Space is Ready!

  👀  Next Steps 👇

👉 Check out Upbound Spaces docs @ https://docs.upbound.io/concepts/upbound-spaces
```
