### PR TITLE
Update breadcrumbs colors and format

### DIFF
--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -29,8 +29,8 @@ import (
 
 var (
 	itemStyle         = lipgloss.NewStyle()
-	kindStyle         = lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(8))
-	selectedItemStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
+	kindStyle         = lipgloss.NewStyle().Foreground(neutralColor)
+	selectedItemStyle = lipgloss.NewStyle().Foreground(upboundBrandColor)
 )
 
 var backNavBinding = key.NewBinding(

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -229,7 +229,7 @@ func (s *Space) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 
 	items := make([]list.Item, 0, len(nss.Items)+1)
 	if s.CanBack() {
-		items = append(items, item{text: "..", kind: "profiles", onEnter: s.Back, back: true})
+		items = append(items, item{text: "..", kind: "spaces", onEnter: s.Back, back: true})
 	}
 	for _, ns := range nss.Items {
 		items = append(items, item{text: ns.Name, kind: "group", onEnter: func(m model) (model, error) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Update `up ctx` styles and breadcrumb format:
- All purple has been changed to use Upbound brand purple
- The breadcrumbs path now follows the same convention as `up ctx <path>` eg. `upbound/upbound-aws-us-east-1/group/ctp`

Screenshots!

Dark mode

![image](https://github.com/upbound/up/assets/1841682/c1b8d101-bd11-4013-9b31-63a54accda68)

![image](https://github.com/upbound/up/assets/1841682/7a224faa-b14d-4f39-8ecd-a1bd993ccbbc)

Light mode

![image](https://github.com/upbound/up/assets/1841682/379159a5-6c6d-48c1-b4a1-b449411af620)

![image](https://github.com/upbound/up/assets/1841682/000295e0-1dc1-4de8-b417-52f0ae691be5)

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Look at the beautiful screenshots
