### PR TITLE
Add CRUD support for spaces groups

### DIFF
--- a/cmd/up/group/cmd.go
+++ b/cmd/up/group/cmd.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"strconv"
+
+	"github.com/alecthomas/kong"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+	"github.com/upbound/up/internal/feature"
+	"github.com/upbound/up/internal/upbound"
+)
+
+var (
+	fieldNames = []string{"NAME", "PROTECTED"}
+)
+
+func init() {
+	runtime.Must(spacesv1beta1.AddToScheme(scheme.Scheme))
+}
+
+// BeforeReset is the first hook to run.
+func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
+	return feature.HideMaturity(p, maturity)
+}
+
+// AfterApply constructs and binds an Upbound context to any subcommands
+// that have Run() methods that receive it.
+func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
+	upCtx, err := upbound.NewFromFlags(c.Flags)
+	if err != nil {
+		return err
+	}
+	kongCtx.Bind(upCtx)
+
+	if !upCtx.Profile.IsSpace() {
+		// TODO: add legacy support
+		return errors.New("Only Spaces contexts supported for now.")
+	}
+	return nil
+}
+
+// Cmd contains commands for interacting with groups.
+type Cmd struct {
+	Create createCmd `cmd:"" help:"Create a group."`
+	Delete deleteCmd `cmd:"" help:"Delete a group."`
+	List   listCmd   `cmd:"" help:"List groups in the space."`
+	Get    getCmd    `cmd:"" help:"Get a group."`
+
+	Short       bool   `short:"s" env:"UP_SHORT" name:"short" help:"Short output."`
+	KubeContext string `env:"UP_CONTEXT" default:"upbound" name:"context" help:"Kubernetes context to operate on."`
+
+	// Common Upbound API configuration
+	Flags upbound.Flags `embed:""`
+}
+
+func (c *Cmd) Help() string {
+	return `
+Interact with groups within the current space. Both Upbound profiles and
+local Spaces are supported. Use the "profile" management command to switch
+between different Upbound profiles or to connect to a local Space.`
+}
+
+func extractGroupFields(obj any) []string {
+	resp, ok := obj.(corev1.Namespace)
+	if !ok {
+		return []string{"unknown", "unknown"}
+	}
+
+	protected := false
+	if av, ok := resp.ObjectMeta.Labels[spacesv1beta1.ControlPlaneGroupProtectionKey]; ok {
+		if val, err := strconv.ParseBool(av); err == nil {
+			protected = val
+		}
+	}
+
+	return []string{
+		resp.GetObjectMeta().GetName(),
+		strconv.FormatBool(protected),
+	}
+}

--- a/cmd/up/group/create.go
+++ b/cmd/up/group/create.go
@@ -23,10 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
-	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
@@ -39,13 +36,10 @@ type createCmd struct {
 
 // Run executes the create command.
 func (c *createCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
-	// get context
-	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	// get profile
+	currentProfile, err := getCurrentProfile(ctx, upCtx)
 	if err != nil {
 		return err
-	}
-	if currentProfile == nil {
-		return errors.New(profile.NoSpacesContextMsg)
 	}
 
 	// create client

--- a/cmd/up/group/create.go
+++ b/cmd/up/group/create.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+	"github.com/upbound/up/internal/profile"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// createCmd creates a group in a space.
+type createCmd struct {
+	Name               string `arg:"" required:"" help:"Name of group."`
+	DeletionProtection bool   `name:"deletion-protection" optional:"" default:"false" help:"Enable deletion protection on the new group." negatable:""`
+}
+
+// Run executes the create command.
+func (c *createCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
+	// get context
+	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	if err != nil {
+		return err
+	}
+	if currentProfile == nil {
+		return errors.New(profile.NoSpacesContextMsg)
+	}
+
+	// create client
+	restConfig, _, err := currentProfile.GetSpaceRestConfig()
+	if err != nil {
+		return err
+	}
+	cl, err := ctrlclient.New(restConfig, ctrlclient.Options{})
+	if err != nil {
+		return err
+	}
+
+	// create group
+	group := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.Name,
+			Labels: map[string]string{
+				spacesv1beta1.ControlPlaneGroupLabelKey:      "true",
+				spacesv1beta1.ControlPlaneGroupProtectionKey: strconv.FormatBool(c.DeletionProtection),
+			},
+		},
+	}
+
+	if err := cl.Create(ctx, &group); err != nil {
+		return err
+	}
+
+	p.Printfln("%s created", c.Name)
+	return nil
+}

