### PR TITLE
Remove deletion protection label/flag from group create

### DIFF
--- a/cmd/up/group/create.go
+++ b/cmd/up/group/create.go
@@ -16,22 +16,19 @@ package group
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/pterm/pterm"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
 
 // createCmd creates a group in a space.
 type createCmd struct {
-	Name               string `arg:"" required:"" help:"Name of group."`
-	DeletionProtection bool   `name:"deletion-protection" optional:"" default:"false" help:"Enable deletion protection on the new group." negatable:""`
+	Name string `arg:"" required:"" help:"Name of group."`
 }
 
 // Run executes the create command.
@@ -40,9 +37,6 @@ func (c *createCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx
 	group := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.Name,
-			Labels: map[string]string{
-				spacesv1beta1.ControlPlaneGroupProtectionKey: strconv.FormatBool(c.DeletionProtection),
-			},
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

This PR removes setting the deletion protection label on groups during create. After the discussion this morning, it was decided this should not be set via the CLI.

Fixes https://github.com/upbound/up/issues/475

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
ran `up group create` against a cloud space