### PR TITLE
Bump connect agent version to 0.0.0-408.g343d295

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PLATFORMS ?= linux_amd64 linux_arm64 linux_arm darwin_amd64 darwin_arm64 windows
 -include build/makelib/common.mk
 
 # Connect agent version
-UP_CONNECT_AGENT_VERSION = 0.0.0-309.gd29fc13
+UP_CONNECT_AGENT_VERSION = 0.0.0-408.g343d295
 
 # ====================================================================================
 # Setup Output


### PR DESCRIPTION
### Description of your changes

Bumps the connect agent to the latest version

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
attached a space locally and saw everything was working as expected