### PR TITLE
Use `up` in exec if in PATH

### DIFF
--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -17,6 +17,7 @@ package ctx
 import (
 	"context"
 	"os"
+	"os/exec"
 	"sort"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -33,7 +34,6 @@ import (
 	"github.com/upbound/up-sdk-go/service/organizations"
 	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
-	"github.com/upbound/up/internal/version"
 )
 
 var (
@@ -386,16 +386,16 @@ func buildSpacesClient(ingress string, ca []byte, authInfo *clientcmdapi.AuthInf
 }
 
 func getOrgScopedAuthInfo(upCtx *upbound.Context, orgName string) (*clientcmdapi.AuthInfo, error) {
-	var cmd string
-	switch version.GetReleaseTarget() {
-	case version.ReleaseTargetRelease:
+	// find the current executable path
+	cmd, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	// if the current executable was the same `up` that is found in PATH
+	path, err := exec.LookPath("up")
+	if err == nil && path == cmd {
 		cmd = "up"
-	case version.ReleaseTargetDebug:
-		var err error
-		cmd, err = os.Executable()
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return &clientcmdapi.AuthInfo{


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fixes https://github.com/upbound/up/issues/490

The current logic for setting path to `up` in the Kubeconfig AuthInfo exec switches depending on the target release version. If we are on the `release` build, then use `"up"`. If we are on the `debug` build, then use the current executable path. This has unfortunate side effects when customers use `up` but don't have the CLI in `PATH` - the AuthInfo won't ever be able to resolve the exec.

This change standardises the mechanism regardless of release target. The AuthInfo will always fall back to the full path of the `up` executable, unless we can guarantee we're running it from `PATH`.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~~

### How has this code been tested

Running from `PATH`:
```yaml
$ up ctx acmeco/upbound-gcp-us-west-1/default --profile production -f -
...
users:
- name: upbound
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - organization
      - token
      command: up
...
```

Running from pwd:
```yaml
$ ./up ctx upbound/upbound-gcp-us-west-1/nicks-group -f -
...
users:
- name: upbound
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - organization
      - token
      command: /Users/nicholasthomson/Workspace/up/_output/bin/darwin_arm64/up
...
```