### PR TITLE
Make ctp list derive context from kubeconfig

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -21,7 +21,11 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/posener/complete"
 	"k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/utils/ptr"
 
+	xpcommonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
 	cp "github.com/upbound/up-sdk-go/service/controlplanes"
 	"github.com/upbound/up/cmd/up/controlplane/connector"
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
@@ -134,7 +138,7 @@ func extractCloudFields(obj any) []string {
 	}
 }
 
-func extractSpaceFields(obj any) []string {
+func extractSpaceFieldsLegacy(obj any) []string {
 	resp, ok := obj.(*controlplane.Response)
 	if !ok {
 		return []string{"unknown", "unknown", "", "", "", "", ""}
@@ -151,6 +155,28 @@ func extractSpaceFields(obj any) []string {
 	}
 }
 
+func extractSpaceFields(obj any) []string {
+	ctp, ok := obj.(spacesv1beta1.ControlPlane)
+	if !ok {
+		return []string{"unknown", "unknown", "", "", "", "", ""}
+	}
+
+	v := ""
+	if pv := ctp.Spec.Crossplane.Version; pv != nil {
+		v = *pv
+	}
+
+	return []string{
+		ctp.GetNamespace(),
+		ctp.GetName(),
+		v,
+		string(ctp.GetCondition(xpcommonv1.TypeSynced).Status),
+		string(ctp.GetCondition(xpcommonv1.TypeReady).Status),
+		ctp.Annotations["internal.spaces.upbound.io/message"],
+		formatAge(ptr.To(time.Since(ctp.CreationTimestamp.Time))),
+	}
+}
+
 func formatAge(age *time.Duration) string {
 	if age == nil {
 		return ""
@@ -160,8 +186,11 @@ func formatAge(age *time.Duration) string {
 }
 
 func tabularPrint(obj any, printer upterm.ObjectPrinter, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpace() {
+	if obj, ok := obj.([]spacesv1beta1.ControlPlane); ok {
 		return printer.Print(obj, spacefieldNames, extractSpaceFields)
+	}
+	if upCtx.Profile.IsSpace() {
+		return printer.Print(obj, spacefieldNames, extractSpaceFieldsLegacy)
 	}
 	return printer.Print(obj, cloudfieldNames, extractCloudFields)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,10 +16,14 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
@@ -120,6 +124,27 @@ func (c *Config) GetUpboundProfile(name string) (profile.Profile, error) {
 		return profile.Profile{}, errors.Errorf(errProfileNotFoundFmt, name)
 	}
 	return p, nil
+}
+
+// GetCurrentContext returns the current context from the kubeconfig, profile and config
+func (c *Config) GetCurrentContext(ctx context.Context) (profileName string, currentProfile *profile.Profile, ctp types.NamespacedName, err error) {
+	po := clientcmd.NewDefaultPathOptions()
+	conf, err := po.GetStartingConfig()
+	if err != nil {
+		return "", nil, types.NamespacedName{}, err
+	}
+
+	profiles, err := c.GetUpboundProfiles()
+	if err != nil {
+		return "", nil, types.NamespacedName{}, err
+	}
+
+	profileName, currentProfile, ctp, err = profile.FromKubeconfig(ctx, profiles, conf)
+	if err != nil {
+		return "", nil, types.NamespacedName{}, err
+	}
+
+	return profileName, currentProfile, ctp, nil
 }
 
 // GetUpboundProfiles returns the list of existing profiles. If no profiles

--- a/internal/profile/kubeconfig.go
+++ b/internal/profile/kubeconfig.go
@@ -32,7 +32,10 @@ import (
 // FromKubeconfig finds the profile by a given user kubeconfig. It returns
 // a related profile, the current group/namespace, and the controlplane if the
 // kubeconfig points to a controlplane through mxe-router.
-func FromKubeconfig(ctx context.Context, profiles map[string]Profile, conf *clientcmdapi.Config) (string, *Profile, types.NamespacedName, error) {
+//
+// If the current kubeconfig context does not point to a Space or a controlplane,
+// it returns NO ERROR, but all other values are zero values.
+func FromKubeconfig(ctx context.Context, profiles map[string]Profile, conf *clientcmdapi.Config) (profileName string, profile *Profile, namespace types.NamespacedName, err error) {
 	return findProfileByKubeconfig(ctx, profiles, conf, GetIngressHost)
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -23,6 +23,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	NoSpacesContextMsg = "This cluster does not have spaces installed, use `up space init` to install spaces."
+	NoGroupMsg         = "The current kubeconfig context does not point to a group, use `up ctx` to select a group."
+)
+
 // Type is a type of Upbound profile.
 type Type string
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

This PR makes `up ctp list` kubeconfig context aware, making it independent from the current profile. The profile is automatically derived:

$ kubectl ctx not-space-kube
$ up ctp list
You are not on a space.
$ kubectl ctx space
$ up ctp list
.... controlplanes from the profile matching the kubeconfig context's URL ....
$ up ctp connect ctp
$ up ctp list
In a controlplane, you cannot list controlplanes.
Use 'up ctx ..' to go to group level.

Fixes https://github.com/upbound/spaces/issues/752

NOTE: this breaks the use against a cloud profile. We will bring it back in a follow-up.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

This can be tested locally by running the following setup:

- create local kind cluster with spaces
- create empty kind cluster
- follow the command logic from description
