### PR TITLE
space subcommands should respect 'groups'

### DIFF
--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -47,7 +47,7 @@ const (
 )
 
 type ctpConnector interface {
-	GetKubeConfig(ctx context.Context, name string) (*api.Config, error)
+	GetKubeConfig(ctx context.Context, name, namespace string) (*api.Config, error)
 }
 
 // AfterApply sets default values in command after assignment and validation.
@@ -104,6 +104,8 @@ type connectCmd struct {
 	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
 	Token string `help:"API token used to authenticate. Required for Upbound Cloud; ignored otherwise."`
 
+	Group string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
+
 	stdin  io.Reader
 	client ctpConnector
 }
@@ -129,7 +131,7 @@ func (c *connectCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pt
 		return nil
 	}
 
-	cfg, err := c.client.GetKubeConfig(ctx, c.Name)
+	cfg, err := c.client.GetKubeConfig(ctx, c.Name, c.Group)
 	if controlplane.IsNotFound(err) {
 		p.Printfln("Control plane %s not found", c.Name)
 		return nil

--- a/cmd/up/controlplane/connect_test.go
+++ b/cmd/up/controlplane/connect_test.go
@@ -18,9 +18,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
 func TestUpdateKubeConfig(t *testing.T) {

--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	cloudfieldNames = []string{"NAME", "ID", "STATUS", "CONFIGURATION", "CONFIGURATION STATUS"}
-	spacefieldNames = []string{"NAME", "ID", "STATUS", "MESSAGE", "CONNECTION NAME", "CONNECTION NAMESPACE"}
+	spacefieldNames = []string{"NAME", "ID", "GROUP", "STATUS", "MESSAGE", "CONNECTION NAME"}
 )
 
 // BeforeReset is the first hook to run.
@@ -143,10 +143,10 @@ func extractSpaceFields(obj any) []string {
 	return []string{
 		resp.Name,
 		resp.ID,
+		resp.Group,
 		resp.Status,
 		resp.Message,
 		resp.ConnName,
-		resp.ConnNamespace,
 	}
 }
 

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -31,7 +31,7 @@ import (
 )
 
 type ctpCreator interface {
-	Create(ctx context.Context, name string, opts controlplane.Options) (*controlplane.Response, error)
+	Create(ctx context.Context, name, namespace string, opts controlplane.Options) (*controlplane.Response, error)
 }
 
 // createCmd creates a control plane on Upbound.
@@ -41,8 +41,8 @@ type createCmd struct {
 	ConfigurationName *string `help:"The optional name of the Configuration."`
 	Description       string  `short:"d" help:"Description for control plane."`
 
-	SecretName      string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`
-	SecretNamespace string `default:"default" help:"The name of namespace for the control plane's secret. Only applicable for Space control planes."`
+	SecretName string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`
+	Group      string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
 
 	client ctpCreator
 }
@@ -80,9 +80,10 @@ func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound
 	_, err := c.client.Create(
 		ctx,
 		c.Name,
+		c.Group,
 		controlplane.Options{
 			SecretName:        c.SecretName,
-			SecretNamespace:   c.SecretNamespace,
+			SecretNamespace:   c.Group,
 			ConfigurationName: c.ConfigurationName,
 		},
 	)

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
-
 	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/controlplane/cloud"
 	"github.com/upbound/up/internal/controlplane/space"
@@ -31,7 +31,7 @@ import (
 )
 
 type ctpCreator interface {
-	Create(ctx context.Context, name, namespace string, opts controlplane.Options) (*controlplane.Response, error)
+	Create(ctx context.Context, ctp types.NamespacedName, opts controlplane.Options) (*controlplane.Response, error)
 }
 
 // createCmd creates a control plane on Upbound.
@@ -42,19 +42,22 @@ type createCmd struct {
 	Description       string  `short:"d" help:"Description for control plane."`
 
 	SecretName string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`
-	Group      string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
+	Group      string `short:"g" help:"The control plane group that the control plane is contained in. This defaults to the group specified in the current profile."`
 
 	client ctpCreator
 }
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
 		if err != nil {
 			return err
 		}
+		if c.Group == "" {
+			c.Group = ns
+		}
+
 		client, err := dynamic.NewForConfig(kubeconfig)
 		if err != nil {
 			return err
@@ -79,8 +82,7 @@ func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) er
 func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
 	_, err := c.client.Create(
 		ctx,
-		c.Name,
-		c.Group,
+		types.NamespacedName{Name: c.Name, Namespace: c.Group},
 		controlplane.Options{
 			SecretName:        c.SecretName,
 			SecretNamespace:   c.Group,

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
-
 	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/controlplane/cloud"
 	"github.com/upbound/up/internal/controlplane/space"
@@ -31,25 +31,28 @@ import (
 )
 
 type ctpDeleter interface {
-	Delete(ctx context.Context, name, namespace string) error
+	Delete(ctx context.Context, ctp types.NamespacedName) error
 }
 
 // deleteCmd deletes a control plane on Upbound.
 type deleteCmd struct {
 	Name  string `arg:"" help:"Name of control plane." predictor:"ctps"`
-	Group string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
+	Group string `short:"g" help:"The control plane group that the control plane is contained in. This defaults to the group specified in the current profile."`
 
 	client ctpDeleter
 }
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *deleteCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
 		if err != nil {
 			return err
 		}
+		if c.Group == "" {
+			c.Group = ns
+		}
+
 		client, err := dynamic.NewForConfig(kubeconfig)
 		if err != nil {
 			return err
@@ -70,7 +73,7 @@ func (c *deleteCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) er
 
 // Run executes the delete command.
 func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if err := c.client.Delete(ctx, c.Name, c.Group); err != nil {
+	if err := c.client.Delete(ctx, types.NamespacedName{Name: c.Name, Namespace: c.Group}); err != nil {
 		if controlplane.IsNotFound(err) {
 			p.Printfln("Control plane %s not found", c.Name)
 			return nil

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -31,12 +31,13 @@ import (
 )
 
 type ctpDeleter interface {
-	Delete(ctx context.Context, name string) error
+	Delete(ctx context.Context, name, namespace string) error
 }
 
 // deleteCmd deletes a control plane on Upbound.
 type deleteCmd struct {
-	Name string `arg:"" help:"Name of control plane." predictor:"ctps"`
+	Name  string `arg:"" help:"Name of control plane." predictor:"ctps"`
+	Group string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
 
 	client ctpDeleter
 }
@@ -69,7 +70,7 @@ func (c *deleteCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) er
 
 // Run executes the delete command.
 func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if err := c.client.Delete(ctx, c.Name); err != nil {
+	if err := c.client.Delete(ctx, c.Name, c.Group); err != nil {
 		if controlplane.IsNotFound(err) {
 			p.Printfln("Control plane %s not found", c.Name)
 			return nil

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -32,7 +32,7 @@ import (
 )
 
 type ctpGetter interface {
-	Get(ctx context.Context, name string) (*controlplane.Response, error)
+	Get(ctx context.Context, name, namespace string) (*controlplane.Response, error)
 }
 
 // AfterApply sets default values in command after assignment and validation.
@@ -65,14 +65,15 @@ func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error
 
 // getCmd gets a single control plane in an account on Upbound.
 type getCmd struct {
-	Name string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
+	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
+	Group string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
 
 	client ctpGetter
 }
 
 // Run executes the get command.
 func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
-	ctp, err := c.client.Get(ctx, c.Name)
+	ctp, err := c.client.Get(ctx, c.Name, c.Group)
 	if controlplane.IsNotFound(err) {
 		p.Printfln("Control plane %s not found", c.Name)
 		return nil

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
-
 	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/controlplane/cloud"
 	"github.com/upbound/up/internal/controlplane/space"
@@ -32,17 +32,20 @@ import (
 )
 
 type ctpGetter interface {
-	Get(ctx context.Context, name, namespace string) (*controlplane.Response, error)
+	Get(ctx context.Context, name types.NamespacedName) (*controlplane.Response, error)
 }
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
 		if err != nil {
 			return err
 		}
+		if c.Group == "" {
+			c.Group = ns
+		}
+
 		client, err := dynamic.NewForConfig(kubeconfig)
 		if err != nil {
 			return err
@@ -66,14 +69,14 @@ func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error
 // getCmd gets a single control plane in an account on Upbound.
 type getCmd struct {
 	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
-	Group string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
+	Group string `short:"g" help:"The control plane group that the control plane is contained in. This defaults to the group specified in the current profile."`
 
 	client ctpGetter
 }
 
 // Run executes the get command.
 func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
-	ctp, err := c.client.Get(ctx, c.Name, c.Group)
+	ctp, err := c.client.Get(ctx, types.NamespacedName{Name: c.Name, Namespace: c.Group})
 	if controlplane.IsNotFound(err) {
 		p.Printfln("Control plane %s not found", c.Name)
 		return nil

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/upbound/up-sdk-go/service/configurations"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
-
 	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/controlplane/cloud"
 	"github.com/upbound/up/internal/controlplane/space"
@@ -37,7 +36,7 @@ type ctpLister interface {
 
 // listCmd list control planes in an account on Upbound.
 type listCmd struct {
-	Group     string `short:"g" default:"default" help:"The control plane group that the control plane is contained in."`
+	Group     string `short:"g" help:"The control plane group that the control plane is contained in. This defaults to the group specified in the current profile."`
 	AllGroups bool   `short:"A" default:"false" help:"List control planes across all groups."`
 
 	client ctpLister
@@ -45,12 +44,15 @@ type listCmd struct {
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
 		if err != nil {
 			return err
 		}
+		if c.Group == "" {
+			c.Group = ns
+		}
+
 		client, err := dynamic.NewForConfig(kubeconfig)
 		if err != nil {
 			return err

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -105,7 +105,7 @@ func (c *spaceCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.
 	if prof.Kubeconfig != "" {
 		kubeconfigLocation = fmt.Sprintf("kubeconfig at %q", prof.Kubeconfig)
 	}
-	p.Printf("Profile %q updated to use Kubernetes context %q from the %s", upCtx.ProfileName, prof.KubeContext, kubeconfigLocation)
+	p.Printf("Profile %q updated to use Kubernetes context %q from the %s. Defaulting to group %q.", upCtx.ProfileName, prof.KubeContext, kubeconfigLocation, c.Kube.Namespace())
 	if setDefault {
 		p.Print(" and selected as the default profile")
 	}

--- a/cmd/up/profile/set.go
+++ b/cmd/up/profile/set.go
@@ -126,9 +126,14 @@ func (c *spaceCmd) checkForSpaces(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if _, err := kClient.AppsV1().Deployments("upbound-system").Get(ctx, "mxe-controller", metav1.GetOptions{}); kerrors.IsNotFound(err) {
+	_, err = kClient.AppsV1().Deployments("upbound-system").Get(ctx, "mxe-controller", metav1.GetOptions{})
+	if kerrors.IsNotFound(err) {
+		_, err = kClient.AppsV1().Deployments("upbound-system").Get(ctx, "spaces-controller", metav1.GetOptions{})
+	}
+	if kerrors.IsNotFound(err) {
 		return false, nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return false, errors.Wrap(err, errKubeContact)
 	}
 

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -139,7 +139,8 @@ func (c *destroyCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if !upCtx.Profile.IsSpace() {
 		return nil, fmt.Errorf("destroy is not supported for non-space profile %q", upCtx.ProfileName)
 	}
-	return upCtx.Profile.GetKubeClientConfig()
+	cfg, _, err := upCtx.Profile.GetKubeClientConfig()
+	return cfg, err
 }
 
 // Run executes the uninstall command.

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -21,12 +21,13 @@ import (
 	"strings"
 
 	"github.com/blang/semver/v4"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
 	"helm.sh/helm/v3/pkg/chart"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/yaml"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up/internal/config"
 	"github.com/upbound/up/internal/input"
@@ -166,7 +167,8 @@ func (c *upgradeCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if !upCtx.Profile.IsSpace() {
 		return nil, fmt.Errorf("upgrade is not supported for non-space profile %q", upCtx.ProfileName)
 	}
-	return upCtx.Profile.GetKubeClientConfig()
+	cfg, _, err := upCtx.Profile.GetKubeClientConfig()
+	return cfg, err
 }
 
 // Run executes the upgrade command.

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -200,7 +200,7 @@ func convert(ctp *controlplanes.ControlPlaneResponse) *controlplane.Response {
 }
 
 func formatStatus(status controlplanes.ConfigurationStatus) string {
-	switch status {
+	switch status { // nolint: exhaustive
 	case "":
 		return ""
 	case controlplanes.ConfigurationReady:
@@ -211,7 +211,7 @@ func formatStatus(status controlplanes.ConfigurationStatus) string {
 }
 
 func toMessage(status controlplanes.Status) string {
-	switch status {
+	switch status { // nolint: exhaustive
 	case controlplanes.StatusProvisioning:
 		return "Controlplane is being created"
 	case controlplanes.StatusUpdating:

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -90,7 +90,7 @@ func New(ctp ctpClient, cfg cfgGetter, account string, opts ...Option) *Client {
 }
 
 // Get the ControlPlane corresponding to the given ControlPlane name.
-func (c *Client) Get(ctx context.Context, name string) (*controlplane.Response, error) {
+func (c *Client) Get(ctx context.Context, name, namespace string) (*controlplane.Response, error) {
 	resp, err := c.ctp.Get(ctx, c.account, name)
 
 	if sdkerrs.IsNotFound(err) {
@@ -105,7 +105,7 @@ func (c *Client) Get(ctx context.Context, name string) (*controlplane.Response, 
 }
 
 // List all ControlPlanes within the Upbound Cloud account.
-func (c *Client) List(ctx context.Context) ([]*controlplane.Response, error) {
+func (c *Client) List(ctx context.Context, namespace string) ([]*controlplane.Response, error) {
 	l, err := c.ctp.List(ctx, c.account, common.WithSize(maxItems))
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (c *Client) List(ctx context.Context) ([]*controlplane.Response, error) {
 }
 
 // Create a new ControlPlane with the given name and the supplied Options.
-func (c *Client) Create(ctx context.Context, name string, opts controlplane.Options) (*controlplane.Response, error) {
+func (c *Client) Create(ctx context.Context, name, namespace string, opts controlplane.Options) (*controlplane.Response, error) {
 	params := &controlplanes.ControlPlaneCreateParameters{
 		Name:        name,
 		Description: opts.Description,
@@ -142,7 +142,7 @@ func (c *Client) Create(ctx context.Context, name string, opts controlplane.Opti
 }
 
 // Delete the ControlPlane corresponding to the given ControlPlane name.
-func (c *Client) Delete(ctx context.Context, name string) error {
+func (c *Client) Delete(ctx context.Context, name, namespace string) error {
 	err := c.ctp.Delete(ctx, c.account, name)
 	if sdkerrs.IsNotFound(err) {
 		return controlplane.NewNotFound(err)
@@ -151,7 +151,7 @@ func (c *Client) Delete(ctx context.Context, name string) error {
 }
 
 // GetKubeConfig for the given Control Plane.
-func (c *Client) GetKubeConfig(ctx context.Context, name string) (*api.Config, error) {
+func (c *Client) GetKubeConfig(ctx context.Context, name, namespace string) (*api.Config, error) {
 	return kube.BuildControlPlaneKubeconfig(
 		c.proxy,
 		path.Join(c.account, name),

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -16,24 +16,25 @@ package cloud
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"path"
+	"strings"
+	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	sdkerrs "github.com/upbound/up-sdk-go/errors"
 	"github.com/upbound/up-sdk-go/service/common"
 	"github.com/upbound/up-sdk-go/service/configurations"
 	"github.com/upbound/up-sdk-go/service/controlplanes"
-
 	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/kube"
 )
 
 const (
 	maxItems = 100
-
-	notAvailable = "n/a"
 )
 
 type ctpClient interface {
@@ -90,8 +91,11 @@ func New(ctp ctpClient, cfg cfgGetter, account string, opts ...Option) *Client {
 }
 
 // Get the ControlPlane corresponding to the given ControlPlane name.
-func (c *Client) Get(ctx context.Context, name, namespace string) (*controlplane.Response, error) {
-	resp, err := c.ctp.Get(ctx, c.account, name)
+func (c *Client) Get(ctx context.Context, ctp types.NamespacedName) (*controlplane.Response, error) {
+	if ctp.Namespace != "" {
+		return nil, errors.New("namespace is not supported for Upbound Cloud control planes")
+	}
+	resp, err := c.ctp.Get(ctx, c.account, ctp.Name)
 
 	if sdkerrs.IsNotFound(err) {
 		return nil, controlplane.NewNotFound(err)
@@ -106,6 +110,9 @@ func (c *Client) Get(ctx context.Context, name, namespace string) (*controlplane
 
 // List all ControlPlanes within the Upbound Cloud account.
 func (c *Client) List(ctx context.Context, namespace string) ([]*controlplane.Response, error) {
+	if namespace != "" {
+		return nil, errors.New("namespace is not supported for Upbound Cloud control planes")
+	}
 	l, err := c.ctp.List(ctx, c.account, common.WithSize(maxItems))
 	if err != nil {
 		return nil, err
@@ -119,9 +126,12 @@ func (c *Client) List(ctx context.Context, namespace string) ([]*controlplane.Re
 }
 
 // Create a new ControlPlane with the given name and the supplied Options.
-func (c *Client) Create(ctx context.Context, name, namespace string, opts controlplane.Options) (*controlplane.Response, error) {
+func (c *Client) Create(ctx context.Context, ctp types.NamespacedName, opts controlplane.Options) (*controlplane.Response, error) {
+	if ctp.Namespace != "" {
+		return nil, errors.New("namespace is not supported for Upbound Cloud control planes")
+	}
 	params := &controlplanes.ControlPlaneCreateParameters{
-		Name:        name,
+		Name:        ctp.Name,
 		Description: opts.Description,
 	}
 	if opts.ConfigurationName != nil {
@@ -142,8 +152,11 @@ func (c *Client) Create(ctx context.Context, name, namespace string, opts contro
 }
 
 // Delete the ControlPlane corresponding to the given ControlPlane name.
-func (c *Client) Delete(ctx context.Context, name, namespace string) error {
-	err := c.ctp.Delete(ctx, c.account, name)
+func (c *Client) Delete(ctx context.Context, ctp types.NamespacedName) error {
+	if ctp.Namespace != "" {
+		return errors.New("namespace is not supported for Upbound Cloud control planes")
+	}
+	err := c.ctp.Delete(ctx, c.account, ctp.Name)
 	if sdkerrs.IsNotFound(err) {
 		return controlplane.NewNotFound(err)
 	}
@@ -151,27 +164,68 @@ func (c *Client) Delete(ctx context.Context, name, namespace string) error {
 }
 
 // GetKubeConfig for the given Control Plane.
-func (c *Client) GetKubeConfig(ctx context.Context, name, namespace string) (*api.Config, error) {
+func (c *Client) GetKubeConfig(ctx context.Context, ctp types.NamespacedName) (*api.Config, error) {
 	return kube.BuildControlPlaneKubeconfig(
 		c.proxy,
-		path.Join(c.account, name),
+		path.Join(c.account, ctp.Name),
 		c.token,
 		false,
 	), nil
 }
 
 func convert(ctp *controlplanes.ControlPlaneResponse) *controlplane.Response {
-	cfgName, cfgStatus := notAvailable, notAvailable
+	var cfgName string
+	var cfgStatus controlplanes.ConfigurationStatus
 	if ctp.ControlPlane.Configuration != nil {
 		cfgName = *ctp.ControlPlane.Configuration.Name
-		cfgStatus = string(ctp.ControlPlane.Configuration.Status)
+		cfgStatus = ctp.ControlPlane.Configuration.Status
+	}
+
+	var age *time.Duration
+	if ctp.ControlPlane.CreatedAt != nil {
+		d := time.Since(*ctp.ControlPlane.CreatedAt)
+		age = &d
 	}
 
 	return &controlplane.Response{
-		ID:        ctp.ControlPlane.ID.String(),
-		Name:      ctp.ControlPlane.Name,
-		Status:    string(ctp.Status),
-		Cfg:       cfgName,
-		CfgStatus: cfgStatus,
+		ID:      ctp.ControlPlane.ID.String(),
+		Name:    ctp.ControlPlane.Name,
+		Synced:  toBool(true),
+		Ready:   toBool(ctp.Status == controlplanes.StatusReady),
+		Message: toMessage(ctp.Status),
+		Cfg:     cfgName,
+		Updated: formatStatus(cfgStatus),
+		Age:     age,
 	}
+}
+
+func formatStatus(status controlplanes.ConfigurationStatus) string {
+	switch status {
+	case "":
+		return ""
+	case controlplanes.ConfigurationReady:
+		return "True"
+	default:
+		return strings.ToUpper(string(status)[:1]) + string(status)[1:]
+	}
+}
+
+func toMessage(status controlplanes.Status) string {
+	switch status {
+	case controlplanes.StatusProvisioning:
+		return "Controlplane is being created"
+	case controlplanes.StatusUpdating:
+		return "Controlplane is being updated"
+	case controlplanes.StatusDeleting:
+		return "Controlplane is being deleted"
+	default:
+		return ""
+	}
+}
+
+func toBool(b bool) string {
+	if b {
+		return "True"
+	}
+	return "False"
 }

--- a/internal/controlplane/cloud/cloud_test.go
+++ b/internal/controlplane/cloud/cloud_test.go
@@ -20,15 +20,16 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	sdkerrs "github.com/upbound/up-sdk-go/errors"
 	"github.com/upbound/up-sdk-go/service/common"
 	"github.com/upbound/up-sdk-go/service/controlplanes"
-
 	"github.com/upbound/up/internal/controlplane"
 )
 
@@ -60,17 +61,21 @@ var (
 	}
 
 	ctp1Resp = &controlplane.Response{
-		Name:      "ctp1",
-		ID:        "00000000-0000-0000-0000-000000000000",
-		Cfg:       "cfg1",
-		CfgStatus: string(controlplanes.ConfigurationReady),
+		Name:    "ctp1",
+		ID:      "00000000-0000-0000-0000-000000000000",
+		Cfg:     "cfg1",
+		Updated: "True",
+		Synced:  "True",
+		Ready:   "False",
 	}
 
 	ctp2Resp = &controlplane.Response{
-		Name:      "ctp2",
-		ID:        "00000000-0000-0000-0000-000000000001",
-		Cfg:       "cfg1",
-		CfgStatus: string(controlplanes.ConfigurationReady),
+		Name:    "ctp2",
+		ID:      "00000000-0000-0000-0000-000000000001",
+		Cfg:     "cfg1",
+		Updated: "True",
+		Synced:  "True",
+		Ready:   "False",
 	}
 )
 
@@ -148,7 +153,7 @@ func TestGet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			c := New(tc.args.ctp, tc.args.cfg, acct)
-			got, err := c.Get(context.Background(), tc.args.name, "")
+			got, err := c.Get(context.Background(), types.NamespacedName{Name: tc.args.name})
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nGet(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -206,7 +211,7 @@ func TestDelete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			c := New(tc.args.ctp, tc.args.cfg, acct)
-			err := c.Delete(context.Background(), tc.args.name, "")
+			err := c.Delete(context.Background(), types.NamespacedName{Name: tc.args.name})
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nDelete(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -344,10 +349,12 @@ func TestConvert(t *testing.T) {
 			},
 			want: want{
 				resp: &controlplane.Response{
-					Name:      "ctp1",
-					ID:        "00000000-0000-0000-0000-000000000000",
-					Cfg:       notAvailable,
-					CfgStatus: notAvailable,
+					Name:    "ctp1",
+					ID:      "00000000-0000-0000-0000-000000000000",
+					Synced:  "True",
+					Ready:   "False",
+					Cfg:     "",
+					Updated: "",
 				},
 			},
 		},

--- a/internal/controlplane/cloud/cloud_test.go
+++ b/internal/controlplane/cloud/cloud_test.go
@@ -148,7 +148,7 @@ func TestGet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			c := New(tc.args.ctp, tc.args.cfg, acct)
-			got, err := c.Get(context.Background(), tc.args.name)
+			got, err := c.Get(context.Background(), tc.args.name, "")
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nGet(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -206,7 +206,7 @@ func TestDelete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			c := New(tc.args.ctp, tc.args.cfg, acct)
-			err := c.Delete(context.Background(), tc.args.name)
+			err := c.Delete(context.Background(), tc.args.name, "")
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nDelete(...): -want error, +got error:\n%s", tc.reason, diff)
@@ -296,7 +296,7 @@ func TestList(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 
 			c := New(tc.args.ctp, tc.args.cfg, acct)
-			got, err := c.List(context.Background())
+			got, err := c.List(context.Background(), "")
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nList(...): -want error, +got error:\n%s", tc.reason, diff)

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -14,18 +14,25 @@
 
 package controlplane
 
+import (
+	"time"
+)
+
 // Response is a normalized ControlPlane response.
 // NOTE(tnthornton) this is expected to be different in the near future as
 // cloud and spaces APIs converge.
 type Response struct {
-	ID      string
-	Name    string
-	Group   string
-	Message string
-	Status  string
+	ID                string
+	Group             string
+	Name              string
+	CrossplaneVersion string
+	Synced            string
+	Ready             string
+	Message           string
+	Age               *time.Duration
 
-	Cfg       string
-	CfgStatus string
+	Cfg     string
+	Updated string
 
 	ConnName string
 }

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -20,12 +20,12 @@ package controlplane
 type Response struct {
 	ID      string
 	Name    string
+	Group   string
 	Message string
 	Status  string
 
 	Cfg       string
 	CfgStatus string
 
-	ConnName      string
-	ConnNamespace string
+	ConnName string
 }

--- a/internal/controlplane/space/space.go
+++ b/internal/controlplane/space/space.go
@@ -157,7 +157,7 @@ func (c *Client) GetKubeConfig(ctx context.Context, ctp types.NamespacedName) (*
 			Version:  "v1",
 			Resource: "secrets",
 		}).
-		Namespace(ctp.Name).
+		Namespace(ctp.Namespace).
 		Get(
 			ctx,
 			r.ConnName,

--- a/internal/upbound/flags.go
+++ b/internal/upbound/flags.go
@@ -47,8 +47,9 @@ type KubeFlags struct {
 	Context string `name:"kubecontext" help:"Override default kubeconfig context."`
 
 	// set by AfterApply
-	config  *rest.Config
-	context string
+	config    *rest.Config
+	context   string
+	namespace string
 }
 
 func (f *KubeFlags) AfterApply() error {
@@ -75,6 +76,12 @@ func (f *KubeFlags) AfterApply() error {
 	}
 	f.config = restConfig
 
+	ns, _, err := loader.Namespace()
+	if err != nil {
+		return err
+	}
+	f.namespace = ns
+
 	return nil
 }
 
@@ -93,4 +100,8 @@ func (f *KubeFlags) GetConfig() *rest.Config {
 // is changed.
 func (f *KubeFlags) GetContext() string {
 	return f.context
+}
+
+func (f *KubeFlags) Namespace() string {
+	return f.namespace
 }


### PR DESCRIPTION
### Description of your changes
With Spaces 1.2, 'groups' are introduced. Unfortunately, that means many of the related commands no longer work. This changeset attempts to address that.

Highlevel changes:
- thread groups through connect, create, delete, get, list
- translate -A == --all-groups for list

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
1. Update unit test - all pass
2. Ran through various commands called out below

#### up ctp get
```bash
./_output/bin/darwin_arm64/up ctp get one
Control plane one not found

./_output/bin/darwin_arm64/up ctp get two -g two
Control plane two not found

./_output/bin/darwin_arm64/up ctp list
No control planes found

./_output/bin/darwin_arm64/up ctp list -A
No control planes found
```
#### up ctp create one
```
./_output/bin/darwin_arm64/up ctp create one
one created
```
#### up ctp create two -g two
```
./_output/bin/darwin_arm64/up ctp create two -g two
two created
```
#### up ctp list
```bash
./_output/bin/darwin_arm64/up ctp list
NAME   ID                                     GROUP     STATUS     MESSAGE                                                                                                                                 CONNECTION NAME
one    8ccaec1c-2550-4f68-9531-e188394490c8   default   Creating   Waiting for start up: Unready resources: admin-services, admin-services-uses-kube-control-plane, get-backup-configuration, and 5 more   kubeconfig-one

./_output/bin/darwin_arm64/up ctp list -A
NAME   ID                                     GROUP     STATUS     MESSAGE                                                                                             CONNECTION NAME
one    8ccaec1c-2550-4f68-9531-e188394490c8   default   Creating   Waiting for start up: Unready resources: admin-services, kube-control-plane, and xmanagedServices   kubeconfig-one
two    3048d360-488d-48ee-b7ba-591757f8182e   two       Creating   Waiting for start up                                                                                kubeconfig-two
```
#### up ctp connect one
```
./_output/bin/darwin_arm64/up ctp connect one

kubectl get ns
NAME                STATUS   AGE
crossplane-system   Active   3m33s
default             Active   4m2s
kube-node-lease     Active   4m2s
kube-public         Active   4m2s
kube-system         Active   4m2s
upbound-system      Active   3m33s
```
#### up ctp connect two -g two
```
./_output/bin/darwin_arm64/up ctp connect two -g two

kubectl get ns
NAME                STATUS   AGE
crossplane-system   Active   3m10s
default             Active   3m35s
kube-node-lease     Active   3m35s
kube-public         Active   3m35s
kube-system         Active   3m35s
upbound-system      Active   3m10s
```
#### up ctp delete two -g two
```
./_output/bin/darwin_arm64/up ctp delete two -g two
two deleted
```
#### up ctp delete one
```
./_output/bin/darwin_arm64/up ctp delete one
one deleted

./_output/bin/darwin_arm64/up ctp list -A
NAME   ID                                     GROUP     STATUS     MESSAGE   CONNECTION NAME
one    8ccaec1c-2550-4f68-9531-e188394490c8   default   Deleting             kubeconfig-one
two    3048d360-488d-48ee-b7ba-591757f8182e   two       Deleting             kubeconfig-two

./_output/bin/darwin_arm64/up ctp get two -g two
NAME   ID                                     GROUP   STATUS     MESSAGE   CONNECTION NAME
two    3048d360-488d-48ee-b7ba-591757f8182e   two     Deleting             kubeconfig-two

```