### PR TITLE
feat(uxp): bump uxp to v1.15.x

### DIFF
--- a/cmd/up/space/prerequisites/providers/helm/helm.go
+++ b/cmd/up/space/prerequisites/providers/helm/helm.go
@@ -41,7 +41,7 @@ var (
 	providerName = "provider-helm"
 	// Package version to be installed
 	version   = "v0.17.0"
-	pkgRef, _ = name.ParseReference(fmt.Sprintf("xpkg.upbound.io/crossplane-contrib/provider-helm:%s", version))
+	pkgRef, _ = name.ParseReference(fmt.Sprintf("crossplane-contrib/provider-helm:%s", version))
 
 	objectsCRD = "releases.helm.crossplane.io"
 	xrdCRD     = "compositeresourcedefinitions.apiextensions.crossplane.io"

--- a/cmd/up/space/prerequisites/providers/kubernetes/kubernetes.go
+++ b/cmd/up/space/prerequisites/providers/kubernetes/kubernetes.go
@@ -40,7 +40,7 @@ import (
 var (
 	providerName = "provider-kubernetes"
 	version      = "v0.12.1"
-	pkgRef, _    = name.ParseReference(fmt.Sprintf("xpkg.upbound.io/crossplane-contrib/provider-kubernetes:%s", version))
+	pkgRef, _    = name.ParseReference(fmt.Sprintf("crossplane-contrib/provider-kubernetes:%s", version))
 
 	objectsCRD = "objects.kubernetes.crossplane.io"
 	xrdCRD     = "compositeresourcedefinitions.apiextensions.crossplane.io"

--- a/cmd/up/space/prerequisites/uxp/uxp.go
+++ b/cmd/up/space/prerequisites/uxp/uxp.go
@@ -36,7 +36,7 @@ var (
 	ns        = "upbound-system"
 	// Chart version to be installed. universal-crossplane does not include a
 	// v prefix.
-	version = "1.14.6-up.1"
+	version = "1.15.2-up.1"
 
 	xrdCRD = "compositeresourcedefinitions.apiextensions.crossplane.io"
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- bump uxp version to v1.15.x to use registry feature
- remove registries for provider-helm and provider-kubernetes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
_output/bin/darwin_arm64/up space init 1.2.4 --token-file=/Users/haarchri/.aws/spaces-pull.json
 INFO  Setting defaults for vanilla Kubernetes (type kind)
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm

Would you like to install them now? [y/N]: Yes

  ✓   [1/5]: Installing cert-manager                                                                                                  
  ✓   [2/5]: Installing universal-crossplane                                                                                          
  ✓   [3/5]: Installing ingress-nginx                                                                                                 
  ✓   [4/5]: Installing provider-kubernetes                                                                                           
  ✓   [5/5]: Installing provider-helm                                                                                                 
 INFO  Required prerequisites met!
```

```
helm list -A
NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                                   APP VERSION
universal-crossplane    upbound-system  1               2024-04-25 11:28:46.060963 +0200 CEST   deployed        universal-crossplane-1.15.2-up.1        1.15.2-up.1
```

```
kubectl get pkgrev
NAME                                                                                     HEALTHY   REVISION   IMAGE                                            STATE    DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/crossplane-contrib-provider-helm-839e04a83ec3         True      1          crossplane-contrib/provider-helm:v0.17.0         Active                               2m53s
providerrevision.pkg.crossplane.io/crossplane-contrib-provider-kubernetes-6ef2ebb6f1db   True      1          crossplane-contrib/provider-kubernetes:v0.12.1   Active                               3m

```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
