### PR TITLE
feat(cli): add sos-report option in cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cover.out
 
 # ignore direnv files
 .envrc
+.DS_Store

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/upbound/up/cmd/up/profile"
 	"github.com/upbound/up/cmd/up/repository"
 	"github.com/upbound/up/cmd/up/robot"
+	"github.com/upbound/up/cmd/up/sos"
 	"github.com/upbound/up/cmd/up/space"
 	"github.com/upbound/up/cmd/up/trace"
 	tviewtemplate "github.com/upbound/up/cmd/up/tview-template"
@@ -145,6 +146,7 @@ type alpha struct {
 	Migration     migration.Cmd     `cmd:"" maturity:"alpha" help:"Migrate control planes to Upbound Managed Control Planes."`
 	Trace         trace.Cmd         `cmd:"" maturity:"alpha" hidden:"" help:"Trace a Crossplane resource."`
 	TviewTemplate tviewtemplate.Cmd `cmd:"" maturity:"alpha" hidden:"" help:"TView example."`
+	SOS           sos.Cmd           `cmd:"" maturity:"alpha" help:"Create SOS Report"`
 
 	WebLogin login.LoginWebCmd `cmd:"" maturity:"alpha" help:"Use web browser to login to up cli."`
 }

--- a/cmd/up/sos/export.go
+++ b/cmd/up/sos/export.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sos
+
+import (
+	"context"
+
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/upbound/up/internal/migration"
+	"github.com/upbound/up/internal/sos/exporter"
+)
+
+type exportCmd struct {
+	Output string `short:"o" help:"Specifies the file path where the exported archive will be saved. Defaults to 'xp-sos-report.tar.gz'." default:"xp-sos-report.tar.gz"`
+}
+
+func (c *exportCmd) Help() string {
+	return `
+	Usage:
+    sos export [options]
+
+The 'export' command is used to export the current state of a Crossplane or Universal Crossplane (XP/UXP) control plane
+into an archive file.
+
+Examples:
+	sos export
+        Exports the sos report to the default archive file named 'xp-sos-report.tar.gz'.
+    
+	sos export --output=my-export.tar.gz
+	Exports the sos report to the default archive file named 'my-export.tar.gz'.
+`
+}
+
+func (c *exportCmd) Run(ctx context.Context, migCtx *migration.Context) error {
+	cfg := migCtx.Kubeconfig
+
+	crdClient, err := apiextensionsclientset.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	appsClient, err := appsv1.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
+
+	e := exporter.NewControlPlaneStateExporter(crdClient, dynamicClient, discoveryClient, appsClient, mapper, exporter.Options{
+		OutputArchive: c.Output,
+	})
+
+	if err = e.Export(ctx); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/up/sos/sos.go
+++ b/cmd/up/sos/sos.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sos
+
+import (
+	"github.com/alecthomas/kong"
+
+	"github.com/upbound/up/internal/kube"
+	"github.com/upbound/up/internal/migration"
+)
+
+// AfterApply constructs and binds Upbound specific context to any subcommands
+// that have Run() methods that receive it.
+func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
+	cfg, err := kube.GetKubeConfig(c.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	kongCtx.Bind(&migration.Context{
+		Kubeconfig: cfg,
+	})
+	return nil
+}
+
+type Cmd struct {
+	Export exportCmd `cmd:"" help:"Export an sos report of a Crossplane or Universal Crossplane (XP/UXP) control plane into an archive."`
+
+	Kubeconfig string `type:"existingfile" help:"Override default kubeconfig path."`
+}
+
+func (c *Cmd) Help() string {
+	return `
+The 'sos' command collects configuration details, system information and diagnostic information from a Crossplane or Universal Crossplane (XP/UXP) control plane.
+For instance: the running providers, functions, and system and service configuration files.
+The command stores this output in the resulting archive.
+
+For detailed information on each command and its options, use the '--help' flag with the specific command (e.g., 'up alpha sos export --help').
+`
+}

--- a/internal/migration/meta/v1alpha1/types.go
+++ b/internal/migration/meta/v1alpha1/types.go
@@ -53,6 +53,13 @@ type CrossplaneInfo struct {
 	FeatureFlags []string `json:"featureFlags,omitempty" yaml:"featureFlags,omitempty"`
 }
 
+type PackageInfo struct {
+	// Name is the Name of the Package
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// Package is the Package Source of the Package
+	Package string `json:"package,omitempty" yaml:"package,omitempty"`
+}
+
 // ExportOptions are the options used to create the export.
 type ExportOptions struct {
 	// IncludedNamespaces are the namespaces included in the export.
@@ -78,6 +85,10 @@ type ExportMeta struct {
 	Options ExportOptions `json:"options,omitempty" yaml:"options,omitempty"`
 	// Crossplane is the information about the Crossplane instance on the exported control plane.
 	Crossplane CrossplaneInfo `json:"crossplane,omitempty" yaml:"crossplane,omitempty"`
+	// Providers is the information about the Providers on the control plane.
+	Providers []PackageInfo `json:"providers,omitempty" yaml:"providers,omitempty"`
+	// Functions is the information about the Functions on the control plane.
+	Functions []PackageInfo `json:"functions,omitempty" yaml:"functions,omitempty"`
 	// Stats are the statistics about the exported resources.
 	Stats ExportStats `json:"stats,omitempty" yaml:"stats,omitempty"`
 }

--- a/internal/sos/exporter/export.go
+++ b/internal/sos/exporter/export.go
@@ -1,0 +1,251 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/mholt/archiver/v4"
+	"github.com/pterm/pterm"
+	"github.com/spf13/afero"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+
+	"github.com/upbound/up/internal/migration/meta/v1alpha1"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// Options for the exporter.
+type Options struct {
+	// OutputArchive is the path to the archive file to be created.
+	OutputArchive string
+}
+
+// ControlPlaneStateExporter exports the state of a Crossplane control plane.
+type ControlPlaneStateExporter struct {
+	crdClient       apiextensionsclientset.Interface
+	dynamicClient   dynamic.Interface
+	discoveryClient discovery.DiscoveryInterface
+	appsClient      appsv1.AppsV1Interface
+	resourceMapper  meta.RESTMapper
+	options         Options
+}
+
+// NewControlPlaneStateExporter returns a new ControlPlaneStateExporter.
+func NewControlPlaneStateExporter(crdClient apiextensionsclientset.Interface, dynamicClient dynamic.Interface, discoveryClient discovery.DiscoveryInterface, appsClient appsv1.AppsV1Interface, mapper meta.RESTMapper, opts Options) *ControlPlaneStateExporter {
+	return &ControlPlaneStateExporter{
+		crdClient:       crdClient,
+		dynamicClient:   dynamicClient,
+		discoveryClient: discoveryClient,
+		appsClient:      appsClient,
+		resourceMapper:  mapper,
+		options:         opts,
+	}
+}
+
+// Export exports the state of the control plane.
+func (e *ControlPlaneStateExporter) Export(ctx context.Context) error { // nolint:gocyclo
+	pterm.EnableStyling()
+	upterm.DefaultObjPrinter.Pretty = true
+
+	pterm.Println("Starting SOS Report...")
+
+	fs := afero.Afero{Fs: afero.NewOsFs()}
+	tmpDir, err := fs.TempDir("", "up")
+	if err != nil {
+		return errors.Wrap(err, "cannot create temporary directory")
+	}
+	defer func() {
+		_ = fs.RemoveAll(tmpDir)
+	}()
+
+	// Scan the control plane for types to export.
+	scanMsg := "Scanning control plane... "
+	s, _ := upterm.CheckmarkSuccessSpinner.Start(scanMsg)
+	crdList, err := fetchAllCRDs(ctx, e.crdClient)
+	if err != nil {
+		s.Fail(scanMsg + "Failed!")
+		return errors.Wrap(err, "cannot fetch CRDs")
+	}
+	exportList := make([]apiextensionsv1.CustomResourceDefinition, 0, len(crdList))
+	for _, crd := range crdList {
+		// We only want to export the following types:
+		// - Crossplane Core CRDs - Has suffix ".crossplane.io".
+		// - CRDs owned by Crossplane packages - Has owner reference to a Crossplane package.
+		// - CRDs owned by a CompositeResourceDefinition - Has owner reference to a CompositeResourceDefinition.
+		if !e.shouldExport(crd) {
+			// Ignore CRDs that we don't want to export.
+			continue
+		}
+		exportList = append(exportList, crd)
+	}
+	s.Success(scanMsg + fmt.Sprintf("%d types found! 👀", len(exportList)))
+
+	// Export Crossplane resources.
+	crCounts := make(map[string]int, len(exportList))
+	exportCRsMsg := "Exporting sos report resources... "
+	s, _ = upterm.CheckmarkSuccessSpinner.Start(exportCRsMsg + fmt.Sprintf("0 / %d", len(exportList)))
+	for _, crd := range exportList {
+		gvr, err := e.customResourceGVR(crd)
+		if err != nil {
+			s.Fail(exportCRsMsg + "Failed!")
+			return errors.Wrapf(err, "cannot get GVR for %q", crd.GetName())
+		}
+
+		s.UpdateText(exportCRsMsg + fmt.Sprintf("Analyse %s...", gvr.GroupResource()))
+
+		sub := false
+		for _, vr := range crd.Spec.Versions {
+			if vr.Storage && vr.Subresources != nil && vr.Subresources.Status != nil {
+				// This CRD has a status subresource. We store this as a metadata per type and use
+				// it during import to determine if we should apply the status subresource.
+				sub = true
+				break
+			}
+		}
+		exporter := NewUnstructuredExporter(
+			NewUnstructuredFetcher(e.dynamicClient, e.options),
+			NewFileSystemPersister(fs, tmpDir, &v1alpha1.TypeMeta{
+				Categories:            crd.Spec.Names.Categories,
+				WithStatusSubresource: sub,
+			}))
+
+		// ExportResource will fetch all resources of the given GVR and store them in the
+		// well-known directory structure.
+		count, err := exporter.ExportResources(ctx, gvr)
+		if err != nil {
+			s.Fail(exportCRsMsg + "Failed!")
+			return errors.Wrapf(err, "cannot export resources for %q", crd.GetName())
+		}
+		crCounts[gvr.GroupResource().String()] = count
+	}
+
+	total := 0
+	for _, count := range crCounts {
+		total += count
+	}
+	s.Success(exportCRsMsg + " exported! 📤")
+
+	// Export a top level metadata file. This file contains details like when the export was done,
+	// the version and feature flags of Crossplane and number of resources exported per type.
+	// This metadata file is used during import to determine if the import is compatible with the
+	// current Crossplane version and feature flags and also enables manual inspection the exported state.
+	me := NewPersistentMetadataExporter(e.appsClient, e.dynamicClient, fs, tmpDir)
+	if err = me.ExportMetadata(ctx, e.options, crCounts); err != nil {
+		return errors.Wrap(err, "cannot write export metadata")
+	}
+
+	// Archive the sos report state.
+	archiveMsg := "Report state... "
+	s, _ = upterm.CheckmarkSuccessSpinner.Start(archiveMsg)
+	if err = e.archive(ctx, fs, tmpDir); err != nil {
+		s.Fail(archiveMsg + "Failed!")
+		return errors.Wrap(err, "cannot archive exported state")
+	}
+	s.Success(archiveMsg + fmt.Sprintf("archived to %q! 📦", e.options.OutputArchive))
+
+	pterm.Println("\nSuccessfully exported sos report!")
+	return nil
+}
+
+func (e *ControlPlaneStateExporter) shouldExport(in apiextensionsv1.CustomResourceDefinition) bool {
+	for _, ref := range in.GetOwnerReferences() {
+		// Types owned by a Crossplane package.
+		if ref.APIVersion == "pkg.crossplane.io/v1" {
+			return true
+		}
+	}
+
+	return strings.HasSuffix(in.GetName(), ".crossplane.io")
+}
+
+func (e *ControlPlaneStateExporter) customResourceGVR(in apiextensionsv1.CustomResourceDefinition) (schema.GroupVersionResource, error) {
+	version := ""
+	for _, vr := range in.Spec.Versions {
+		if vr.Storage {
+			version = vr.Name
+		}
+	}
+
+	rm, err := e.resourceMapper.RESTMapping(schema.GroupKind{
+		Group: in.Spec.Group,
+		Kind:  in.Spec.Names.Kind,
+	}, version)
+
+	if err != nil {
+		return schema.GroupVersionResource{}, errors.Wrapf(err, "cannot get REST mapping for %q", in.GetName())
+	}
+
+	return rm.Resource, nil
+}
+
+func (e *ControlPlaneStateExporter) archive(ctx context.Context, fs afero.Afero, dir string) error {
+	files, err := archiver.FilesFromDisk(nil, map[string]string{
+		dir + "/": "",
+	})
+	if err != nil {
+		return err
+	}
+
+	out, err := fs.Create(e.options.OutputArchive)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	if err = fs.Chmod(e.options.OutputArchive, 0600); err != nil {
+		return err
+	}
+
+	format := archiver.CompressedArchive{
+		Compression: archiver.Gz{},
+		Archival:    archiver.Tar{},
+	}
+
+	return format.Archive(ctx, out, files)
+}
+
+func fetchAllCRDs(ctx context.Context, kube apiextensionsclientset.Interface) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	var crds []apiextensionsv1.CustomResourceDefinition
+
+	continueToken := ""
+	for {
+		l, err := kube.ApiextensionsV1().CustomResourceDefinitions().List(ctx, v1.ListOptions{
+			Limit:    defaultPageSize,
+			Continue: continueToken,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot list CRDs")
+		}
+		crds = append(crds, l.Items...)
+		continueToken = l.GetContinue()
+		if continueToken == "" {
+			break
+		}
+	}
+
+	return crds, nil
+}

--- a/internal/sos/exporter/export.go
+++ b/internal/sos/exporter/export.go
@@ -165,7 +165,7 @@ func (e *ControlPlaneStateExporter) Export(ctx context.Context) error { // nolin
 	}
 	s.Success(archiveMsg + fmt.Sprintf("archived to %q! 📦", e.options.OutputArchive))
 
-	pterm.Println("\nSuccessfully exported sos report!")
+	pterm.Println("\nSuccessfully exported SOS Report!")
 	return nil
 }
 

--- a/internal/sos/exporter/fetch.go
+++ b/internal/sos/exporter/fetch.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	defaultPageSize = 500
+)
+
+type ResourceFetcher interface {
+	FetchResources(ctx context.Context, gvr schema.GroupVersionResource) ([]unstructured.Unstructured, error)
+}
+
+type UnstructuredFetcher struct {
+	kube     dynamic.Interface
+	pageSize int64
+}
+
+func NewUnstructuredFetcher(kube dynamic.Interface, opts Options) *UnstructuredFetcher {
+
+	return &UnstructuredFetcher{
+		kube:     kube,
+		pageSize: defaultPageSize,
+	}
+}
+
+func (e *UnstructuredFetcher) FetchResources(ctx context.Context, gvr schema.GroupVersionResource) ([]unstructured.Unstructured, error) {
+	var resources []unstructured.Unstructured
+
+	continueToken := ""
+	for {
+		l, err := e.kube.Resource(gvr).List(ctx, v1.ListOptions{
+			Limit:    e.pageSize,
+			Continue: continueToken,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot list %q resources", gvr.GroupResource())
+		}
+		resources = append(resources, l.Items...)
+		continueToken = l.GetContinue()
+		if continueToken == "" {
+			break
+		}
+	}
+
+	return resources, nil
+}

--- a/internal/sos/exporter/metadata.go
+++ b/internal/sos/exporter/metadata.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+
+	"github.com/upbound/up/internal/migration/crossplane"
+	"github.com/upbound/up/internal/migration/meta/v1alpha1"
+)
+
+type MetadataExporter interface {
+	ExportMetadata(ctx context.Context) error
+}
+
+type PersistentMetadataExporter struct {
+	appsClient    appsv1.AppsV1Interface
+	dynamicClient dynamic.Interface
+	fs            afero.Afero
+	root          string
+}
+
+func NewPersistentMetadataExporter(apps appsv1.AppsV1Interface, dynamic dynamic.Interface, fs afero.Afero, root string) *PersistentMetadataExporter {
+	return &PersistentMetadataExporter{
+		dynamicClient: dynamic,
+		appsClient:    apps,
+		fs:            fs,
+		root:          root,
+	}
+}
+
+func (e *PersistentMetadataExporter) ExportMetadata(ctx context.Context, opts Options, custom map[string]int) error {
+	xp, err := crossplane.CollectInfo(ctx, e.appsClient)
+	if err != nil {
+		return errors.Wrap(err, "cannot get Crossplane info")
+	}
+
+	providers, err := crossplane.CollectPackageInfo(
+		ctx, e.dynamicClient,
+		schema.GroupVersionResource{
+			Group:    "pkg.crossplane.io",
+			Version:  "v1",
+			Resource: "providers",
+		})
+	if err != nil {
+		return errors.Wrap(err, "cannot get Provider info")
+	}
+
+	functions, err := crossplane.CollectPackageInfo(
+		ctx, e.dynamicClient,
+		schema.GroupVersionResource{
+			Group:    "pkg.crossplane.io",
+			Version:  "v1beta1",
+			Resource: "functions",
+		})
+	if err != nil {
+		return errors.Wrap(err, "cannot get Provider info")
+	}
+
+	total := 0
+	for _, v := range custom {
+		total += v
+	}
+	em := &v1alpha1.ExportMeta{
+		Version:    "v1alpha1",
+		ExportedAt: time.Now().UTC(),
+		Crossplane: *xp,
+		Providers:  *providers,
+		Functions:  *functions,
+		Stats: v1alpha1.ExportStats{
+			Total:           total,
+			CustomResources: custom,
+		},
+	}
+	b, err := yaml.Marshal(&em)
+	if err != nil {
+		return errors.Wrap(err, "cannot marshal information metadata to yaml")
+	}
+	err = e.fs.WriteFile(filepath.Join(e.root, "information.yaml"), b, 0600)
+	if err != nil {
+		return errors.Wrap(err, "cannot write information metadata")
+	}
+	return nil
+}

