### PR TITLE
Polish keyboard navigation in `up ctx`

### DIFF
--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -155,13 +155,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { // nolint:gocyclo // T
 				return m.WithTermination(msg, nil), tea.Quit
 			}
 
-		case "enter", "left":
+		case "enter", "left", "right":
 			var fn KeyFunc
 			switch keypress {
 			case "left":
 				if state, ok := m.state.(Back); ok {
 					fn = state.Back
 				}
+			case "right":
+				fallthrough
 			case "enter":
 				if i, ok := m.list.SelectedItem().(item); ok {
 					fn = i.onEnter

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -116,7 +116,7 @@ func (s *Space) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 	}
 
 	items := make([]list.Item, 0, len(nss.Items)+1)
-	items = append(items, item{text: "..", kind: "profiles", onEnter: s.Back})
+	items = append(items, item{text: "..", kind: "profiles", onEnter: s.Back, back: true})
 	for _, ns := range nss.Items {
 		items = append(items, item{text: ns.Name, kind: "group", onEnter: func(ctx context.Context, upCtx *upbound.Context, m model) (model, error) {
 			m.state = &Group{space: *s, name: ns.Name}
@@ -125,7 +125,7 @@ func (s *Space) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 	}
 
 	if len(nss.Items) == 0 {
-		items = append(items, item{text: "No groups found"})
+		items = append(items, item{text: "No groups found", emptyList: true})
 	}
 
 	return items, nil
@@ -169,7 +169,7 @@ func (g *Group) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 	}
 
 	items := make([]list.Item, 0, len(ctps.Items)+2)
-	items = append(items, item{text: "..", kind: "groups", onEnter: g.Back})
+	items = append(items, item{text: "..", kind: "groups", onEnter: g.Back, back: true})
 
 	for _, ctp := range ctps.Items {
 		items = append(items, item{text: ctp.Name, kind: "ctp", onEnter: func(ctx context.Context, upCtx *upbound.Context, m model) (model, error) {
@@ -188,7 +188,7 @@ func (g *Group) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 	*/
 
 	if len(ctps.Items) == 0 {
-		items = append(items, item{text: "No ControlPlanes found"})
+		items = append(items, item{text: "No ControlPlanes found", emptyList: true})
 	}
 
 	return items, nil
@@ -214,7 +214,7 @@ var _ Back = &ControlPlane{}
 
 func (ctp *ControlPlane) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item, error) {
 	return []list.Item{
-		item{text: "..", kind: "group", onEnter: ctp.Back},
+		item{text: "..", kind: "group", onEnter: ctp.Back, back: true},
 		/*
 			item{text: fmt.Sprintf("Connect to %s", ctp.NamespacedName), onEnter: KeyFunc(func(ctx context.Context, upCtx *upbound.Context, m model) (model, error) {
 				msg, err := ctp.Accept(ctx, upCtx)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

- Use right arrow to select
- Add full vim keybindings support
- Manipulate cursor to select first item below ".." in non-empty lists
- Select ".." by default in empty lists and disable moving the cursor to empty list text
- Prevent full help menu from opening

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
