### PR TITLE
Fix regexp for old controlplane path

### DIFF
--- a/cmd/up/migration/import.go
+++ b/cmd/up/migration/import.go
@@ -37,7 +37,7 @@ var (
 	// Matches https://00.000.000.0.nip.io/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp1/k8s
 	newControlPlanePathRE = regexp.MustCompile(`^(?P<base>.+)/apis/spaces.upbound.io/(?P<version>v[^/]+)/namespaces/(?P<namespace>[^/]+)/controlplanes/(?P<controlplane>[^/]+)/k8s$`)
 	// Matches https://spaces-foo.upboundrocks.cloud/v1/controlplanes/acmeco/default/ctp/k8s
-	oldControlPlanePathRE = regexp.MustCompile(`^(?P<base>.+)/v1/control[pP]lanes/(?P<namespace>[^/]+)/(?P<controlplane>[^/]+)/ctp/k8s$`)
+	oldControlPlanePathRE = regexp.MustCompile(`^(?P<base>.+)/v1/control[pP]lanes/(?P<account>[^/]+)/(?P<namespace>[^/]+)/(?P<controlplane>[^/]+)/k8s$`)
 )
 
 type importCmd struct {

--- a/cmd/up/migration/import_test.go
+++ b/cmd/up/migration/import_test.go
@@ -41,6 +41,13 @@ func TestIsMCP(t *testing.T) {
 			},
 			want: true,
 		},
+		"OldWithDifferentNames": {
+			reason: "Should match with the old format with lowercase controplanes, even with a different account/ctp name",
+			args: args{
+				host: "https://spaces-foo.upboundrocks.cloud/v1/controlplanes/mycompany/default/ctp1/k8s",
+			},
+			want: true,
+		},
 		"OldCamelCase": {
 			reason: "Should match with the old format with camelcase controlPlanes",
 			args: args{


### PR DESCRIPTION
### Description of your changes

Looks like the current regexp for old control plane path only works if controlplane is named as ctp.
This PR fixes the regexp for old controlplane path.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Unit tests