--- a/internal/sos/exporter/persist.go
+++ b/internal/sos/exporter/persist.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+
+	"github.com/upbound/up/internal/migration/meta/v1alpha1"
+)
+
+type ResourcePersister interface {
+	PersistResources(ctx context.Context, groupResource string, resources []unstructured.Unstructured) error
+}
+
+type FileSystemPersister struct {
+	fs   afero.Afero
+	root string
+
+	meta *v1alpha1.TypeMeta
+}
+
+func NewFileSystemPersister(fs afero.Afero, root string, m *v1alpha1.TypeMeta) *FileSystemPersister {
+	return &FileSystemPersister{
+		fs:   fs,
+		root: root,
+		meta: m,
+	}
+}
+
+func (p *FileSystemPersister) pathFor(dirs ...string) string {
+	dirs = append([]string{p.root}, dirs...)
+	return filepath.Join(dirs...)
+}
+
+func (p *FileSystemPersister) PersistResources(_ context.Context, groupResource string, resources []unstructured.Unstructured) error { // nolint:gocyclo // This is slightly over the limit, but it's not too bad.
+	if len(resources) == 0 {
+		return nil
+	}
+
+	if err := p.fs.MkdirAll(p.pathFor(groupResource), 0700); err != nil {
+		return errors.Wrapf(err, "cannot create directory resource group %q", groupResource)
+	}
+
+	if p.meta != nil {
+		b, err := yaml.Marshal(&p.meta)
+		if err != nil {
+			return errors.Wrap(err, "cannot marshal type meta to yaml")
+		}
+
+		mf := p.pathFor(groupResource, "metadata.yaml")
+		err = p.fs.WriteFile(mf, b, 0600)
+		if err != nil {
+			return errors.Wrapf(err, "cannot write type metadata to %q", mf)
+		}
+	}
+
+	for i := range resources {
+		fileDirPath := p.pathFor(groupResource, "cluster")
+		if resources[i].GetNamespace() != "" {
+			fileDirPath = p.pathFor(groupResource, "namespaces", resources[i].GetNamespace())
+		}
+
+		if err := p.fs.MkdirAll(fileDirPath, 0700); err != nil {
+			return errors.Wrapf(err, "cannot create directory %q for resource %q", groupResource, resources[i].GetName())
+		}
+
+		b, err := yaml.Marshal(&resources[i])
+		if err != nil {
+			return errors.Wrap(err, "cannot marshal resource to yaml")
+		}
+
+		f := filepath.Join(fileDirPath, resources[i].GetName()+".yaml")
+		err = p.fs.WriteFile(f, b, 0600)
+		if err != nil {
+			return errors.Wrapf(err, "cannot write resource to %q", f)
+		}
+	}
+
+	return nil
+}

