### PR TITLE
Prevent spinner from overwriting confirmation prompt during attach/detach

### DIFF
--- a/cmd/up/space/detach.go
+++ b/cmd/up/space/detach.go
@@ -153,8 +153,7 @@ func (c *detachCmd) Run(ctx context.Context, upCtx *upbound.Context, ac *account
 
 func (c *detachCmd) detachSpace(ctx context.Context, detachSpinner *pterm.SpinnerPrinter, upCtx *upbound.Context, ac *accounts.Client, oc *organizations.Client, kClient *kubernetes.Clientset, mgr *helm.Installer, rc *robots.Client, sc client.Client) error {
 	if kClient == nil {
-		detachSpinner.UpdateText("Continue? (y/N)")
-		if err := warnAndConfirm(
+		if err := warnAndConfirmWithSpinner(detachSpinner,
 			`Not connected to a Space cluster, would you like to only remove the Space "%s/%s" from the Upbound Console?`+"\n\n"+
 				"  If the other Space cluster still exists, the Upbound agent will be left running and you will need to delete it manually.\n",
 			upCtx.Account, c.Space,
@@ -239,8 +238,7 @@ func (c *detachCmd) deleteResources(ctx context.Context, kClient *kubernetes.Cli
 		if c.Space == "" {
 			return errors.New("failed to find Space to detach from Upbound Console")
 		}
-		detachSpinner.UpdateText("Continue? (Y/n)")
-		if err := warnAndConfirm(
+		if err := warnAndConfirmWithSpinner(detachSpinner,
 			`We're unable to confirm if the Space "%s/%s" is currently connected to Upbound Console. Would you like to delete it anyway?`+"\n\n"+
 				"  If the other Space cluster still exists, the Upbound agent will be left running and you will need to delete it manually.\n",
 			upCtx.Account, c.Space,


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Attach and detach commands use a spinner to communicate the status of the ongoing operation. If a potential conflict is found, such as attaching a Space that's already been attached, the user is prompted to confirm whether they want to proceed. The spinner overwrites that prompt because it's still active, so we work around that by making the spinner draw its own prompt. But the first prompt is briefly visible for a flash, and the spinner's prompt may be misleading about whether the default is to proceed or abort.

This PR updates attach and detach commands to disable the spinner while prompting the user. This relieves the spinner of needing to write its own prompt, allowing attach/detach to use the existing prompt which correctly indicates the default selection.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I put together a [gist](https://gist.github.com/branden/f7fa37944d72ea86b9a024d86eb4fc8a) with output from the attach/detach commands. There are two text files `before.txt` and `after.txt` showing output before and after this PR. Each shows:
* successful attach
* reattach of attached cluster, aborted
* reattach of attached cluster, proceeding
* successful detach
* re-detach of detached cluster, aborted
* re-detach of detached cluster, proceeding

For convenience there's also a `diff.diff` showing the diff between `before.txt` and `after.txt`.

Note that the spinner's prompt in `before.txt` isn't captured due to competition between the spinner and the overwritten confirmation prompt and ensuing terminal weirdness.