### PR TITLE
Expose ctx and ctp commands

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -100,12 +100,12 @@ type cli struct {
 	Login              login.LoginCmd               `cmd:"" help:"Login to Upbound."`
 	Logout             login.LogoutCmd              `cmd:"" help:"Logout of Upbound."`
 	Configuration      configuration.Cmd            `cmd:"" name:"configuration" aliases:"cfg" help:"Interact with configurations."`
-	ControlPlane       controlplane.Cmd             `cmd:"" hidden:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes in the current context, both in the cloud and in a local space."`
+	ControlPlane       controlplane.Cmd             `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes in the current context, both in the cloud and in a local Space."`
 	Space              space.Cmd                    `cmd:"" help:"Interact with Spaces."`
 	Group              group.Cmd                    `cmd:"" help:"Interact with groups inside Spaces."`
 	Organization       organization.Cmd             `cmd:"" name:"organization" aliases:"org" help:"Interact with Upbound organizations."`
 	Profile            profile.Cmd                  `cmd:"" help:"Interact with Upbound profiles or local Spaces."`
-	Ctx                ctx.Cmd                      `cmd:"" maturity:"alpha" hidden:"" help:"Select an Upbound kubeconfig context."`
+	Ctx                ctx.Cmd                      `cmd:"" help:"Select an Upbound kubeconfig context."`
 	Repository         repository.Cmd               `cmd:"" name:"repository" aliases:"repo" help:"Interact with repositories."`
 	Robot              robot.Cmd                    `cmd:"" name:"robot" help:"Interact with robots."`
 	UXP                uxp.Cmd                      `cmd:"" help:"Interact with UXP."`

--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -99,13 +99,13 @@ type cli struct {
 	Help               helpCmd                      `cmd:"" help:"Show help."`
 	Login              login.LoginCmd               `cmd:"" help:"Login to Upbound."`
 	Logout             login.LogoutCmd              `cmd:"" help:"Logout of Upbound."`
-	Configuration      configuration.Cmd            `cmd:"" name:"configuration" aliases:"cfg" help:"Interact with configurations."`
-	ControlPlane       controlplane.Cmd             `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes in the current context, both in the cloud and in a local Space."`
+	Ctx                ctx.Cmd                      `cmd:"" help:"Select an Upbound kubeconfig context."`
 	Space              space.Cmd                    `cmd:"" help:"Interact with Spaces."`
 	Group              group.Cmd                    `cmd:"" help:"Interact with groups inside Spaces."`
+	ControlPlane       controlplane.Cmd             `cmd:"" name:"controlplane" aliases:"ctp" help:"Interact with control planes in the current context, both in the cloud and in a local Space."`
+	Configuration      configuration.Cmd            `cmd:"" name:"configuration" aliases:"cfg" help:"Interact with configurations."`
 	Organization       organization.Cmd             `cmd:"" name:"organization" aliases:"org" help:"Interact with Upbound organizations."`
 	Profile            profile.Cmd                  `cmd:"" help:"Interact with Upbound profiles or local Spaces."`
-	Ctx                ctx.Cmd                      `cmd:"" help:"Select an Upbound kubeconfig context."`
 	Repository         repository.Cmd               `cmd:"" name:"repository" aliases:"repo" help:"Interact with repositories."`
 	Robot              robot.Cmd                    `cmd:"" name:"robot" help:"Interact with robots."`
 	UXP                uxp.Cmd                      `cmd:"" help:"Interact with UXP."`


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fixes https://github.com/upbound/up/issues/488

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
$ ./up help
Usage: up <command>

The Upbound CLI

Flags:
  -h, --help                Show context-sensitive help.
      --format="default"    Format for get/list commands. Can be: json, yaml, default
  -q, --quiet               Suppress all output.
      --pretty              Pretty print output.

Commands:
  license                Print Up license information.
  help                   Show help.
  login                  Login to Upbound.
  logout                 Logout of Upbound.
  configuration (cfg)    Interact with configurations.
  controlplane (ctp)     Interact with control planes in the current context, both in the cloud and in a local
                         Space.
  space                  Interact with Spaces.
  group                  Interact with groups inside Spaces.
  organization (org)     Interact with Upbound organizations.
  profile                Interact with Upbound profiles or local Spaces.
  ctx                    Select an Upbound kubeconfig context.
  repository (repo)      Interact with repositories.
  robot                  Interact with robots.
  uxp                    Interact with UXP.
  xpkg                   Interact with UXP packages.
  xpls                   Start xpls language server.
  alpha                  Alpha features. Commands may be removed in future releases.
  install-completions    Install shell completions
  version                Print the client and server version information for the current context.

Run "up <command> --help" for more information on a command
```
