### PR TITLE
feat(cli): version to subcommand and client side versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ cover.out
 
 # ignore direnv files
 .envrc
+
+.DS_Store

--- a/cmd/up/common/version.go
+++ b/cmd/up/common/version.go
@@ -1,0 +1,110 @@
+// Copyright 2023 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common contains common functions
+package common
+
+import (
+	"context"
+	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+)
+
+const (
+	errKubeConfig         = "failed to get kubeconfig"
+	errCreateK8sClientset = "could not create the clientset for Kubernetes"
+	errFetchDeployment    = "could not fetch deployments"
+)
+
+// FetchCrossplaneVersion initializes a Kubernetes client and fetches
+// and returns the version of the Crossplane deployment. If the version
+// does not have a leading 'v', it prepends it.
+func FetchCrossplaneVersion() (string, error) {
+	var version string
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return "", errors.Wrap(err, errKubeConfig)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", errors.Wrap(err, errCreateK8sClientset)
+	}
+
+	deployments, err := clientset.AppsV1().Deployments("").List(context.TODO(), v1.ListOptions{
+		LabelSelector: "app=crossplane",
+	})
+	if err != nil {
+		return "", errors.Wrap(err, errFetchDeployment)
+	}
+
+	for _, deployment := range deployments.Items {
+		v, ok := deployment.Labels["app.kubernetes.io/version"]
+		if ok {
+			if !strings.HasPrefix(v, "v") {
+				version = "v" + v
+			}
+			return version, nil
+		}
+
+		if len(deployment.Spec.Template.Spec.Containers) > 0 {
+			image := deployment.Spec.Template.Spec.Containers[0].Image
+			parts := strings.Split(image, ":")
+			if len(parts) > 1 {
+				imageTag := parts[1]
+				if !strings.HasPrefix(imageTag, "v") {
+					imageTag = "v" + imageTag
+				}
+				return imageTag, nil
+			}
+		}
+	}
+
+	return "", errors.New("Crossplane version or image tag not found")
+}
+
+// FetchSpacesVersion initializes a Kubernetes client and fetches
+// and returns the version of the spaces-controller deployment.
+func FetchSpacesVersion() (string, error) {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return "", errors.Wrap(err, errKubeConfig)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", errors.Wrap(err, errCreateK8sClientset)
+	}
+
+	deployments, err := clientset.AppsV1().Deployments("").List(context.TODO(), v1.ListOptions{
+		LabelSelector: "app=spaces-controller",
+	})
+	if err != nil {
+		return "", errors.Wrap(err, errFetchDeployment)
+	}
+
+	for _, deployment := range deployments.Items {
+		v, ok := deployment.Labels["app.kubernetes.io/version"]
+		if ok {
+			return v, nil
+		}
+	}
+
+	return "", errors.New("spaces-controller version not found")
+}

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/willabides/kongplete"
 
+	"github.com/upbound/up/cmd/up/common"
 	"github.com/upbound/up/cmd/up/configuration"
 	"github.com/upbound/up/cmd/up/configuration/template"
 	"github.com/upbound/up/cmd/up/controlplane"
@@ -58,7 +59,22 @@ type versionFlag bool
 // BeforeApply indicates that we want to execute the logic before running any
 // commands.
 func (v versionFlag) BeforeApply(ctx *kong.Context) error { // nolint:unparam
-	fmt.Fprintln(ctx.Stdout, version.GetVersion())
+	fmt.Fprintln(ctx.Stdout, "Client Version: "+version.GetVersion())
+
+	if vxp, err := common.FetchCrossplaneVersion(); err != nil {
+		ctx.Exit(1)
+		return err
+	} else if vxp != "" {
+		fmt.Fprintln(ctx.Stdout, "Server Version: "+vxp)
+	}
+
+	if sc, err := common.FetchSpacesVersion(); err != nil {
+		ctx.Exit(1)
+		return err
+	} else if sc != "" {
+		fmt.Fprintln(ctx.Stdout, "Spaces Controller Version: "+sc)
+	}
+
 	ctx.Exit(0)
 	return nil
 }

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/willabides/kongplete"
 