--- a/cmd/up/group/delete.go
+++ b/cmd/up/group/delete.go
@@ -27,7 +27,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
-	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
@@ -40,13 +39,10 @@ type deleteCmd struct {
 
 // Run executes the create command.
 func (c *deleteCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
-	// get context
-	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	// get profile
+	currentProfile, err := getCurrentProfile(ctx, upCtx)
 	if err != nil {
 		return err
-	}
-	if currentProfile == nil {
-		return errors.New(profile.NoSpacesContextMsg)
 	}
 
 	// create client

--- a/cmd/up/group/delete.go
+++ b/cmd/up/group/delete.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+	"github.com/upbound/up/internal/profile"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// deleteCmd creates a group in a space.
+type deleteCmd struct {
+	Name  string `arg:"" required:"" help:"Name of group."`
+	Force bool   `name:"force" optional:"" default:"false" help:"Force the deletion of the group."`
+}
+
+// Run executes the create command.
+func (c *deleteCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
+	// get context
+	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	if err != nil {
+		return err
+	}
+	if currentProfile == nil {
+		return errors.New(profile.NoSpacesContextMsg)
+	}
+
+	// create client
+	restConfig, _, err := currentProfile.GetSpaceRestConfig()
+	if err != nil {
+		return err
+	}
+	cl, err := ctrlclient.New(restConfig, ctrlclient.Options{})
+	if err != nil {
+		return err
+	}
+
+	// delete group
+	group := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.Name,
+		},
+	}
+
+	// ensure deletion protection is disabled, if not forcing
+	if !c.Force {
+		if err := cl.Get(ctx, types.NamespacedName{Name: c.Name}, &group); err != nil {
+			return err
+		}
+
+		if protEn, err := strconv.ParseBool(group.Labels[spacesv1beta1.ControlPlaneGroupProtectionKey]); err != nil {
+			return err
+		} else if protEn {
+			return errors.New("Deletion protection is enabled on the specified group. Use '--force' to delete anyway.")
+		}
+	}
+
+	if err := cl.Delete(ctx, &group); err != nil {
+		return err
+	}
+
+	p.Printfln("%s deleted", c.Name)
+	return nil
+}

--- a/cmd/up/group/get.go
+++ b/cmd/up/group/get.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+	"github.com/upbound/up/internal/profile"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// getCmd gets a specific group in a space.
+type getCmd struct {
+	Name string `arg:"" required:"" help:"Name of group."`
+}
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *getCmd) AfterApply(kongCtx *kong.Context) error {
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+
+	return nil
+}
+
+// Run executes the list command.
+func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
+	// get context
+	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	if err != nil {
+		return err
+	}
+	if currentProfile == nil {
+		return errors.New(profile.NoSpacesContextMsg)
+	}
+
+	// create client
+	restConfig, _, err := currentProfile.GetSpaceRestConfig()
+	if err != nil {
+		return err
+	}
+	cl, err := ctrlclient.New(restConfig, ctrlclient.Options{})
+	if err != nil {
+		return err
+	}
+
+	// list groups
+	var ns corev1.Namespace
+	if err := cl.Get(ctx, types.NamespacedName{Name: c.Name}, &ns); err != nil {
+		return err
+	}
+
+	// only print the group if it is a registered group
+	if _, ok := ns.Labels[spacesv1beta1.ControlPlaneGroupLabelKey]; !ok {
+		return fmt.Errorf("namespace %q is not a group", c.Name)
+	}
+
+	return printer.Print(ns, fieldNames, extractGroupFields)
+}

