### PR TITLE
Hide robot-token flag in attach help

### DIFF
--- a/cmd/up/space/attach.go
+++ b/cmd/up/space/attach.go
@@ -76,7 +76,7 @@ type attachCmd struct {
 	Kube    upbound.KubeFlags `embed:""`
 
 	Space string `arg:"" optional:"" help:"Name of the Upbound Space. If name is not a supplied, one is generated."`
-	Token string `name:"robot-token" optional:"" help:"The Upbound robot token contents used to authenticate the connection."`
+	Token string `name:"robot-token" optional:"" hidden:"" help:"The Upbound robot token contents used to authenticate the connection."`
 
 	Environment string `name:"up-environment" env:"UP_ENVIRONMENT" default:"prod" hidden:"" help:"Override the default Upbound Environment."`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This PR hides the `up space attach` flag `--robot-token` from help output. Users shouldn't need to provide this flag since robot tokens should be generated for them. And familiarity with other `up` commands might mislead a user into thinking they need to provide a personal access token. This hides the potential stumbling block while keeping it around in case it's helpful for debugging or workarounds.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I ran `go run ./cmd/up space attach -h` and verified `--robot-token` wasn't in help output.