### PR TITLE
Do not restore package statuses and use the same confirmation dialog as spaces init

### DIFF
--- a/cmd/up/migration/import.go
+++ b/cmd/up/migration/import.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/pterm/pterm"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
@@ -102,15 +103,16 @@ func (c *importCmd) Run(ctx context.Context, migCtx *migration.Context) error { 
 			fmt.Println("- " + err.Error())
 		}
 		if !c.Yes {
-			res, err := c.prompter.Prompt("Do you still wish to proceed? [y/n]", false)
-			if err != nil {
-				return err
-			}
-			if res != "y" {
+			pterm.Println() // Blank line
+			confirm := pterm.DefaultInteractiveConfirm
+			confirm.DefaultText = "Do you still want to proceed?"
+			confirm.DefaultValue = false
+			result, _ := confirm.Show()
+			pterm.Println() // Blank line
+			if !result {
+				pterm.Error.Println("Preflight checks must pass in order to proceed with the import.")
 				return nil
 			}
-			// Print a newline to separate the prompt from the output.
-			fmt.Println()
 		}
 	}
 

--- a/internal/migration/importer/import.go
+++ b/internal/migration/importer/import.go
@@ -169,27 +169,21 @@ func (im *ControlPlaneStateImporter) Import(ctx context.Context) error { // noli
 		{Group: "pkg.crossplane.io", Kind: "Provider"},
 		{Group: "pkg.crossplane.io", Kind: "Function"},
 		{Group: "pkg.crossplane.io", Kind: "Configuration"},
+		// Note(turkenh): We should not need to wait for ProviderRevision, FunctionRevision, and ConfigurationRevision.
+		// Crossplane should not report packages as ready before revisions are healthy. This is a bug in Crossplane
+		// version <1.14 which was fixed with https://github.com/crossplane/crossplane/pull/4647
+		// Todo(turkenh): Remove these once Crossplane 1.13 is no longer supported.
+		{Group: "pkg.crossplane.io", Kind: "ProviderRevision"},
+		{Group: "pkg.crossplane.io", Kind: "FunctionRevision"},
+		{Group: "pkg.crossplane.io", Kind: "ConfigurationRevision"},
 	} {
 		if err := im.waitForConditions(ctx, s, k, []xpv1.ConditionType{"Installed", "Healthy"}); err != nil {
 			s.Fail(waitPkgsMsg + "Failed!")
 			return errors.Wrapf(err, "there are unhealthy %qs", k.Kind)
 		}
 	}
-	s.Success(waitPkgsMsg + "Installed and Healthy! ⏳")
 
-	waitPkgRevsMsg := "Waiting for PackageRevisions... "
-	s, _ = upterm.CheckmarkSuccessSpinner.Start(waitPkgRevsMsg)
-	for _, k := range []schema.GroupKind{
-		{Group: "pkg.crossplane.io", Kind: "ProviderRevision"},
-		{Group: "pkg.crossplane.io", Kind: "FunctionRevision"},
-		{Group: "pkg.crossplane.io", Kind: "ConfigurationRevision"},
-	} {
-		if err := im.waitForConditions(ctx, s, k, []xpv1.ConditionType{"Healthy"}); err != nil {
-			s.Fail(waitPkgRevsMsg + "Failed!")
-			return errors.Wrapf(err, "there are unhealthy %qs", k.Kind)
-		}
-	}
-	s.Success(waitPkgRevsMsg + "Healthy! ⏳")
+	s.Success(waitPkgsMsg + "Installed and Healthy! ⏳")
 	//////////////////////////////////////////
 
 	// Reset the resource mapper to make sure all CRDs introduced by packages or XRDs are available.


### PR DESCRIPTION
### Description of your changes

This PR is a follow up on the problem described in https://github.com/upbound/up/pull/422 during import:

- Do not restore status for base resources
  - Otherwise, packages reported as installed/healthy before they were actually processed. 
  - No need for restoring status for any other base resources, so, disabled all together.
- Unifies the confirmation dialog as `spaces init` 
  - To confirm exporting secrets.
  - When preflight checks failed during import.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

1. Create a control plane
2. Stop Crossplane
3. Import
4. Ensure it waits successfully.