--- a/cmd/up/group/get.go
+++ b/cmd/up/group/get.go
@@ -24,10 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
-	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
@@ -46,13 +43,10 @@ func (c *getCmd) AfterApply(kongCtx *kong.Context) error {
 
 // Run executes the list command.
 func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
-	// get context
-	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	// get profile
+	currentProfile, err := getCurrentProfile(ctx, upCtx)
 	if err != nil {
 		return err
-	}
-	if currentProfile == nil {
-		return errors.New(profile.NoSpacesContextMsg)
 	}
 
 	// create client

--- a/cmd/up/group/list.go
+++ b/cmd/up/group/list.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package group
+
+import (
+	"context"
+
+	"github.com/alecthomas/kong"
+	"github.com/pterm/pterm"
+	corev1 "k8s.io/api/core/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+	"github.com/upbound/up/internal/profile"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+// listCmd list groups in a space.
+type listCmd struct {
+}
+
+// AfterApply sets default values in command after assignment and validation.
+func (c *listCmd) AfterApply(kongCtx *kong.Context) error {
+	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
+
+	return nil
+}
+
+// Run executes the list command.
+func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
+	// get context
+	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	if err != nil {
+		return err
+	}
+	if currentProfile == nil {
+		return errors.New(profile.NoSpacesContextMsg)
+	}
+
+	// create client
+	restConfig, _, err := currentProfile.GetSpaceRestConfig()
+	if err != nil {
+		return err
+	}
+	cl, err := ctrlclient.New(restConfig, ctrlclient.Options{})
+	if err != nil {
+		return err
+	}
+
+	// list groups
+	var nss corev1.NamespaceList
+	if err := cl.List(ctx, &nss, ctrlclient.MatchingLabels(map[string]string{spacesv1beta1.ControlPlaneGroupLabelKey: "true"})); err != nil {
+		return err
+	}
+
+	return printer.Print(nss.Items, fieldNames, extractGroupFields)
+}

--- a/cmd/up/group/list.go
+++ b/cmd/up/group/list.go
@@ -22,10 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
-
 	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
-	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
@@ -43,13 +40,10 @@ func (c *listCmd) AfterApply(kongCtx *kong.Context) error {
 
 // Run executes the list command.
 func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx *upbound.Context, p pterm.TextPrinter) error { // nolint:gocyclo
-	// get context
-	_, currentProfile, _, err := upCtx.Cfg.GetCurrentContext(ctx)
+	// get profile
+	currentProfile, err := getCurrentProfile(ctx, upCtx)
 	if err != nil {
 		return err
-	}
-	if currentProfile == nil {
-		return errors.New(profile.NoSpacesContextMsg)
 	}
 
 	// create client

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/upbound/up/cmd/up/configuration/template"
 	"github.com/upbound/up/cmd/up/controlplane"
 	"github.com/upbound/up/cmd/up/ctx"
+	"github.com/upbound/up/cmd/up/group"
 	"github.com/upbound/up/cmd/up/login"
 	"github.com/upbound/up/cmd/up/migration"
 	"github.com/upbound/up/cmd/up/organization"
@@ -101,6 +102,7 @@ type cli struct {
 	Configuration      configuration.Cmd            `cmd:"" name:"configuration" aliases:"cfg" help:"Interact with configurations."`
 	ControlPlane       controlplane.Cmd             `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes of the current profile, both in Upbound and local Spaces."`
 	Space              space.Cmd                    `cmd:"" help:"Interact with local Spaces."`
+	Group              group.Cmd                    `cmd:"" help:"Interact with groups inside Spaces."`
 	Organization       organization.Cmd             `cmd:"" name:"organization" aliases:"org" help:"Interact with Upbound organizations."`
 	Profile            profile.Cmd                  `cmd:"" help:"Interact with Upbound profiles or local Spaces."`
 	Ctx                ctx.Cmd                      `cmd:"" maturity:"alpha" hidden:"" help:"Select an Upbound kubeconfig context."`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,10 +16,14 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
@@ -120,6 +124,27 @@ func (c *Config) GetUpboundProfile(name string) (profile.Profile, error) {
 		return profile.Profile{}, errors.Errorf(errProfileNotFoundFmt, name)
 	}
 	return p, nil
+}
+
+// GetCurrentContext returns the current context from the kubeconfig, profile and config
+func (c *Config) GetCurrentContext(ctx context.Context) (profileName string, currentProfile *profile.Profile, ctp types.NamespacedName, err error) {
+	po := clientcmd.NewDefaultPathOptions()
+	conf, err := po.GetStartingConfig()
+	if err != nil {
+		return "", nil, types.NamespacedName{}, err
+	}
+
+	profiles, err := c.GetUpboundProfiles()
+	if err != nil {
+		return "", nil, types.NamespacedName{}, err
+	}
+
+	profileName, currentProfile, ctp, err = profile.FromKubeconfig(ctx, profiles, conf)
+	if err != nil {
+		return "", nil, types.NamespacedName{}, err
+	}
+
+	return profileName, currentProfile, ctp, nil
 }
 
 // GetUpboundProfiles returns the list of existing profiles. If no profiles

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -23,6 +23,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	NoSpacesContextMsg = "This cluster does not have spaces installed, use `up space init` to install spaces."
+	NoGroupMsg         = "The current kubeconfig context does not point to a group, use `up ctx` to select a group."
+)
+
 // Type is a type of Upbound profile.
 type Type string
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Rebased on top of https://github.com/upbound/up/pull/457

Add support for `up group create/list/get/delete` using the selected spaces kubeconfig.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```bash
$ go run ./cmd/up group list
NAME   PROTECTED

$ go run ./cmd/up group create nick-unprotected
nick-unprotected created
$ go run ./cmd/up group create nick-protected --deletion-protection
nick-protected created
$ go run ./cmd/up group list
NAME               PROTECTED
nick-protected     true
nick-unprotected   false

$ go run ./cmd/up group get nick-protected
NAME             PROTECTED
nick-protected   true

$ go run ./cmd/up group delete nick-protected
up: error: group.deleteCmd.Run(): Deletion protection is enabled on the specified group. Use '--force' to delete anyway.
exit status 1
$ go run ./cmd/up group delete nick-protected --force
nick-protected deleted
$ go run ./cmd/up group delete nick-unprotected
nick-unprotected deleted
```
