### PR TITLE
Unify 'up ctp connect' and 'up ctp kubeconfig get'

### DIFF
--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -18,103 +18,36 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/upbound/up-sdk-go/service/configurations"
-	cp "github.com/upbound/up-sdk-go/service/controlplanes"
+	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
 	"github.com/upbound/up/internal/controlplane"
-	"github.com/upbound/up/internal/controlplane/cloud"
-	"github.com/upbound/up/internal/controlplane/space"
 	"github.com/upbound/up/internal/kube"
 	"github.com/upbound/up/internal/upbound"
-	"github.com/upbound/up/internal/upterm"
 )
 
 const (
 	upboundPrefix = "upbound_"
-
-	errFmtConfigBroken = "config is broken, missing %s: %q"
 )
 
-type ctpConnector interface {
-	GetKubeConfig(ctx context.Context, ctp types.NamespacedName) (*api.Config, error)
-}
-
-// AfterApply sets default values in command after assignment and validation.
-func (c *connectCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-	c.stdin = os.Stdin
-
-	if upCtx.Profile.IsSpace() {
-		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
-		if err != nil {
-			return err
-		}
-		if c.Group == "" {
-			c.Group = ns
-		}
-
-		client, err := dynamic.NewForConfig(kubeconfig)
-		if err != nil {
-			return err
-		}
-		c.client = space.New(client)
-	} else {
-		if c.Token == "" {
-			return fmt.Errorf("--token must be specified")
-		}
-
-		if c.Token == "-" {
-			b, err := io.ReadAll(c.stdin)
-			if err != nil {
-				return err
-			}
-			c.Token = strings.TrimSpace(string(b))
-		}
-
-		cfg, err := upCtx.BuildSDKConfig()
-		if err != nil {
-			return err
-		}
-		ctpclient := cp.NewClient(cfg)
-		cfgclient := configurations.NewClient(cfg)
-
-		// The cloud client needs the proxy endpoint and a PAT token for
-		// setting up communication with Upbound Cloud.
-		c.client = cloud.New(
-			ctpclient,
-			cfgclient,
-			upCtx.Account,
-			cloud.WithToken(c.Token),
-			cloud.WithProxyEndpoint(upCtx.ProxyEndpoint),
-		)
-	}
-
-	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
-	return nil
-}
-
-// getCmd gets a single control plane in an account on Upbound.
+// connectCmd connects to a control plane by updating the current kubeconfig with
+// the control plane's kubeconfig. The disconnect command can be used to restore
+// the old context.
 type connectCmd struct {
-	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
-	Token string `help:"API token used to authenticate. Required for Upbound Cloud; ignored otherwise."`
+	kubeconfig.ConnectionSecretCmd `cmd:""`
+}
 
-	Group string `short:"g" help:"The control plane group that the control plane is contained in. By default, this is the group specified in the current profile."`
-
-	stdin  io.Reader
-	client ctpConnector
+func (c *connectCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	return c.ConnectionSecretCmd.AfterApply(kongCtx, upCtx)
 }
 
 // Run executes the get command.
