### PR TITLE
Improve UX of ctp connect+disconnect

### DIFF
--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -131,7 +131,7 @@ func (c *connectCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pt
 	// return early if so.
 	origContext := kcloader.CurrentContext
 	if strings.HasPrefix(origContext, upboundPrefix) {
-		return nil
+		return fmt.Errorf("already connected to a control plane. Disconnect first")
 	}
 
 	cfg, err := c.client.GetKubeConfig(ctx, types.NamespacedName{Namespace: c.Group, Name: c.Name})
@@ -152,6 +152,8 @@ func (c *connectCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pt
 	if err := kube.ApplyControlPlaneKubeconfig(modifiedCfg, "", upCtx.WrapTransport); err != nil {
 		return err
 	}
+
+	p.Printfln("Current context set to %s", modifiedCfg.CurrentContext)
 
 	return nil
 }

--- a/cmd/up/controlplane/disconnect.go
+++ b/cmd/up/controlplane/disconnect.go
@@ -86,7 +86,7 @@ func (c *disconnectCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, u
 }
 
 func origContext(currentCtx string) (string, error) {
-	parts := strings.Split(currentCtx, "_")
+	parts := strings.SplitN(currentCtx, "_", 4)
 	if len(parts) != 4 {
 		return "", fmt.Errorf(errFmtContextParts, len(parts))
 	}

--- a/cmd/up/controlplane/disconnect.go
+++ b/cmd/up/controlplane/disconnect.go
@@ -77,7 +77,12 @@ func (c *disconnectCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, u
 		return err
 	}
 
-	return clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), modifiedCfg, false)
+	if err := clientcmd.ModifyConfig(clientcmd.NewDefaultClientConfigLoadingRules(), modifiedCfg, false); err != nil {
+		return err
+	}
+
+	p.Printfln("Disconnected from control plane %q. Switch back to context %q.", cptContext, target)
+	return nil
 }
 
 func origContext(currentCtx string) (string, error) {

--- a/cmd/up/controlplane/disconnect_test.go
+++ b/cmd/up/controlplane/disconnect_test.go
@@ -55,6 +55,15 @@ func TestOrigContext(t *testing.T) {
 				result: "kind-kind",
 			},
 		},
+		"SuccessUnderscore": {
+			reason: "A well formed context name should be parsed successfully.",
+			args: args{
+				context: "upbound_demo_cpt1_kind_kind_foo_bar",
+			},
+			want: want{
+				result: "kind_kind_foo_bar",
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/cmd/up/controlplane/kubeconfig/get.go
+++ b/cmd/up/controlplane/kubeconfig/get.go
@@ -61,8 +61,8 @@ func (c *getCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error {
 	if err := kube.ApplyControlPlaneKubeconfig(*mcpConf, c.File, upCtx.WrapTransport); err != nil {
 		return err
 	}
-	if c.File == "" {
-		p.Printfln("Current context set to %s", mcpConf.CurrentContext)
-	}
+
+	p.Printfln("Current context set to %s", mcpConf.CurrentContext)
+
 	return nil
 }


### PR DESCRIPTION
What is chagned:

1. print what connect and disconnect do, aka switch contexts in the kubeconfig.
2. fix handling of contexts with underscore. This had been broken on disconnect.

Fixes https://github.com/upbound/up/issues/401.