### PR TITLE
feat(xpkg/build): Add `--controller-tarball` flag

### DIFF
--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -59,6 +60,10 @@ const (
 // fetchFn fetches a package from a source.
 type fetchFn func(context.Context, name.Reference) (v1.Image, error)
 
+func emptyFetch(ctx context.Context, r name.Reference) (v1.Image, error) {
+	return empty.Image, nil
+}
+
 // registryFetch fetches a package from the registry.
 func registryFetch(ctx context.Context, r name.Reference) (v1.Image, error) {
 	return remote.Image(r, remote.WithContext(ctx))
@@ -69,7 +74,7 @@ func daemonFetch(ctx context.Context, r name.Reference) (v1.Image, error) {
 	return daemon.Image(r, daemon.WithContext(ctx))
 }
 
-func xpkgFetch(path string) fetchFn {
+func tarballFetch(path string) fetchFn {
 	return func(ctx context.Context, r name.Reference) (v1.Image, error) {
 		return tarball.ImageFromPath(filepath.Clean(path), nil)
 	}
@@ -97,7 +102,7 @@ func (c *xpExtractCmd) AfterApply() error {
 			}
 			c.Package = path
 		}
-		c.fetch = xpkgFetch(c.Package)
+		c.fetch = tarballFetch(c.Package)
 	}
 	if !c.FromXpkg {
 		if c.Package == "" {


### PR DESCRIPTION
### Description of your changes

Add an additional flag to `up xpkg` that allows building a package with a tarball base image without using docker daemon.

Replaces https://github.com/upbound/up/pull/386
Fixes https://github.com/upbound/up/issues/385

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

1. `crane pull busybox busybox.tar`
2. `up build xpkg -f ./my-package -o ./my-package.xpkg --controller-tarball busybox.tar`