-func (c *connectCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context) error {
+func (c *connectCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context, getter kubeconfig.ConnectionSecretGetter) error {
 	if upCtx.Account == "" {
 		return errors.New("error: account is missing from profile")
 	}
@@ -127,80 +60,43 @@ func (c *connectCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pt
 	if err != nil {
 		return err
 	}
-	// Check if the fs kubeconfig is already pointing to a control plane and
-	// return early if so.
+
+	// Check if the fs kubeconfig is already pointing to a control plane and return early if so.
 	origContext := kcloader.CurrentContext
 	if strings.HasPrefix(origContext, upboundPrefix) {
 		return fmt.Errorf("already connected to a control plane. Disconnect first")
 	}
 
-	cfg, err := c.client.GetKubeConfig(ctx, types.NamespacedName{Namespace: c.Group, Name: c.Name})
+	nname := types.NamespacedName{Namespace: c.Group, Name: c.Name}
+	ctpConfig, err := getter.GetKubeConfig(ctx, nname)
 	if controlplane.IsNotFound(err) {
-		p.Printfln("Control plane %s not found", c.Name)
+		p.Printfln("Control plane %s not found", nname)
 		return nil
 	}
 	if err != nil {
 		return err
 	}
 
-	expectedContextName := defaultContextName(upCtx.Account, c.Name)
-	newKey := controlplaneContextName(upCtx.Account, c.Name, origContext)
-	modifiedCfg, err := extractKubeConfig(*cfg, expectedContextName, newKey)
+	expectedContextName := kubeconfig.ExpectedConnectionSecretContext(upCtx.Account, c.Name)
+	newKey := controlplaneContextName(upCtx.Account, nname, origContext)
+	ctpConfig, err = kubeconfig.ExtractControlPlaneContext(ctpConfig, expectedContextName, newKey)
 	if err != nil {
 		return err
 	}
-	// NOTE(tnthornton) we don't current support supplying files outside of
-	// the default system kubeconfig.
-	if err := kube.ApplyControlPlaneKubeconfig(modifiedCfg, "", upCtx.WrapTransport); err != nil {
+
+	// NOTE(tnthornton) we don't current support supplying files outside of the default system kubeconfig.
+	if err := kube.MergeIntoKubeConfig(ctpConfig, "", true, kube.VerifyKubeConfig(upCtx.WrapTransport)); err != nil {
 		return err
 	}
 
-	p.Printfln("Current context set to %s", modifiedCfg.CurrentContext)
+	p.Printfln("Current context set to %s", ctpConfig.CurrentContext)
 
 	return nil
 }
 
-// extractKubeConfig prunes the given kubeconfig by extracting the one and only
-// or the preferred context if there are multiple. It renames context, cluster
-// and authInfo to the given key.
-func extractKubeConfig(cfg api.Config, preferredContextName, newKey string) (api.Config, error) {
-	ctx, ok := cfg.Contexts[preferredContextName]
-	if !ok {
-		if len(cfg.Contexts) != 1 {
-			return api.Config{}, fmt.Errorf(errFmtConfigBroken, "context", preferredContextName)
-		}
-
-		// fall back if there is only one
-		for k := range cfg.Contexts {
-			ctx = cfg.Contexts[k]
-		}
+func controlplaneContextName(account string, name types.NamespacedName, origCtx string) string {
+	if name.Namespace == "" {
+		return fmt.Sprintf("%s%s_%s/%s_%s", upboundPrefix, account, "default", name.Name, origCtx)
 	}
-
-	cluster, ok := cfg.Clusters[ctx.Cluster]
-	if !ok {
-		return api.Config{}, fmt.Errorf(errFmtConfigBroken, "cluster", ctx.Cluster)
-	}
-	auth, ok := cfg.AuthInfos[ctx.AuthInfo]
-	if !ok {
-		return api.Config{}, fmt.Errorf(errFmtConfigBroken, "user", ctx.AuthInfo)
-	}
-
-	// create new kubeconfig with new keys
-	ctx = ctx.DeepCopy()
-	ctx.Cluster = newKey
-	ctx.AuthInfo = newKey
-	return api.Config{
-		Clusters:       map[string]*api.Cluster{newKey: cluster},
-		AuthInfos:      map[string]*api.AuthInfo{newKey: auth},
-		Contexts:       map[string]*api.Context{newKey: ctx},
-		CurrentContext: newKey,
-	}, nil
-}
-
-func defaultContextName(account, ctpName string) string {
-	return fmt.Sprintf("%s-%s", account, ctpName)
-}
-
-func controlplaneContextName(account, ctpName, origCtx string) string {
-	return fmt.Sprintf("%s%s_%s_%s", upboundPrefix, account, ctpName, origCtx)
+	return fmt.Sprintf("%s%s_%s/%s_%s", upboundPrefix, account, name.Namespace, name.Name, origCtx)
 }

--- a/cmd/up/controlplane/connect.go
+++ b/cmd/up/controlplane/connect.go
@@ -96,7 +96,7 @@ func (c *connectCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upboun
 
 func controlplaneContextName(account string, name types.NamespacedName, origCtx string) string {
 	if name.Namespace == "" {
-		return fmt.Sprintf("%s%s_%s/%s_%s", upboundPrefix, account, "default", name.Name, origCtx)
+		name.Namespace = "default" // passed by value. We can mutate it.
 	}
 	return fmt.Sprintf("%s%s_%s/%s_%s", upboundPrefix, account, name.Namespace, name.Name, origCtx)
 }

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -50,7 +50,7 @@ type createCmd struct {
 // AfterApply sets default values in command after assignment and validation.
 func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetSpaceKubeConfig()
 		if err != nil {
 			return err
 		}

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -45,7 +45,7 @@ type deleteCmd struct {
 // AfterApply sets default values in command after assignment and validation.
 func (c *deleteCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetSpaceKubeConfig()
 		if err != nil {
 			return err
 		}

--- a/cmd/up/controlplane/disconnect.go
+++ b/cmd/up/controlplane/disconnect.go
@@ -81,7 +81,7 @@ func (c *disconnectCmd) Run(printer upterm.ObjectPrinter, p pterm.TextPrinter, u
 		return err
 	}
 
-	p.Printfln("Disconnected from control plane %q. Switch back to context %q.", cptContext, target)
+	p.Printfln("Disconnected from control plane %q and switched back to context %q.", cptContext, target)
 	return nil
 }
 

--- a/cmd/up/controlplane/disconnect_test.go
+++ b/cmd/up/controlplane/disconnect_test.go
@@ -18,9 +18,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
 )
 
 func TestOrigContext(t *testing.T) {
@@ -46,7 +47,7 @@ func TestOrigContext(t *testing.T) {
 				err: errors.New("given context does not have the correct number of parts, expected: 4, got: 1"),
 			},
 		},
-		"Success": {
+		"SuccessNamespaceLess": {
 			reason: "A well formed context name should be parsed successfully.",
 			args: args{
 				context: "upbound_demo_cpt1_kind-kind",
@@ -55,10 +56,28 @@ func TestOrigContext(t *testing.T) {
 				result: "kind-kind",
 			},
 		},
-		"SuccessUnderscore": {
+		"Success": {
+			reason: "A well formed context name should be parsed successfully.",
+			args: args{
+				context: "upbound_demo_default/cpt1_kind-kind",
+			},
+			want: want{
+				result: "kind-kind",
+			},
+		},
+		"SuccessUnderscoreNamespaceLess": {
 			reason: "A well formed context name should be parsed successfully.",
 			args: args{
 				context: "upbound_demo_cpt1_kind_kind_foo_bar",
+			},
+			want: want{
+				result: "kind_kind_foo_bar",
+			},
+		},
+		"SuccessUnderscore": {
+			reason: "A well formed context name should be parsed successfully.",
+			args: args{
+				context: "upbound_demo_default/cpt1_kind_kind_foo_bar",
 			},
 			want: want{
 				result: "kind_kind_foo_bar",

--- a/cmd/up/controlplane/get.go
+++ b/cmd/up/controlplane/get.go
@@ -38,7 +38,7 @@ type ctpGetter interface {
 // AfterApply sets default values in command after assignment and validation.
 func (c *getCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetSpaceKubeConfig()
 		if err != nil {
 			return err
 		}

--- a/cmd/up/controlplane/kubeconfig/connection.go
+++ b/cmd/up/controlplane/kubeconfig/connection.go
@@ -41,14 +41,10 @@ type ConnectionSecretCmd struct {
 	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
 	Token string `help:"API token used to authenticate. Required for Upbound Cloud; ignored otherwise."`
 	Group string `short:"g" help:"The control plane group that the control plane is contained in. By default, this is the group specified in the current profile."`
-
-	stdin io.Reader
 }
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *ConnectionSecretCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-	c.stdin = os.Stdin
-
 	var getter ConnectionSecretGetter
 	if upCtx.Profile.IsSpace() {
 		kubeconfig, ns, err := upCtx.Profile.GetSpaceKubeConfig()
@@ -74,7 +70,7 @@ func (c *ConnectionSecretCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.C
 		}
 
 		if c.Token == "-" {
-			b, err := io.ReadAll(c.stdin)
+			b, err := io.ReadAll(os.Stdin)
 			if err != nil {
 				return err
 			}

--- a/cmd/up/controlplane/kubeconfig/connection.go
+++ b/cmd/up/controlplane/kubeconfig/connection.go
@@ -1,0 +1,147 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeconfig
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/upbound/up-sdk-go/service/configurations"
+	cp "github.com/upbound/up-sdk-go/service/controlplanes"
+	"github.com/upbound/up/internal/controlplane/cloud"
+	"github.com/upbound/up/internal/controlplane/space"
+	"github.com/upbound/up/internal/upbound"
+)
+
+const (
+	errFmtConfigBroken = "config is broken, missing %s: %q"
+)
+
+// ConnectionSecretCmd is the base for command getting connection secret for a control plane.
+type ConnectionSecretCmd struct {
+	Name  string `arg:"" required:"" help:"Name of control plane." predictor:"ctps"`
+	Token string `help:"API token used to authenticate. Required for Upbound Cloud; ignored otherwise."`
+	Group string `short:"g" help:"The control plane group that the control plane is contained in. By default, this is the group specified in the current profile."`
+
+	stdin io.Reader
+}
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *ConnectionSecretCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
+	c.stdin = os.Stdin
+
+	var getter ConnectionSecretGetter
+	if upCtx.Profile.IsSpace() {
+		kubeconfig, ns, err := upCtx.Profile.GetSpaceKubeConfig()
+		if err != nil {
+			return err
+		}
+		if c.Group == "" {
+			c.Group = ns
+		}
+
+		client, err := dynamic.NewForConfig(kubeconfig)
+		if err != nil {
+			return err
+		}
+		getter = space.New(client)
+	} else {
+		if c.Group != "" {
+			return fmt.Errorf("group flag is not supported for control plane profile %q", upCtx.ProfileName)
+		}
+
+		if c.Token == "" {
+			return fmt.Errorf("--token must be specified")
+		}
+
+		if c.Token == "-" {
+			b, err := io.ReadAll(c.stdin)
+			if err != nil {
+				return err
+			}
+			c.Token = strings.TrimSpace(string(b))
+		}
+
+		cfg, err := upCtx.BuildSDKConfig()
+		if err != nil {
+			return err
+		}
+		ctpclient := cp.NewClient(cfg)
+		cfgclient := configurations.NewClient(cfg)
+
+		// The cloud client needs the proxy endpoint and a PAT token for
+		// setting up communication with Upbound Cloud.
+		getter = cloud.New(
+			ctpclient,
+			cfgclient,
+			upCtx.Account,
+			cloud.WithToken(c.Token),
+			cloud.WithProxyEndpoint(upCtx.ProxyEndpoint),
+		)
+	}
+
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+	kongCtx.BindTo(getter, (*ConnectionSecretGetter)(nil))
+
+	return nil
+}
+
+// ExtractControlPlaneContext prunes the given kubeconfig by extracting the one and only
+// or the preferred context if there are multiple. It renames context, cluster
+// and authInfo to the given key.
+func ExtractControlPlaneContext(cfg *api.Config, preferredContextName, newKey string) (*api.Config, error) {
+	ctx, ok := cfg.Contexts[preferredContextName]
+	if !ok {
+		if len(cfg.Contexts) != 1 {
+			return nil, fmt.Errorf(errFmtConfigBroken, "context", preferredContextName)
+		}
+
+		// fall back if there is only one
+		for k := range cfg.Contexts {
+			ctx = cfg.Contexts[k]
+		}
+	}
+
+	cluster, ok := cfg.Clusters[ctx.Cluster]
+	if !ok {
+		return nil, fmt.Errorf(errFmtConfigBroken, "cluster", ctx.Cluster)
+	}
+	auth, ok := cfg.AuthInfos[ctx.AuthInfo]
+	if !ok {
+		return nil, fmt.Errorf(errFmtConfigBroken, "user", ctx.AuthInfo)
+	}
+
+	// create new kubeconfig with new keys
+	ctx = ctx.DeepCopy()
+	ctx.Cluster = newKey
+	ctx.AuthInfo = newKey
+	return &api.Config{
+		Clusters:       map[string]*api.Cluster{newKey: cluster},
+		AuthInfos:      map[string]*api.AuthInfo{newKey: auth},
+		Contexts:       map[string]*api.Context{newKey: ctx},
+		CurrentContext: newKey,
+	}, nil
+}
+
+func ExpectedConnectionSecretContext(account, ctpName string) string {
+	return fmt.Sprintf("%s-%s", account, ctpName)
+}

--- a/cmd/up/controlplane/kubeconfig/kubeconfig.go
+++ b/cmd/up/controlplane/kubeconfig/kubeconfig.go
@@ -15,10 +15,18 @@
 package kubeconfig
 
 import (
+	"context"
+
 	"github.com/alecthomas/kong"
+	"k8s.io/apimachinery/pkg/types"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/upbound/up/internal/feature"
 )
+
+type ConnectionSecretGetter interface {
+	GetKubeConfig(ctx context.Context, ctp types.NamespacedName) (*clientcmdapi.Config, error)
+}
 
 // BeforeReset is the first hook to run.
 func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
@@ -27,5 +35,5 @@ func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
 
 // Cmd contains commands for managing control plane kubeconfig data.
 type Cmd struct {
-	Get getCmd `cmd:"" help:"Get a kubeconfig for a control plane."`
+	Get getCmd `cmd:"" help:"Get a kubeconfig for a control plane and, if not specified otherwise, merge into kubeconfig and select context."`
 }

--- a/cmd/up/controlplane/list.go
+++ b/cmd/up/controlplane/list.go
@@ -45,7 +45,7 @@ type listCmd struct {
 // AfterApply sets default values in command after assignment and validation.
 func (c *listCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
 	if upCtx.Profile.IsSpace() {
-		kubeconfig, ns, err := upCtx.Profile.GetKubeClientConfig()
+		kubeconfig, ns, err := upCtx.Profile.GetSpaceKubeConfig()
 		if err != nil {
 			return err
 		}

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -139,7 +139,7 @@ func (c *destroyCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if !upCtx.Profile.IsSpace() {
 		return nil, fmt.Errorf("destroy is not supported for non-space profile %q", upCtx.ProfileName)
 	}
-	cfg, _, err := upCtx.Profile.GetKubeClientConfig()
+	cfg, _, err := upCtx.Profile.GetSpaceKubeConfig()
 	return cfg, err
 }
 

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -167,7 +167,7 @@ func (c *upgradeCmd) getKubeconfig(upCtx *upbound.Context) (*rest.Config, error)
 	if !upCtx.Profile.IsSpace() {
 		return nil, fmt.Errorf("upgrade is not supported for non-space profile %q", upCtx.ProfileName)
 	}
-	cfg, _, err := upCtx.Profile.GetKubeClientConfig()
+	cfg, _, err := upCtx.Profile.GetSpaceKubeConfig()
 	return cfg, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/connesc/cipherio v0.2.1 // indirect
-	github.com/containerd/console v1.0.3 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/containerd/containerd v1.7.2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
@@ -170,7 +170,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mdp/qrterminal/v3 v3.2.0
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -196,7 +196,7 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.0 // indirect
-	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rivo/uniseg v0.4.6 // indirect
 	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab // indirect
 	github.com/rubenv/sql-migrate v1.4.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,9 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/connesc/cipherio v0.2.1 h1:FGtpTPMbKNNWByNrr9aEBtaJtXjqOzkIXNYJp6OEycw=
 github.com/connesc/cipherio v0.2.1/go.mod h1:ukY0MWJDFnJEbXMQtOcn2VmTpRfzcTz4OoVrWGGJZcA=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
-github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
+github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=
+github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/containerd/containerd v1.7.2 h1:UF2gdONnxO8I6byZXDi5sXWiWvlW3D/sci7dTQimEJo=
 github.com/containerd/containerd v1.7.2/go.mod h1:afcz74+K10M/+cjGHIVQrCt3RAQhUSCAjJ9iMYhhkuI=
 github.com/containerd/continuity v0.4.1 h1:wQnVrjIyQ8vhU2sgOiL5T07jo+ouqc2bnKsv5/EqGhU=
@@ -636,8 +637,8 @@ github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
-github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
@@ -770,8 +771,8 @@ github.com/pterm/pterm v0.12.62/go.mod h1:+c3ujjE7N5qmNx6eKAa7YVSC6m/gCorJJKhzwY
 github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
 github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
-github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rivo/uniseg v0.4.6 h1:Sovz9sDSwbOz9tgUy8JpT+KgCkPYJEN/oYzlJiYTNLg=
+github.com/rivo/uniseg v0.4.6/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab h1:ZjX6I48eZSFetPb41dHudEyVr5v953N15TsNZXlkcWY=
 github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab/go.mod h1:/PfPXh0EntGc3QAAyUaviy4S9tzy4Zp0e2ilq4voC6E=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/internal/controlplane/cloud/cloud.go
+++ b/internal/controlplane/cloud/cloud.go
@@ -165,7 +165,7 @@ func (c *Client) Delete(ctx context.Context, ctp types.NamespacedName) error {
 
 // GetKubeConfig for the given Control Plane.
 func (c *Client) GetKubeConfig(ctx context.Context, ctp types.NamespacedName) (*api.Config, error) {
-	return kube.BuildControlPlaneKubeconfig(
+	return kube.BuildCloudControlPlaneKubeconfig(
 		c.proxy,
 		path.Join(c.account, ctp.Name),
 		c.token,

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -51,11 +51,11 @@ type Profile struct {
 	// Account is the default account to use when this profile is selected.
 	Account string `json:"account,omitempty"`
 
-	// Kubeconfig is the kubeconfig file path that GetKubeClientConfig() will
+	// Kubeconfig is the kubeconfig file path that GetSpaceKubeConfig() will
 	// read. If empty, it refers to client-go's default kubeconfig location.
 	Kubeconfig string `json:"kubeconfig,omitempty"`
 
-	// KubeContext is the context within Kubeconfig that GetKubeClientConfig()
+	// KubeContext is the context within Kubeconfig that GetSpaceKubeConfig()
 	// will read. If empty, it refers to the default context.
 	KubeContext string `json:"kube_context,omitempty"`
 
@@ -78,9 +78,9 @@ func (p Profile) IsSpace() bool {
 	return p.Type == Space
 }
 
-// GetKubeClientConfig returns a *rest.Config loaded from p.Kubeconfig and
+// GetSpaceKubeConfig returns a *rest.Config loaded from p.Kubeconfig and
 // p.KubeContext. It returns an error if p.IsSpace() is false.
-func (p Profile) GetKubeClientConfig() (*rest.Config, string, error) {
+func (p Profile) GetSpaceKubeConfig() (*rest.Config, string, error) {
 	if !p.IsSpace() {
 		return nil, "", fmt.Errorf("kube client not supported for profile type %q", p.Type)
 	}


### PR DESCRIPTION
Use the same code for both commands, and make `up ctp kubeconfig get` work with spaces.

Signed-off-by: Dr. Stefan Schimanski <stefan.schimanski@upbound.com>