-	"github.com/upbound/up/cmd/up/common"
 	"github.com/upbound/up/cmd/up/configuration"
 	"github.com/upbound/up/cmd/up/configuration/template"
 	"github.com/upbound/up/cmd/up/controlplane"
@@ -40,12 +39,12 @@ import (
 	tviewtemplate "github.com/upbound/up/cmd/up/tview-template"
 	"github.com/upbound/up/cmd/up/upbound"
 	"github.com/upbound/up/cmd/up/uxp"
+	v "github.com/upbound/up/cmd/up/version"
 	"github.com/upbound/up/cmd/up/xpkg"
 	"github.com/upbound/up/cmd/up/xpls"
 	"github.com/upbound/up/internal/config"
 	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/upterm"
-	"github.com/upbound/up/internal/version"
 
 	// TODO(epk): Remove this once we upgrade kubernetes deps to 1.25
 	// TODO(epk): Specifically, get rid of the k8s.io/client-go/client/auth/azure
@@ -53,31 +52,6 @@ import (
 	// Embed Kubernetes client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
-
-type versionFlag bool
-
-// BeforeApply indicates that we want to execute the logic before running any
-// commands.
-func (v versionFlag) BeforeApply(ctx *kong.Context) error { // nolint:unparam
-	fmt.Fprintln(ctx.Stdout, "Client Version: "+version.GetVersion())
-
-	if vxp, err := common.FetchCrossplaneVersion(); err != nil {
-		ctx.Exit(1)
-		return err
-	} else if vxp != "" {
-		fmt.Fprintln(ctx.Stdout, "Server Version: "+vxp)
-	}
-
-	if sc, err := common.FetchSpacesVersion(); err != nil {
-		ctx.Exit(1)
-		return err
-	} else if sc != "" {
-		fmt.Fprintln(ctx.Stdout, "Spaces Controller Version: "+sc)
-	}
-
-	ctx.Exit(0)
-	return nil
-}
 
 // AfterApply configures global settings before executing commands.
 func (c *cli) AfterApply(ctx *kong.Context) error { //nolint:unparam
@@ -114,10 +88,9 @@ func (c *cli) BeforeReset(ctx *kong.Context, p *kong.Path) error {
 }
 
 type cli struct {
-	Format  config.Format    `name:"format" enum:"default,json,yaml" default:"default" help:"Format for get/list commands. Can be: json, yaml, default"`
-	Version versionFlag      `short:"v" name:"version" help:"Print version and exit."`
-	Quiet   config.QuietFlag `short:"q" name:"quiet" help:"Suppress all output."`
-	Pretty  bool             `name:"pretty" help:"Pretty print output."`
+	Format config.Format    `name:"format" enum:"default,json,yaml" default:"default" help:"Format for get/list commands. Can be: json, yaml, default"`
+	Quiet  config.QuietFlag `short:"q" name:"quiet" help:"Suppress all output."`
+	Pretty bool             `name:"pretty" help:"Pretty print output."`
 
 	License licenseCmd `cmd:"" help:"Print Up license information."`
 
@@ -136,6 +109,7 @@ type cli struct {
 	XPLS               xpls.Cmd                     `cmd:"" help:"Start xpls language server."`
 	Alpha              alpha                        `cmd:"" help:"Alpha features. Commands may be removed in future releases."`
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"Install shell completions"`
+	Version            v.Cmd                        `cmd:"" help:"Print the client and server version information for the current context."`
 }
 
 type helpCmd struct{}

--- a/cmd/up/version/fetch.go
+++ b/cmd/up/version/fetch.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package common contains common functions
-package common
+// Package version contains common functions to get versions
+package version
 
 import (
 	"context"
@@ -35,7 +35,7 @@ const (
 // FetchCrossplaneVersion initializes a Kubernetes client and fetches
 // and returns the version of the Crossplane deployment. If the version
 // does not have a leading 'v', it prepends it.
-func FetchCrossplaneVersion() (string, error) {
+func FetchCrossplaneVersion(ctx context.Context) (string, error) {
 	var version string
 	config, err := ctrl.GetConfig()
 	if err != nil {
@@ -47,7 +47,7 @@ func FetchCrossplaneVersion() (string, error) {
 		return "", errors.Wrap(err, errCreateK8sClientset)
 	}
 
-	deployments, err := clientset.AppsV1().Deployments("").List(context.TODO(), v1.ListOptions{
+	deployments, err := clientset.AppsV1().Deployments("").List(ctx, v1.ListOptions{
 		LabelSelector: "app=crossplane",
 	})
 	if err != nil {
@@ -81,7 +81,7 @@ func FetchCrossplaneVersion() (string, error) {
 
 // FetchSpacesVersion initializes a Kubernetes client and fetches
 // and returns the version of the spaces-controller deployment.
-func FetchSpacesVersion() (string, error) {
+func FetchSpacesVersion(ctx context.Context) (string, error) {
 	config, err := ctrl.GetConfig()
 	if err != nil {
 		return "", errors.Wrap(err, errKubeConfig)
@@ -92,7 +92,7 @@ func FetchSpacesVersion() (string, error) {
 		return "", errors.Wrap(err, errCreateK8sClientset)
 	}
 
-	deployments, err := clientset.AppsV1().Deployments("").List(context.TODO(), v1.ListOptions{
+	deployments, err := clientset.AppsV1().Deployments("").List(ctx, v1.ListOptions{
 		LabelSelector: "app=spaces-controller",
 	})
 	if err != nil {

--- a/cmd/up/version/version.go
+++ b/cmd/up/version/version.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version contains version cmd
+package version
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/upbound/up/internal/version"
+)
+
+const (
+	errGetCrossplaneVersion = "unable to get crossplane version"
+	errGetSpacesVersion     = "unable to get spaces version"
+)
+
+type Cmd struct {
+	Client bool `env:"" help:"If true, shows client version only (no server required)." json:"client,omitempty"`
+}
+
+// BeforeApply sets default values and parses flags
+func (c *Cmd) BeforeApply() error {
+	flag.BoolVar(&c.Client, "client", false, "If true, shows client version only (no server required).")
+	flag.Parse()
+	return nil
+}
+
+func (c *Cmd) Help() string {
+	return `
+Options:
+  --client=false:
+  If true, shows client version only (no server required).
+
+Usage:
+  up version [flags] [options]
+`
+}
+
+func (c *Cmd) Run(ctx context.Context) error {
+	fmt.Println("Client Version: " + version.GetVersion())
+	if c.Client {
+		return nil
+	}
+
+	vxp, err := FetchCrossplaneVersion(ctx)
+	if err != nil {
+		return errors.Wrap(err, errGetCrossplaneVersion)
+	}
+	if vxp != "" {
+		fmt.Println("Server Version: " + vxp)
+	}
+
+	sc, err := FetchSpacesVersion(ctx)
+	if err != nil {
+		return errors.Wrap(err, errGetSpacesVersion)
+	}
+	if sc != "" {
+		fmt.Println("Spaces Controller Version: " + sc)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0-rc4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.49.0


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
This PR introduces a feature that, when using the up --version command, displays the version of Crossplane or Universal Crossplane and, if applicable, the version of the Spaces controller.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #24

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
cluster without crossplane/universal-crossplane:
```
up version
Client Version: v0.25.0-rc.0.33.g625bf51.dirty
```

cluster with universal-crossplane:
```
up version
Client Version: v0.25.0-rc.0.33.g625bf51.dirty
Server Version: v1.15.0-up.1
```

cluster with universal-crossplane:
```
up version
Client Version: v0.25.0-rc.0.33.g625bf51.dirty
Server Version: v1.15.0
```

cluster with universal-crossplane and spaces:
```
up version                                                                               
Client Version: v0.25.0-rc.0.33.g625bf51.dirty
Server Version: v1.14.6-up.1
Spaces Controller Version: 1.2.3
```

with flag client:
```
up version --client=true
Client Version: v0.25.0-rc.0.34.gd9fcb53.dirty
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
