### PR TITLE
up space list against a disconnected space should return message to user

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -75,6 +75,7 @@ func (c *cli) AfterApply(ctx *kong.Context) error { //nolint:unparam
 	printer.Quiet = c.Quiet
 
 	ctx.Bind(printer)
+	ctx.BindTo(&printer, (*upterm.Printer)(nil))
 	ctx.Bind(c.Quiet)
 	return nil
 }

--- a/cmd/up/space/list.go
+++ b/cmd/up/space/list.go
@@ -35,7 +35,7 @@ import (
 var (
 	spacelistFieldNames = []string{"NAME", "MODE", "PROVIDER", "REGION"}
 
-	errListSpaces = "unable to list Upbound Cloud Spaces"
+	errListSpaces = "unable to list Upbound Spaces"
 )
 
 // listCmd lists all of the spaces in Upbound.
@@ -82,7 +82,7 @@ func (c *listCmd) Run(ctx context.Context, printer upterm.Printer, p pterm.TextP
 	if errors.As(err, &uerr) {
 		if uerr.Status == http.StatusUnauthorized {
 			p.Println("You must be logged in and authorized to list Upbound Cloud Spaces")
-			return nil
+			return uerr
 		}
 	}
 

--- a/cmd/up/space/list.go
+++ b/cmd/up/space/list.go
@@ -16,25 +16,34 @@ package space
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/alecthomas/kong"
 	"github.com/pterm/pterm"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+
 	upboundv1alpha1 "github.com/upbound/up-sdk-go/apis/upbound/v1alpha1"
+	uerrors "github.com/upbound/up-sdk-go/errors"
 	"github.com/upbound/up-sdk-go/service/accounts"
+
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
 
 var (
 	spacelistFieldNames = []string{"NAME", "MODE", "PROVIDER", "REGION"}
+
+	errListSpaces = "unable to list Upbound Cloud Spaces"
 )
 
 // listCmd lists all of the spaces in Upbound.
 type listCmd struct {
 	Upbound upbound.Flags `embed:""`
+
+	kc client.Client
+	ac *accounts.Client
 }
 
 // AfterApply sets default values in command after assignment and validation.
@@ -52,32 +61,39 @@ func (c *listCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	c.ac = accounts.NewClient(cfg)
+
+	kc, err := client.New(ctrlCfg, client.Options{})
+	if err != nil {
+		return errors.Wrap(err, errListSpaces)
+	}
+	c.kc = kc
 
 	kongCtx.Bind(upCtx)
-	kongCtx.Bind(ctrlCfg)
-	kongCtx.Bind(accounts.NewClient(cfg))
-
 	kongCtx.Bind(pterm.DefaultTable.WithWriter(kongCtx.Stdout).WithSeparator("   "))
 
 	return nil
 }
 
 // Run executes the list command.
-func (c *listCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, p pterm.TextPrinter, upCtx *upbound.Context, ac *accounts.Client, rest *rest.Config) error {
-	a, err := upbound.GetOrganization(ctx, ac, upCtx.Account)
-	if err != nil {
-		return err
+func (c *listCmd) Run(ctx context.Context, printer upterm.Printer, p pterm.TextPrinter, upCtx *upbound.Context) error {
+	a, err := upbound.GetOrganization(ctx, c.ac, upCtx.Account)
+	var uerr *uerrors.Error
+	if errors.As(err, &uerr) {
+		if uerr.Status == http.StatusUnauthorized {
+			p.Println("You must be logged in and authorized to list Upbound Cloud Spaces")
+			return nil
+		}
 	}
 
-	sc, err := client.New(rest, client.Options{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, errListSpaces)
 	}
 
 	var l upboundv1alpha1.SpaceList
-	err = sc.List(ctx, &l, &client.ListOptions{Namespace: a.Organization.Name})
+	err = c.kc.List(ctx, &l, &client.ListOptions{Namespace: a.Organization.Name})
 	if err != nil {
-		return err
+		return errors.Wrap(err, errListSpaces)
 	}
 
 	if len(l.Items) == 0 {

--- a/cmd/up/space/list_test.go
+++ b/cmd/up/space/list_test.go
@@ -64,6 +64,7 @@ func TestListCommand(t *testing.T) {
 							MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
 							MockDo: fake.NewMockDoFn(&uerrors.Error{
 								Status: http.StatusUnauthorized,
+								Title:  http.StatusText(http.StatusUnauthorized),
 							}),
 						},
 					}),
@@ -72,7 +73,12 @@ func TestListCommand(t *testing.T) {
 					Account: "some-account",
 				},
 			},
-			want: want{},
+			want: want{
+				err: &uerrors.Error{
+					Status: http.StatusUnauthorized,
+					Title:  http.StatusText(http.StatusUnauthorized),
+				},
+			},
 		},
 		"ErrFailedToQueryForAccount": {
 			reason: "If the user could not query cloud due to service availability we should return an error.",

--- a/cmd/up/space/list_test.go
+++ b/cmd/up/space/list_test.go
@@ -1,0 +1,194 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package space
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+
+	"github.com/upbound/up-sdk-go"
+	upboundv1alpha1 "github.com/upbound/up-sdk-go/apis/upbound/v1alpha1"
+	uerrors "github.com/upbound/up-sdk-go/errors"
+	"github.com/upbound/up-sdk-go/fake"
+	"github.com/upbound/up-sdk-go/service/accounts"
+	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/upterm"
+)
+
+func TestListCommand(t *testing.T) {
+	acc := "some-account"
+	errBoom := errors.New("boom")
+	accResp := `{"account": {"name": "some-account", "type": "organization"}, "organization": {"name": "some-account"}}`
+
+	type args struct {
+		cmd   *listCmd
+		upCtx *upbound.Context
+	}
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"NotLoggedIntoCloud": {
+			reason: "If the user is not logged into cloud, we expect no error and instead a nice human message.",
+			args: args{
+				cmd: &listCmd{
+					ac: accounts.NewClient(&up.Config{
+						Client: &fake.MockClient{
+							MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+							MockDo: fake.NewMockDoFn(&uerrors.Error{
+								Status: http.StatusUnauthorized,
+							}),
+						},
+					}),
+				},
+				upCtx: &upbound.Context{
+					Account: "some-account",
+				},
+			},
+			want: want{},
+		},
+		"ErrFailedToQueryForAccount": {
+			reason: "If the user could not query cloud due to service availability we should return an error.",
+			args: args{
+				cmd: &listCmd{
+					ac: accounts.NewClient(&up.Config{
+						Client: &fake.MockClient{
+							MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+							MockDo: fake.NewMockDoFn(&uerrors.Error{
+								Status: http.StatusServiceUnavailable,
+								Title:  http.StatusText(http.StatusServiceUnavailable),
+							}),
+						},
+					}),
+				},
+				upCtx: &upbound.Context{
+					Account: acc,
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.New(`failed to get Account "some-account": Service Unavailable`), errListSpaces),
+			},
+		},
+		"ErrFailedToListSpaces": {
+			reason: "If we received an error from Cloud, we should return an error.",
+			args: args{
+				cmd: &listCmd{
+					ac: accounts.NewClient(&up.Config{
+						Client: &fake.MockClient{
+							MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+							MockDo: func(req *http.Request, obj interface{}) error {
+								return json.Unmarshal([]byte(accResp), &obj)
+							},
+						},
+					}),
+					kc: &test.MockClient{
+						MockList: test.NewMockListFn(errBoom),
+					},
+				},
+				upCtx: &upbound.Context{
+					Account: acc,
+				},
+			},
+			want: want{
+				err: errors.Wrap(errBoom, errListSpaces),
+			},
+		},
+		"NoSpacesFound": {
+			reason: "If we were able to query Cloud, but no spaces were found, we should print a human consumable error.",
+			args: args{
+				cmd: &listCmd{
+					ac: accounts.NewClient(&up.Config{
+						Client: &fake.MockClient{
+							MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+							MockDo: func(req *http.Request, obj interface{}) error {
+								return json.Unmarshal([]byte(accResp), &obj)
+							},
+						},
+					}),
+					kc: &test.MockClient{
+						MockList: test.NewMockListFn(nil),
+					},
+				},
+				upCtx: &upbound.Context{
+					Account: acc,
+				},
+			},
+			want: want{},
+		},
+		"SpacesFound": {
+			reason: "If we were able to query Cloud, we should attempt to print what was found.",
+			args: args{
+				cmd: &listCmd{
+					ac: accounts.NewClient(&up.Config{
+						Client: &fake.MockClient{
+							MockNewRequest: fake.NewMockNewRequestFn(nil, nil),
+							MockDo: func(req *http.Request, obj interface{}) error {
+								return json.Unmarshal([]byte(accResp), &obj)
+							},
+						},
+					}),
+					kc: &test.MockClient{
+						MockList: func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+							list := obj.(*upboundv1alpha1.SpaceList)
+							list.Items = []upboundv1alpha1.Space{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "some-space",
+									},
+								},
+							}
+							return nil
+						},
+					},
+				},
+				upCtx: &upbound.Context{
+					Account: acc,
+				},
+			},
+			want: want{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+
+			err := tc.args.cmd.Run(
+				context.Background(),
+				upterm.NewNopObjectPrinter(),
+				upterm.NewNopTextPrinter(),
+				tc.args.upCtx,
+			)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nValidateInput(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/internal/upterm/printer.go
+++ b/internal/upterm/printer.go
@@ -26,6 +26,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Printer describes interactions for working with the ObjectPrinter below.
+// NOTE(tnthornton) ideally this would be called "ObjectPrinter".
+// TODO(tnthornton) rename this to ObjectPrinter.
+type Printer interface {
+	Print(obj any, fieldNames []string, extractFields func(any) []string) error
+}
+
 // The ObjectPrinter is intended to make it easy to print individual structs
 // and lists of structs for the 'get' and 'list' commands. It can print as
 // a human-readable table, or computer-readable (JSON or YAML)
@@ -124,4 +131,47 @@ func (p *ObjectPrinter) printDefaultObj(obj any, fieldNames []string, extractFie
 	data[0] = fieldNames
 	data[1] = extractFields(obj)
 	return p.TablePrinter.WithHasHeader().WithData(data).Render()
+}
+
+// NewNopObjectPrinter returns a Printer that does nothing.
+func NewNopObjectPrinter() Printer { return nopObjectPrinter{} }
+
+type nopObjectPrinter struct{}
+
+func (p nopObjectPrinter) Print(obj any, fieldNames []string, extractFields func(any) []string) error {
+	return nil
+}
+
+// NewNopTextPrinter returns a TextPrinter that does nothing.
+func NewNopTextPrinter() pterm.TextPrinter { return nopTextPrinter{} }
+
+type nopTextPrinter struct{}
+
+func (p nopTextPrinter) Sprint(a ...interface{}) string                   { return "" }
+func (p nopTextPrinter) Sprintln(a ...interface{}) string                 { return "" }
+func (p nopTextPrinter) Sprintf(format string, a ...interface{}) string   { return "" }
+func (p nopTextPrinter) Sprintfln(format string, a ...interface{}) string { return "" }
+func (p nopTextPrinter) Print(a ...interface{}) *pterm.TextPrinter {
+	tp := pterm.TextPrinter(nopTextPrinter{})
+	return &tp
+}
+func (p nopTextPrinter) Println(a ...interface{}) *pterm.TextPrinter {
+	tp := pterm.TextPrinter(nopTextPrinter{})
+	return &tp
+}
+func (p nopTextPrinter) Printf(format string, a ...interface{}) *pterm.TextPrinter {
+	tp := pterm.TextPrinter(nopTextPrinter{})
+	return &tp
+}
+func (p nopTextPrinter) Printfln(format string, a ...interface{}) *pterm.TextPrinter {
+	tp := pterm.TextPrinter(nopTextPrinter{})
+	return &tp
+}
+func (p nopTextPrinter) PrintOnError(a ...interface{}) *pterm.TextPrinter {
+	tp := pterm.TextPrinter(nopTextPrinter{})
+	return &tp
+}
+func (p nopTextPrinter) PrintOnErrorf(format string, a ...interface{}) *pterm.TextPrinter {
+	tp := pterm.TextPrinter(nopTextPrinter{})
+	return &tp
 }


### PR DESCRIPTION
### Description of your changes
Prior to this changeset, if a user was not logged in to Upbound Cloud they would be presented with the following error when pointed at a disconnected space:
```
up: error: space.listCmd.Run(): failed to get Account "upbound": Unauthorized: {"message":"Unauthorized"}
```

Changes:
- space list is for listing across spaces, which inherently doesn't work in isolation
- update current logic that returns an error if you are not logged in to upbound cloud
- add test coverage for the interactions
- introduce NopPrinters so that we can test logic without needing to account for stdout comms

Relates to https://github.com/upbound/up/issues/487

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
New unit tests.

With a local build:
1. Without logging in, attempted command and verified that I received expected message.
```
./_output/bin/darwin_arm64/up space list
You must be logged in and authorized to list Upbound Cloud Spaces
```
2. After logging in, verified that I could receive a list for the org that I was logged into.
```
./_output/bin/darwin_arm64/up alpha web-login
taylor logged in

./_output/bin/darwin_arm64/up space list
NAME                    MODE        PROVIDER   REGION
upbound-legacy-gcp      legacy      gcp        us-central-1
upbound-gcp-us-west-1   managed     gcp        us-west-1
upbound-aws-us-east-1   managed     aws        us-east-1
attached-gjsf9          connected
attached-mmdmz          connected
borrelli-self-hosted    connected
bulat-kind-space        connected
erhan-test-space        connected
ezgi-space              connected
michael-test            connected
milo-space-2            connected
milo-space-3            connected
sumbrizzle              connected

```
3. Logged out and attempted to list spaces again:
```
./_output/bin/darwin_arm64/up logout
taylor logged out

./_output/bin/darwin_arm64/up space list
You must be logged in and authorized to list Upbound Cloud Spaces
```
4. Verified that I could still install a space into a kind cluster.
