### PR TITLE
Make ctp CRUD commands derive context from kubeconfig

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -31,14 +31,11 @@ import (
 	"github.com/upbound/up/cmd/up/controlplane/kubeconfig"
 	"github.com/upbound/up/cmd/up/controlplane/pkg"
 	"github.com/upbound/up/cmd/up/controlplane/pullsecret"
-	"github.com/upbound/up/internal/controlplane"
 	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/upbound"
-	"github.com/upbound/up/internal/upterm"
 )
 
 var (
-	cloudfieldNames = []string{"NAME", "CONFIGURATION", "UPDATED", "SYNCED", "READY", "MESSAGE", "AGE"}
 	spacefieldNames = []string{"GROUP", "NAME", "CROSSPLANE", "SYNCED", "READY", "MESSAGE", "AGE"}
 )
 
@@ -121,40 +118,6 @@ local Spaces are supported. Use the "profile" management command to switch
 between different Upbound profiles or to connect to a local Space.`
 }
 
-func extractCloudFields(obj any) []string {
-	resp, ok := obj.(*controlplane.Response)
-	if !ok {
-		return []string{"unknown", "unknown", "", "", "", "", ""}
-	}
-
-	return []string{
-		resp.Name,
-		resp.Cfg,
-		resp.Updated,
-		resp.Synced,
-		resp.Ready,
-		resp.Message,
-		formatAge(resp.Age),
-	}
-}
-
-func extractSpaceFieldsLegacy(obj any) []string {
-	resp, ok := obj.(*controlplane.Response)
-	if !ok {
-		return []string{"unknown", "unknown", "", "", "", "", ""}
-	}
-
-	return []string{
-		resp.Group,
-		resp.Name,
-		resp.CrossplaneVersion,
-		resp.Synced,
-		resp.Ready,
-		resp.Message,
-		formatAge(resp.Age),
-	}
-}
-
 func extractSpaceFields(obj any) []string {
 	ctp, ok := obj.(spacesv1beta1.ControlPlane)
 	if !ok {
@@ -183,14 +146,4 @@ func formatAge(age *time.Duration) string {
 	}
 
 	return duration.HumanDuration(*age)
-}
-
-func tabularPrint(obj any, printer upterm.ObjectPrinter, upCtx *upbound.Context) error {
-	if obj, ok := obj.([]spacesv1beta1.ControlPlane); ok {
-		return printer.Print(obj, spacefieldNames, extractSpaceFields)
-	}
-	if upCtx.Profile.IsSpace() {
-		return printer.Print(obj, spacefieldNames, extractSpaceFieldsLegacy)
-	}
-	return printer.Print(obj, cloudfieldNames, extractCloudFields)
 }

--- a/cmd/up/controlplane/delete.go
+++ b/cmd/up/controlplane/delete.go
@@ -18,15 +18,15 @@ import (
 	"context"
 
 	"github.com/alecthomas/kong"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/dynamic"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/upbound/up-sdk-go/service/configurations"
-	cp "github.com/upbound/up-sdk-go/service/controlplanes"
-	"github.com/upbound/up/internal/controlplane"
-	"github.com/upbound/up/internal/controlplane/cloud"
-	"github.com/upbound/up/internal/controlplane/space"
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
 )
 
@@ -44,37 +44,48 @@ type deleteCmd struct {
 
 // AfterApply sets default values in command after assignment and validation.
 func (c *deleteCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) error {
-	if upCtx.Profile.IsSpace() {
-		kubeconfig, ns, err := upCtx.Profile.GetSpaceRestConfig()
-		if err != nil {
-			return err
-		}
-		if c.Group == "" {
-			c.Group = ns
-		}
-
-		client, err := dynamic.NewForConfig(kubeconfig)
-		if err != nil {
-			return err
-		}
-		c.client = space.New(client)
-	} else {
-		cfg, err := upCtx.BuildSDKConfig()
-		if err != nil {
-			return err
-		}
-		ctpclient := cp.NewClient(cfg)
-		cfgclient := configurations.NewClient(cfg)
-
-		c.client = cloud.New(ctpclient, cfgclient, upCtx.Account)
-	}
 	return nil
 }
 
 // Run executes the delete command.
 func (c *deleteCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error {
-	if err := c.client.Delete(ctx, types.NamespacedName{Name: c.Name, Namespace: c.Group}); err != nil {
-		if controlplane.IsNotFound(err) {
+	_, currentProfile, ctp, err := upCtx.Cfg.GetCurrentContext(ctx)
+	if err != nil {
+		return err
+	}
+	if currentProfile == nil {
+		return errors.New(profile.NoSpacesContextMsg)
+	}
+	if ctp.Namespace == "" {
+		return errors.New(profile.NoGroupMsg)
+	}
+	if ctp.Name != "" {
+		return errors.New("Cannot delete control planes from inside a control plane, use `up ctx ..` to switch to a group level.")
+	}
+
+	// create client
+	restConfig, _, err := currentProfile.GetSpaceRestConfig()
+	if err != nil {
+		return err
+	}
+	cl, err := ctrlclient.New(restConfig, ctrlclient.Options{})
+	if err != nil {
+		return err
+	}
+
+	ns := ctp.Namespace
+	if c.Group != "" {
+		ns = c.Group
+	}
+
+	ctpToDelete := &spacesv1beta1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.Name,
+			Namespace: ns,
+		},
+	}
+	if err := cl.Delete(ctx, ctpToDelete); err != nil {
+		if kerrors.IsNotFound(err) {
 			p.Printfln("Control plane %s not found", c.Name)
 			return nil
 		}


### PR DESCRIPTION
### Description of your changes

This PR is the continuation of #457 makes `up ctp get/create/delete` kubeconfig context aware, making it independent from the current profile. The profile is automatically derived. 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested


