### PR TITLE
space init: install opentelemetry-operator as prerequisite

### DIFF
--- a/cmd/up/space/features/features.go
+++ b/cmd/up/space/features/features.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+)
+
+const (
+	// EnableAlphaSharedTelemetry enables alpha support for Telemetry.
+	EnableAlphaSharedTelemetry feature.Flag = "EnableSharedTelemetry"
+)
+
+func EnableFeatures(features *feature.Flags, params map[string]any) {
+	if isAlphaSharedTelemetryEnabled(params) {
+		features.Enable(EnableAlphaSharedTelemetry)
+	}
+}
+
+func isAlphaSharedTelemetryEnabled(params map[string]any) bool {
+	enabled, err := fieldpath.Pave(params).GetBool("features.alpha.observability.enabled")
+	if err != nil {
+		return false
+	}
+	return enabled
+}

--- a/cmd/up/space/prerequisites/manager.go
+++ b/cmd/up/space/prerequisites/manager.go
@@ -18,6 +18,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"k8s.io/client-go/rest"
 
+	"github.com/upbound/up/cmd/up/space/prerequisites/opentelemetrycollector"
+
 	"github.com/upbound/up/cmd/up/space/defaults"
 	"github.com/upbound/up/cmd/up/space/prerequisites/certmanager"
 	"github.com/upbound/up/cmd/up/space/prerequisites/ingressnginx"
@@ -88,6 +90,12 @@ func New(config *rest.Config, defs *defaults.CloudConfig) (*Manager, error) {
 		return nil, errors.Wrap(err, errCreatePrerequisite)
 	}
 	prereqs = append(prereqs, phelm)
+
+	otelopr, err := opentelemetrycollector.New(config)
+	if err != nil {
+		return nil, errors.Wrap(err, errCreatePrerequisite)
+	}
+	prereqs = append(prereqs, otelopr)
 
 	return &Manager{
 		prereqs: prereqs,

--- a/cmd/up/space/prerequisites/manager.go
+++ b/cmd/up/space/prerequisites/manager.go
@@ -39,7 +39,7 @@ type Prerequisite interface {
 	GetName() string
 
 	Install() error
-	IsInstalled() bool
+	IsInstalled() (bool, error)
 }
 
 // Manager provides APIs for interacting with Prerequisites within the target
@@ -107,15 +107,19 @@ func New(config *rest.Config, defs *defaults.CloudConfig, features *feature.Flag
 
 // Check performs IsInstalled checks for each of the Prerequisites against the
 // target cluster.
-func (m *Manager) Check() *Status {
+func (m *Manager) Check() (*Status, error) {
 	notInstalled := []Prerequisite{}
 	for _, p := range m.prereqs {
-		if !p.IsInstalled() {
+		installed, err := p.IsInstalled()
+		if err != nil {
+			return nil, err
+		}
+		if !installed {
 			notInstalled = append(notInstalled, p)
 		}
 	}
 
 	return &Status{
 		NotInstalled: notInstalled,
-	}
+	}, nil
 }

--- a/cmd/up/space/prerequisites/opentelemetrycollector/opentelemetrycollector.go
+++ b/cmd/up/space/prerequisites/opentelemetrycollector/opentelemetrycollector.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package opentelemetrycollector
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apixv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/upbound/up/internal/install"
+	"github.com/upbound/up/internal/install/helm"
+)
+
+var (
+	chartName     = "opentelemetry-operator"
+	otelMgrURL, _ = url.Parse("https://open-telemetry.github.io/opentelemetry-helm-charts")
+
+	// Chart version to be installed
+	version = "0.56.0"
+
+	// Set image used to contrib to cover more exporters
+	values = map[string]any{
+		"manager": map[string]any{
+			"collectorImage": map[string]any{
+				"repository": "otel/opentelemetry-collector-contrib",
+			},
+		},
+	}
+
+	otelCollectorCRD = "opentelemetrycollector.opentelemetry.io"
+
+	errFmtCreateHelmManager = "failed to create helm manager for %s"
+	errFmtCreateK8sClient   = "failed to create kubernetes client for helm chart %s"
+	errFmtCreateNamespace   = "failed to create namespace %s"
+)
+
+// OpenTelemetryCollectorOperator represents a Helm manager
+type OpenTelemetryCollectorOperator struct {
+	mgr       install.Manager
+	crdclient *apixv1client.ApiextensionsV1Client
+	kclient   kubernetes.Interface
+}
+
+// New constructs a new OpenTelemetryCollectorMgr instance that can used to install the
+// opentelemetry-operator chart.
+func New(config *rest.Config) (*OpenTelemetryCollectorOperator, error) {
+	mgr, err := helm.NewManager(config,
+		chartName,
+		otelMgrURL,
+		helm.WithNamespace(chartName),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf(errFmtCreateHelmManager, chartName))
+	}
+	crdclient, err := apixv1client.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf(errFmtCreateK8sClient, chartName))
+	}
+	kclient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf(errFmtCreateK8sClient, chartName))
+	}
+
+	return &OpenTelemetryCollectorOperator{
+		mgr:       mgr,
+		crdclient: crdclient,
+		kclient:   kclient,
+	}, nil
+}
+
+// GetName returns the name of the opentelemetry-operator chart.
+func (c *OpenTelemetryCollectorOperator) GetName() string {
+	return chartName
+}
+
+// Install performs a Helm install of the chart.
+func (c *OpenTelemetryCollectorOperator) Install() error {
+	if c.IsInstalled() {
+		// nothing to do
+		return nil
+	}
+
+	// create namespace before creating chart.
+	_, err := c.kclient.CoreV1().
+		Namespaces().
+		Create(context.Background(),
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: chartName,
+				},
+			}, metav1.CreateOptions{})
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		return errors.Wrap(err, fmt.Sprintf(errFmtCreateNamespace, chartName))
+	}
+
+	return c.mgr.Install(version, values)
+}
+
+// IsInstalled checks if opentelemetry operator has been installed in the target cluster.
+func (c *OpenTelemetryCollectorOperator) IsInstalled() bool {
+	_, err := c.crdclient.
+		CustomResourceDefinitions().
+		Get(
+			context.Background(),
+			otelCollectorCRD,
+			metav1.GetOptions{},
+		)
+	return !kerrors.IsNotFound(err)
+}

--- a/cmd/up/space/prerequisites/opentelemetrycollector/opentelemetrycollector.go
+++ b/cmd/up/space/prerequisites/opentelemetrycollector/opentelemetrycollector.go
@@ -47,7 +47,7 @@ var (
 		},
 	}
 
-	otelCollectorCRD = "opentelemetrycollector.opentelemetry.io"
+	otelCollectorCRD = "opentelemetrycollectors.opentelemetry.io"
 
 	errFmtCreateHelmManager = "failed to create helm manager for %s"
 	errFmtCreateK8sClient   = "failed to create kubernetes client for helm chart %s"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Adds [opentelemetry-operator](https://github.com/open-telemetry/opentelemetry-operator) installation as a prerequisite for `space init`, but only if the feature is enabled through the flag.

The operator [needs](https://opentelemetry.io/docs/kubernetes/helm/operator/) `cert-manager` but as it is also installed under prerequisites, we have it covered.

This is needed as the Shared Telemetry needs the operator to provision telemetry collectors for control planes.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
No flag:
```bash
 up space init --token-file="../key.json" "v1.2.4" \
  --set "account=bob"
 INFO  Setting defaults for vanilla Kubernetes (type kind)
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm

Would you like to install them now? [y/N]:
```

enabled=false:
```bash
up space init --token-file="../key.json" "v1.2.4" \
  --set "account=bob" \
  --set "features.alpha.observability.enabled=false"
 INFO  Setting defaults for vanilla Kubernetes (type kind)
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm

Would you like to install them now? [y/N]:
```

enabled=true
```bash
up space init --token-file="../key.json" "v1.2.4" \
  --set "account=bob" \
  --set "features.alpha.observability.enabled=true"
 INFO  Setting defaults for vanilla Kubernetes (type kind)
 WARNING  One or more required prerequisites are not installed:

❌ cert-manager
❌ universal-crossplane
❌ ingress-nginx
❌ provider-kubernetes
❌ provider-helm
❌ opentelemetry-operator

Would you like to install them now? [y/N]: Yes

▀  [1/6]: Installing cert-manager (0s)
  ✓   [1/6]: Installing cert-manager
  ✓   [2/6]: Installing universal-crossplane
  ✓   [3/6]: Installing ingress-nginx
  ✓   [4/6]: Installing provider-kubernetes
  ✓   [5/6]: Installing provider-helm
  ✓   [6/6]: Installing opentelemetry-operator
 INFO  Required prerequisites met!
 INFO  Proceeding with Upbound Spaces installation...
  ✓   [1/3]: Creating pull secret upbound-pull-secret
  ✓   [2/3]: Initializing Space components
  ✓   [3/3]: Starting Space Components
  🙌  Your Upbound Space is Ready!

  👀  Next Steps 👇

👉 Check out Upbound Spaces docs @ https://docs.upbound.io/concepts/upbound-spaces
```

```bash
k get all -n opentelemetry-operator
NAME                                          READY   STATUS    RESTARTS   AGE
pod/opentelemetry-operator-798dff6b6d-98dfm   2/2     Running   0          19m

NAME                                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
service/opentelemetry-operator           ClusterIP   10.96.16.56    <none>        8443/TCP,8080/TCP   19m
service/opentelemetry-operator-webhook   ClusterIP   10.96.58.215   <none>        443/TCP             19m

NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/opentelemetry-operator   1/1     1            1           19m

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/opentelemetry-operator-798dff6b6d   1         1         1       19m
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