--- a/internal/sos/exporter/resource.go
+++ b/internal/sos/exporter/resource.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"context"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ResourceExporter interface {
+	ExportResources(ctx context.Context, gvr schema.GroupVersionResource) (count int, err error)
+}
+
+type UnstructuredExporter struct {
+	fetcher   ResourceFetcher
+	persister ResourcePersister
+}
+
+func NewUnstructuredExporter(f ResourceFetcher, p ResourcePersister) *UnstructuredExporter {
+	return &UnstructuredExporter{
+		fetcher:   f,
+		persister: p,
+	}
+}
+
+func (e *UnstructuredExporter) ExportResources(ctx context.Context, gvr schema.GroupVersionResource) (int, error) {
+	resources, err := e.fetcher.FetchResources(ctx, gvr)
+	if err != nil {
+		return 0, errors.Wrap(err, "cannot fetch resources")
+	}
+
+	allowedResources := map[string]struct{}{
+		"configurations.pkg.crossplane.io":           {},
+		"configurationrevisions.pkg.crossplane.io":   {},
+		"controllerconfigs.pkg.crossplane.io":        {},
+		"deploymentruntimeconfigs.pkg.crossplane.io": {},
+		"functions.pkg.crossplane.io":                {},
+		"functionrevisions.pkg.crossplane.io":        {},
+		"locks.pkg.crossplane.io":                    {},
+		"providers.pkg.crossplane.io":                {},
+		"providerrevisions.pkg.crossplane.io":        {},
+	}
+
+	// Only persist resources if the GVR is in the allowed list
+	if _, ok := allowedResources[gvr.GroupResource().String()]; ok {
+		if err = e.persister.PersistResources(ctx, gvr.GroupResource().String(), resources); err != nil {
+			return 0, errors.Wrap(err, "cannot persist resources")
+		}
+	}
+
+	return len(resources), nil
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Whenever I tackle incidents, I find myself repeatedly asking the same set of questions: what version of XP/UXP is in use along with the arguments, which providers and functions are present, and could I see the revisions, etc. To streamline this process this PR will do:
- add an option in cli to create a sos-report `up alpha sos export`
- export only resources from the following CRDs:

```
configurations.pkg.crossplane.io
configurationrevisions.pkg.crossplane.io
controllerconfigs.pkg.crossplane.io
deploymentruntimeconfigs.pkg.crossplane.io
functions.pkg.crossplane.io
functionrevisions.pkg.crossplane.io
locks.pkg.crossplane.io                 
providers.pkg.crossplane.io             
providerrevisions.pkg.crossplane.io    
```

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
up alpha sos export
Starting SOS Report...
  ✓   Scanning control plane... 23 types found! 👀                                                                                                                                                                                                                                                  
  ✓   Exporting sos report resources...  exported! 📤                                                                                                                                                                                                                                               
  ✓   Report state... archived to "xp-sos-report.tar.gz"! 📦                                                                                                                                                                                                                                        

Successfully exported SOS Report!
```

```
33396286 -rw-------@  1 haarchri  staff    6961 Mar  8 14:43 xp-sos-report.tar.gz
```


```
├── configurationrevisions.pkg.crossplane.io
│   ├── cluster
│   │   ├── mxp-control-plane-9b247788e429.yaml
│   │   ├── mxp-host-cluster-4095fee546e3.yaml
│   │   └── provider-host-cluster-143e26de42cf.yaml
│   └── metadata.yaml
├── configurations.pkg.crossplane.io
│   ├── cluster
│   │   ├── mxp-control-plane.yaml
│   │   ├── mxp-host-cluster.yaml
│   │   └── provider-host-cluster.yaml
│   └── metadata.yaml
├── deploymentruntimeconfigs.pkg.crossplane.io
│   ├── cluster
│   │   ├── default.yaml
│   │   ├── provider-helm.yaml
│   │   └── provider-kubernetes.yaml
│   └── metadata.yaml
├── functionrevisions.pkg.crossplane.io
│   ├── cluster
│   │   ├── function-auto-ready-59637c63012e.yaml
│   │   └── function-sequencer-addb5d6142dd.yaml
│   └── metadata.yaml
├── functions.pkg.crossplane.io
│   ├── cluster
│   │   ├── function-auto-ready.yaml
│   │   ├── function-sequencer.yaml
│   │   └── spaces-composer.yaml
│   └── metadata.yaml
├── information.yaml
├── locks.pkg.crossplane.io
│   ├── cluster
│   │   └── lock.yaml
│   └── metadata.yaml
├── providerrevisions.pkg.crossplane.io
│   ├── cluster
│   │   ├── provider-helm-839e04a83ec3.yaml
│   │   └── provider-kubernetes-6ef2ebb6f1db.yaml
│   └── metadata.yaml
└── providers.pkg.crossplane.io
    ├── cluster
    │   ├── provider-helm.yaml
    │   └── provider-kubernetes.yaml
    └── metadata.yaml

17 directories, 29 file
```

```
version: v1alpha1
exportedAt: 2024-03-08T13:43:30.768132Z
crossplane:
    distribution: universal-crossplane-1.14.6-up.1
    namespace: upbound-system
    version: 1.14.6-up.1
    featureFlags:
        - --enable-usages
providers:
    - name: provider-helm
      package: xpkg.upbound.io/crossplane-contrib/provider-helm:v0.17.0
    - name: provider-kubernetes
      package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.12.1
functions:
    - name: function-auto-ready
      package: xpkg.upbound.io/upbound/function-auto-ready:v0.2.1
    - name: function-sequencer
      package: xpkg.upbound.io/crossplane-contrib/function-sequencer:v0.1.1
stats:
    total: 756
    customResources:
        compositeresourcedefinitions.apiextensions.crossplane.io: 6
        compositionrevisions.apiextensions.crossplane.io: 6
        compositions.apiextensions.crossplane.io: 6
        configurationrevisions.pkg.crossplane.io: 3
        configurations.pkg.crossplane.io: 3
        controllerconfigs.pkg.crossplane.io: 0
        deploymentruntimeconfigs.pkg.crossplane.io: 3
        environmentconfigs.apiextensions.crossplane.io: 0
        functionrevisions.pkg.crossplane.io: 3
        functions.pkg.crossplane.io: 3
        gotemplates.gotemplating.fn.crossplane.io: 0
        inputs.sequencer.fn.crossplane.io: 0
        locks.pkg.crossplane.io: 1
        objects.kubernetes.crossplane.io: 264
        providerconfigs.helm.crossplane.io: 9
        providerconfigs.kubernetes.crossplane.io: 10
        providerconfigusages.helm.crossplane.io: 78
        providerconfigusages.kubernetes.crossplane.io: 264
        providerrevisions.pkg.crossplane.io: 2
        providers.pkg.crossplane.io: 2
        releases.helm.crossplane.io: 78
        storeconfigs.secrets.crossplane.io: 1
        usages.apiextensions.crossplane.io: 14
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
