### PR TITLE
feat(version): bump provider helm and kubernetes version and configur…

### DIFF
--- a/cmd/up/space/prerequisites/providers/helm/helm.go
+++ b/cmd/up/space/prerequisites/providers/helm/helm.go
@@ -40,7 +40,7 @@ import (
 var (
 	providerName = "provider-helm"
 	// Package version to be installed
-	version   = "v0.16.0"
+	version   = "v0.17.0"
 	pkgRef, _ = name.ParseReference(fmt.Sprintf("xpkg.upbound.io/crossplane-contrib/provider-helm:%s", version))
 
 	objectsCRD = "releases.helm.crossplane.io"

--- a/cmd/up/space/prerequisites/providers/kubernetes/kubernetes.go
+++ b/cmd/up/space/prerequisites/providers/kubernetes/kubernetes.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	providerName = "provider-kubernetes"
-	version      = "v0.11.4"
+	version      = "v0.12.1"
 	pkgRef, _    = name.ParseReference(fmt.Sprintf("xpkg.upbound.io/crossplane-contrib/provider-kubernetes:%s", version))
 
 	objectsCRD = "objects.kubernetes.crossplane.io"

--- a/cmd/up/space/prerequisites/uxp/uxp.go
+++ b/cmd/up/space/prerequisites/uxp/uxp.go
@@ -36,7 +36,7 @@ var (
 	ns        = "upbound-system"
 	// Chart version to be installed. universal-crossplane does not include a
 	// v prefix.
-	version = "1.14.5-up.1"
+	version = "1.14.6-up.1"
 
 	xrdCRD = "compositeresourcedefinitions.apiextensions.crossplane.io"
 
@@ -108,6 +108,17 @@ func (u *UXP) Install() error {
 	return u.mgr.Install(version, map[string]any{
 		"args": []string{
 			"--enable-usages",
+			"--max-reconcile-rate=1000",
+		},
+		"resourcesCrossplane": map[string]any{
+			"requests": map[string]any{
+				"cpu":    "500m",
+				"memory": "1Gi",
+			},
+			"limits": map[string]any{
+				"cpu":    "1000m",
+				"memory": "2Gi",
+			},
 		},
 	})
 }


### PR DESCRIPTION
…e uxp chart

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- bump provider-kubernetes
- bump provider-helm
- bump uxp version
- add args and resources to uxp

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`/Users/haarchri/.gvm/pkgsets/go1.20/global/bin/up space init SPACES_VERSION=1.2.1 --token-file=/Users/haarchri/.aws/spaces-pull.json`


```
kubectl describe pod -n upbound-system       crossplane-56447df4b8-9z78r
[...]
    Args:
      core
      start
      --enable-usages
      --max-reconcile-rate=1000
    State:          Running
      Started:      Wed, 28 Feb 2024 18:50:00 +0100
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  2Gi
    Requests:
      cpu:     500m
      memory:  1Gi
[...]
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
