### PR TITLE
Derive state from extensions

### DIFF
--- a/cmd/up/ctx/cmd_test.go
+++ b/cmd/up/ctx/cmd_test.go
@@ -16,18 +16,64 @@ package ctx
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/upbound/up/internal/upbound"
+)
+
+const (
+	hubCA = `
+-----BEGIN CERTIFICATE-----
+MIIDNzCCAh+gAwIBAgIIMPmY2QCCgcYwDQYJKoZIhvcNAQELBQAwIjEgMB4GA1UE
+AwwXMTI3LjAuMC4xLWNhQDE2OTkxOTMzMzgwIBcNMjMxMTA1MTMwODU4WhgPMjEy
+MzEwMTIxMzA4NThaMB8xHTAbBgNVBAMMFDEyNy4wLjAuMUAxNjk5MTkzMzM4MIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzPVMYesXhGL3YQlmNeft2oIg
+CmfXQaJee34G4OL7G8NIjkU9XJVhqLGtU/gNRY9+vB/k8NZLF+xipJT5GVzFMu+o
+tJeMHuFYB+2iMNINPMWhEAOqa9kSGDsUzH2gZVjZZiz/paWf54iAGW0L5urXLqFh
+hTsHGvIk8qdln3HxxNN3nwB+6jXjzbGSJ7XLYFiQcsCtjbyzFNxdnMuYeNbOvxK/
+GWCWF27NP1/vT+7XudcrXvtDcgqG5Zf4oq45Wheeo1vZaYJUOX29zpMX4cZ7KnKp
+bDOSTW9KHeRP8YpPa6tnq0Irpj2FNEha/ouJRYxXN7ACzKmChR3fn24k9n8P5QID
+AQABo3IwcDAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYD
+VR0TAQH/BAIwADAfBgNVHSMEGDAWgBQJUtOqYZLkhCSCT3ILBfptuUZMaTAaBgNV
+HREEEzARgglsb2NhbGhvc3SHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBAJb7OSze
++Zq+fPS1wQ2YKELtLtJ2r49VdgC+UMxw0pggEID1dRM+A9jm3m7mA099OpmQK9AO
+TlFKZHtZl+PV6oTA5Wd7gg9YUNenECgcHfMVJvtr5ctH+ynVGrPbxXSrJBWuxBZk
+bmTQVoNz1SdOXn1aRjqH6GgDQJh8UZUMjlmusYGoWHt/vFRcJS8fY6M3ANf7OGFd
+cuRD2TNaJprYCB9Q7yvybTNYOh2STnTyzRxM2vxmYmGtyOVW5Eu6Ut5VPS/Jgli1
+LAOjVgGvSuiuM72Cr2qQgc7Q5ke4M0DG90Qr/DZMSlc4US1Ba++cy3+8n3puxbIg
+9X+1x5wP0N2O06Y=
+-----END CERTIFICATE-----
+`
+	ingressCA = `
+-----BEGIN CERTIFICATE-----
+MIIDCjCCAfKgAwIBAgIIGB6xU7MT5AAwDQYJKoZIhvcNAQELBQAwIjEgMB4GA1UE
+AwwXMTI3LjAuMC4xLWNhQDE2OTkxOTMzMzgwIBcNMjMxMTA1MTMwODU4WhgPMjEy
+MzEwMTIxMzA4NThaMCIxIDAeBgNVBAMMFzEyNy4wLjAuMS1jYUAxNjk5MTkzMzM4
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0OHCeG2uTE4y6ce98V/3
+6M/jnVxcYYNSSciAHAlLEIyrCzQbsGWWcdaAMsXhlJ2ZrXLMV8pRYCqNpVzA981T
+YK1ODuJfCaOldppb9HPrw3Q7rTVLxjGBL5T0gnaPsxqglVS3hBAbkPtuOGV0Fl/Z
+JMJcYR4WUxe0jyLwD4+tftT2Rso72wGMqhItSF4EqbLd3vf7qWgjFgFNL4Ggqsy4
+hDWmOQNg1CGOGa2140JKDhqIBZ23Xefns2yaZ8u/F14jyjmJ/BwTAywRB+0RwtjZ
+HAAIocu3XKUoJeQO1dvT91YrzQ+THHA5W6XMonnYZj0majkWG5fqqDEmtky8lHWm
+XQIDAQABo0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAdBgNV
+HQ4EFgQUCVLTqmGS5IQkgk9yCwX6bblGTGkwDQYJKoZIhvcNAQELBQADggEBADtq
+EpQ5jEnr4vepbeZ2QCyX/2OxdSKlWzK2YA1cMThooQKbGZ43POa15n4lD6uMViXy
+yZTbzP8sWQ3kJpj252pm9KuO8uv3w5zxgL/aVdu6+k/EzpWab2jsR7Fzuj3dDYTM
+aU88g5QpmUX3xtP7HqVwl+LzZuZpM8U7il8PWGyraDnniSAYfp9pp5lViPN2IPP9
+ORaAbHyljalRFcjEDBwZtSBo3zcaA12uKtaEoFZShU0PDKCFCJ1weyqEI/Jmoays
+xPWjLExASVeAdNehjgFcrfoc7ZWtJYeE42his0athGjS/fNK7PnjijpZn6h76hRB
+92l9SyA6+IXPGFmjFUU=
+-----END CERTIFICATE-----
+`
 )
 
 func TestSwapContext(t *testing.T) {
@@ -311,171 +357,493 @@ func TestSwapContext(t *testing.T) {
 	}
 }
 
-func TestDeriveState(t *testing.T) {
-	hubCA := `
------BEGIN CERTIFICATE-----
-MIIDNzCCAh+gAwIBAgIIMPmY2QCCgcYwDQYJKoZIhvcNAQELBQAwIjEgMB4GA1UE
-AwwXMTI3LjAuMC4xLWNhQDE2OTkxOTMzMzgwIBcNMjMxMTA1MTMwODU4WhgPMjEy
-MzEwMTIxMzA4NThaMB8xHTAbBgNVBAMMFDEyNy4wLjAuMUAxNjk5MTkzMzM4MIIB
-IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzPVMYesXhGL3YQlmNeft2oIg
-CmfXQaJee34G4OL7G8NIjkU9XJVhqLGtU/gNRY9+vB/k8NZLF+xipJT5GVzFMu+o
-tJeMHuFYB+2iMNINPMWhEAOqa9kSGDsUzH2gZVjZZiz/paWf54iAGW0L5urXLqFh
-hTsHGvIk8qdln3HxxNN3nwB+6jXjzbGSJ7XLYFiQcsCtjbyzFNxdnMuYeNbOvxK/
-GWCWF27NP1/vT+7XudcrXvtDcgqG5Zf4oq45Wheeo1vZaYJUOX29zpMX4cZ7KnKp
-bDOSTW9KHeRP8YpPa6tnq0Irpj2FNEha/ouJRYxXN7ACzKmChR3fn24k9n8P5QID
-AQABo3IwcDAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDAYD
-VR0TAQH/BAIwADAfBgNVHSMEGDAWgBQJUtOqYZLkhCSCT3ILBfptuUZMaTAaBgNV
-HREEEzARgglsb2NhbGhvc3SHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBAJb7OSze
-+Zq+fPS1wQ2YKELtLtJ2r49VdgC+UMxw0pggEID1dRM+A9jm3m7mA099OpmQK9AO
-TlFKZHtZl+PV6oTA5Wd7gg9YUNenECgcHfMVJvtr5ctH+ynVGrPbxXSrJBWuxBZk
-bmTQVoNz1SdOXn1aRjqH6GgDQJh8UZUMjlmusYGoWHt/vFRcJS8fY6M3ANf7OGFd
-cuRD2TNaJprYCB9Q7yvybTNYOh2STnTyzRxM2vxmYmGtyOVW5Eu6Ut5VPS/Jgli1
-LAOjVgGvSuiuM72Cr2qQgc7Q5ke4M0DG90Qr/DZMSlc4US1Ba++cy3+8n3puxbIg
-9X+1x5wP0N2O06Y=
------END CERTIFICATE-----
-`
-	ingressCA := `
------BEGIN CERTIFICATE-----
-MIIDCjCCAfKgAwIBAgIIGB6xU7MT5AAwDQYJKoZIhvcNAQELBQAwIjEgMB4GA1UE
-AwwXMTI3LjAuMC4xLWNhQDE2OTkxOTMzMzgwIBcNMjMxMTA1MTMwODU4WhgPMjEy
-MzEwMTIxMzA4NThaMCIxIDAeBgNVBAMMFzEyNy4wLjAuMS1jYUAxNjk5MTkzMzM4
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0OHCeG2uTE4y6ce98V/3
-6M/jnVxcYYNSSciAHAlLEIyrCzQbsGWWcdaAMsXhlJ2ZrXLMV8pRYCqNpVzA981T
-YK1ODuJfCaOldppb9HPrw3Q7rTVLxjGBL5T0gnaPsxqglVS3hBAbkPtuOGV0Fl/Z
-JMJcYR4WUxe0jyLwD4+tftT2Rso72wGMqhItSF4EqbLd3vf7qWgjFgFNL4Ggqsy4
-hDWmOQNg1CGOGa2140JKDhqIBZ23Xefns2yaZ8u/F14jyjmJ/BwTAywRB+0RwtjZ
-HAAIocu3XKUoJeQO1dvT91YrzQ+THHA5W6XMonnYZj0majkWG5fqqDEmtky8lHWm
-XQIDAQABo0IwQDAOBgNVHQ8BAf8EBAMCAqQwDwYDVR0TAQH/BAUwAwEB/zAdBgNV
-HQ4EFgQUCVLTqmGS5IQkgk9yCwX6bblGTGkwDQYJKoZIhvcNAQELBQADggEBADtq
-EpQ5jEnr4vepbeZ2QCyX/2OxdSKlWzK2YA1cMThooQKbGZ43POa15n4lD6uMViXy
-yZTbzP8sWQ3kJpj252pm9KuO8uv3w5zxgL/aVdu6+k/EzpWab2jsR7Fzuj3dDYTM
-aU88g5QpmUX3xtP7HqVwl+LzZuZpM8U7il8PWGyraDnniSAYfp9pp5lViPN2IPP9
-ORaAbHyljalRFcjEDBwZtSBo3zcaA12uKtaEoFZShU0PDKCFCJ1weyqEI/Jmoays
-xPWjLExASVeAdNehjgFcrfoc7ZWtJYeE42his0athGjS/fNK7PnjijpZn6h76hRB
-92l9SyA6+IXPGFmjFUU=
------END CERTIFICATE-----
-`
+// func TestDeriveState(t *testing.T) {
+// 	ingressPublicNotFound := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 		return "", nil, errors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "ingress-public")
+// 	}
+// 	ingressUnknownKind := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 		return "", nil, &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "ConfigMap"}}
+// 	}
+// 	authOrgExec, _ := getOrgScopedAuthInfo(&upbound.Context{ProfileName: "profile"}, "org")
 
+// 	tests := map[string]struct {
+// 		conf           clientcmdapi.Config
+// 		getIngressHost func(ctx context.Context, cl client.Client) (host string, ca []byte, err error)
+
+// 		want    NavigationState
+// 		wantErr string
+// 	}{
+// 		"HubWithoutIngressPublic": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "hub",
+// 				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "hub"}},
+// 				Clusters:       map[string]*clientcmdapi.Cluster{"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)}},
+// 				AuthInfos:      map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+// 			},
+// 			getIngressHost: ingressPublicNotFound,
+// 			want:           &Root{},
+// 			wantErr:        "<nil>",
+// 		},
+// 		"HubWithIngressPublic": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "hub",
+// 				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "hub"}},
+// 				Clusters:       map[string]*clientcmdapi.Cluster{"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)}},
+// 				AuthInfos:      map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+// 			},
+// 			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 				return "https://ingress", []byte(ingressCA), nil
+// 			},
+// 			want: &Group{
+// 				Space: Space{
+// 					Name:    "hub",
+// 					Ingress: "https://ingress",
+// 					CA:      []byte(ingressCA),
+// 					AuthInfo: &clientcmdapi.AuthInfo{
+// 						Token: "token",
+// 					},
+// 				},
+// 				Name: "default",
+// 			},
+// 			wantErr: "<nil>",
+// 		},
+// 		"IngressWithIngressPublic": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "ingress",
+// 				Contexts:       map[string]*clientcmdapi.Context{"ingress": {Namespace: "default", Cluster: "ingress", AuthInfo: "hub"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"hub":     {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
+// 					"ingress": {Server: "https://ingress", CertificateAuthorityData: []byte(ingressCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+// 			},
+// 			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 				return "https://ingress", []byte(ingressCA), nil
+// 			},
+// 			want: &Group{
+// 				Space: Space{
+// 					Name:    "ingress",
+// 					Ingress: "https://ingress",
+// 					CA:      []byte(ingressCA),
+// 					AuthInfo: &clientcmdapi.AuthInfo{
+// 						Token: "token",
+// 					},
+// 				},
+// 				Name: "default",
+// 			},
+// 			wantErr: "<nil>",
+// 		},
+// 		"WithoutNamespace": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "ingress",
+// 				Contexts:       map[string]*clientcmdapi.Context{"ingress": {Namespace: "", Cluster: "ingress", AuthInfo: "hub"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"hub":     {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
+// 					"ingress": {Server: "https://ingress", CertificateAuthorityData: []byte(ingressCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+// 			},
+// 			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 				return "https://ingress", []byte(ingressCA), nil
+// 			},
+// 			want: &Space{
+// 				Ingress: "https://ingress",
+// 				CA:      []byte(ingressCA),
+// 				AuthInfo: &clientcmdapi.AuthInfo{
+// 					Token: "token",
+// 				},
+// 				Name: "ingress",
+// 			},
+// 			wantErr: "<nil>",
+// 		},
+// 		"ControlPlane": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "ctp1",
+// 				Contexts:       map[string]*clientcmdapi.Context{"ctp1": {Namespace: "default", Cluster: "ctp1", AuthInfo: "hub"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"hub":     {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
+// 					"ingress": {Server: "https://ingress", CertificateAuthorityData: []byte(ingressCA)},
+// 					"ctp1":    {Server: "https://ingress/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp1/k8s", CertificateAuthorityData: []byte(ingressCA)},
+// 					"ctp2":    {Server: "https://ingress/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp2/k8s", CertificateAuthorityData: []byte(ingressCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": authOrgExec},
+// 			},
+// 			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 				return "https://ingress", []byte(ingressCA), nil
+// 			},
+// 			want: &ControlPlane{
+// 				Group: Group{
+// 					Space: Space{
+// 						Ingress:  "https://ingress",
+// 						CA:       []byte(ingressCA),
+// 						AuthInfo: authOrgExec,
+// 						Name:     "ctp1",
+// 					},
+// 					Name: "default",
+// 				},
+// 				Name: "ctp1",
+// 			},
+// 			wantErr: "<nil>",
+// 		},
+// 		"CloudSpace": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "upbound",
+// 				Contexts:       map[string]*clientcmdapi.Context{"upbound": {Namespace: "default", Cluster: "upbound", AuthInfo: "upbound"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"upbound": {Server: "https://eu-west-1.ibm-cloud.com", CertificateAuthorityData: []byte(ingressCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": authOrgExec},
+// 			},
+// 			getIngressHost: ingressPublicNotFound,
+// 			want: &Group{
+// 				Space: Space{
+// 					Org: Organization{
+// 						Name: "org",
+// 					},
+// 					Name:     "eu-west-1", // TODO: where does this come from?
+// 					Ingress:  "eu-west-1.ibm-cloud.com",
+// 					CA:       []byte(ingressCA),
+// 					AuthInfo: authOrgExec,
+// 				},
+// 				Name: "default",
+// 			},
+// 			wantErr: "<nil>",
+// 		},
+// 		"CloudControlPlane": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "upbound",
+// 				Contexts:       map[string]*clientcmdapi.Context{"upbound": {Namespace: "default", Cluster: "upbound", AuthInfo: "upbound"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"upbound": {Server: "https://eu-west-1.ibm-cloud.com/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp1/k8s", CertificateAuthorityData: []byte(ingressCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": authOrgExec},
+// 			},
+// 			getIngressHost: ingressUnknownKind,
+// 			want: &ControlPlane{
+// 				Group: Group{
+// 					Space: Space{
+// 						Org: Organization{
+// 							Name: "org",
+// 						},
+// 						Name:     "eu-west-1",
+// 						Ingress:  "eu-west-1.ibm-cloud.com",
+// 						CA:       []byte(ingressCA),
+// 						AuthInfo: authOrgExec,
+// 					},
+// 					Name: "default",
+// 				},
+// 				Name: "ctp1",
+// 			},
+// 			wantErr: "<nil>",
+// 		},
+// 		"UnknownCluster": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "hub",
+// 				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "invalid", AuthInfo: "hub"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+// 			},
+// 			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 				return "https://ingress", []byte(ingressCA), nil
+// 			},
+// 			want:    nil,
+// 			wantErr: `invalid configuration: cluster "invalid" was not found for context "hub"`,
+// 		},
+// 		"UnknownAuthInfo": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "hub",
+// 				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "invalid"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+// 			},
+// 			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 				return "https://ingress", []byte(ingressCA), nil
+// 			},
+// 			want:    nil,
+// 			wantErr: `invalid configuration: user "invalid" was not found for context "hub"`,
+// 		},
+// 		"UnknownContext": {
+// 			conf: clientcmdapi.Config{
+// 				CurrentContext: "invalid",
+// 				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "hub"}},
+// 				Clusters: map[string]*clientcmdapi.Cluster{
+// 					"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
+// 				},
+// 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+// 			},
+// 			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+// 				return "https://ingress", []byte(ingressCA), nil
+// 			},
+// 			want:    nil, // or do we want an error?
+// 			wantErr: `invalid configuration: context was not found for specified context: invalid`,
+// 		},
+// 	}
+// 	for name, tt := range tests {
+// 		t.Run(name, func(t *testing.T) {
+// 			upCtx := &upbound.Context{
+// 				Kubecfg: clientcmd.NewDefaultClientConfig(tt.conf, nil),
+// 			}
+// 			got, err := deriveState(context.Background(), upCtx, &tt.conf, tt.getIngressHost)
+// 			if diff := cmp.Diff(tt.wantErr, fmt.Sprintf("%v", err)); diff != "" {
+// 				t.Fatalf("DeriveState(...): -want err, +got err:\n%s", diff)
+// 			}
+// 			if diff := cmp.Diff(tt.want, got); diff != "" {
+// 				t.Errorf("swapContext(...): -want conf, +got conf:\n%s", diff)
+// 			}
+// 		})
+// 	}
+// }
+
+func TestDeriveNewState(t *testing.T) {
+	hubAuth := clientcmdapi.AuthInfo{}
+
+	ingressFound := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+		return "eu-west-1.ibm-cloud.com", []byte(ingressCA), nil
+	}
 	ingressPublicNotFound := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-		return "", nil, errors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "ingress-public")
+		return "", nil, kerrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "ingress-public")
 	}
-	ingressUnknownKind := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-		return "", nil, &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "ConfigMap"}}
+	ingressErr := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+		return "", nil, errors.New("unknown error!")
 	}
-	authOrgExec, _ := getOrgScopedAuthInfo(&upbound.Context{ProfileName: "profile"}, "org")
 
 	tests := map[string]struct {
 		conf           clientcmdapi.Config
-		getIngressHost func(ctx context.Context, cl client.Client) (host string, ca []byte, err error)
+		getIngressHost getIngressHostFn
 
 		want    NavigationState
 		wantErr string
 	}{
-		"HubWithoutIngressPublic": {
+		"NoCurrentContext": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "",
+				Contexts: map[string]*clientcmdapi.Context{
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"hub": {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
+			},
+			getIngressHost: ingressFound,
+			want:           &Root{},
+			wantErr:        "<nil>",
+		},
+		"InvalidCurrentContext": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "noexist",
+				Contexts: map[string]*clientcmdapi.Context{
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"hub": {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
+			},
+			getIngressHost: ingressFound,
+			want:           &Root{},
+			wantErr:        "<nil>",
+		},
+		"NoIngressFound": {
 			conf: clientcmdapi.Config{
 				CurrentContext: "hub",
-				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "hub"}},
-				Clusters:       map[string]*clientcmdapi.Cluster{"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)}},
-				AuthInfos:      map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+				Contexts: map[string]*clientcmdapi.Context{
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"hub": {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
 			},
 			getIngressHost: ingressPublicNotFound,
 			want:           &Root{},
 			wantErr:        "<nil>",
 		},
-		"HubWithIngressPublic": {
+		"GetIngressError": {
 			conf: clientcmdapi.Config{
 				CurrentContext: "hub",
-				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "hub"}},
-				Clusters:       map[string]*clientcmdapi.Cluster{"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)}},
-				AuthInfos:      map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
-			},
-			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-				return "https://ingress", []byte(ingressCA), nil
-			},
-			want: &Group{
-				Space: Space{
-					Name:    "hub",
-					Ingress: "https://ingress",
-					CA:      []byte(ingressCA),
-					AuthInfo: &clientcmdapi.AuthInfo{
-						Token: "token",
+				Contexts: map[string]*clientcmdapi.Context{
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
 					},
 				},
-				Name: "default",
-			},
-			wantErr: "<nil>",
-		},
-		"IngressWithIngressPublic": {
-			conf: clientcmdapi.Config{
-				CurrentContext: "ingress",
-				Contexts:       map[string]*clientcmdapi.Context{"ingress": {Namespace: "default", Cluster: "ingress", AuthInfo: "hub"}},
 				Clusters: map[string]*clientcmdapi.Cluster{
-					"hub":     {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
-					"ingress": {Server: "https://ingress", CertificateAuthorityData: []byte(ingressCA)},
+					"hub": {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
 				},
-				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
 			},
-			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-				return "https://ingress", []byte(ingressCA), nil
-			},
-			want: &Group{
-				Space: Space{
-					Name:    "ingress",
-					Ingress: "https://ingress",
-					CA:      []byte(ingressCA),
-					AuthInfo: &clientcmdapi.AuthInfo{
-						Token: "token",
+			getIngressHost: ingressErr,
+			want:           &Root{},
+			wantErr:        "<nil>",
+		},
+		"SpaceFound": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "hub",
+				Contexts: map[string]*clientcmdapi.Context{
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
 					},
 				},
-				Name: "default",
-			},
-			wantErr: "<nil>",
-		},
-		"WithoutNamespace": {
-			conf: clientcmdapi.Config{
-				CurrentContext: "ingress",
-				Contexts:       map[string]*clientcmdapi.Context{"ingress": {Namespace: "", Cluster: "ingress", AuthInfo: "hub"}},
 				Clusters: map[string]*clientcmdapi.Cluster{
-					"hub":     {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
-					"ingress": {Server: "https://ingress", CertificateAuthorityData: []byte(ingressCA)},
+					"hub": {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
 				},
-				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
 			},
-			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-				return "https://ingress", []byte(ingressCA), nil
-			},
+			getIngressHost: ingressFound,
 			want: &Space{
-				Ingress: "https://ingress",
-				CA:      []byte(ingressCA),
-				AuthInfo: &clientcmdapi.AuthInfo{
-					Token: "token",
-				},
-				Name: "ingress",
+				Org:        Organization{},
+				Name:       "hub",
+				Ingress:    "eu-west-1.ibm-cloud.com",
+				CA:         []byte(ingressCA),
+				HubContext: "hub",
 			},
 			wantErr: "<nil>",
 		},
-		"ControlPlane": {
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := DeriveNewState(context.Background(), &tt.conf, tt.getIngressHost)
+			if diff := cmp.Diff(tt.wantErr, fmt.Sprintf("%v", err)); diff != "" {
+				t.Fatalf("DeriveNewState(...): -want err, +got err:\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("DeriveNewState(...): -want conf, +got conf:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeriveExistingDisconnectedState(t *testing.T) {
+	hubAuth := clientcmdapi.AuthInfo{}
+
+	ingressFound := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+		return "eu-west-1.ibm-cloud.com", []byte(ingressCA), nil
+	}
+
+	buildDisconnectedExtension := func(hubCtx string) DisconnectedConfiguration {
+		return DisconnectedConfiguration{
+			HubContext: hubCtx,
+		}
+	}
+
+	tests := map[string]struct {
+		conf           clientcmdapi.Config
+		dcConfig       DisconnectedConfiguration
+		getIngressHost getIngressHostFn
+
+		want    NavigationState
+		wantErr string
+	}{
+		"UnknownHubCluster": {
 			conf: clientcmdapi.Config{
-				CurrentContext: "ctp1",
-				Contexts:       map[string]*clientcmdapi.Context{"ctp1": {Namespace: "default", Cluster: "ctp1", AuthInfo: "hub"}},
-				Clusters: map[string]*clientcmdapi.Cluster{
-					"hub":     {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
-					"ingress": {Server: "https://ingress", CertificateAuthorityData: []byte(ingressCA)},
-					"ctp1":    {Server: "https://ingress/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp1/k8s", CertificateAuthorityData: []byte(ingressCA)},
-					"ctp2":    {Server: "https://ingress/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp2/k8s", CertificateAuthorityData: []byte(ingressCA)},
+				CurrentContext: "upbound",
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "group",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
 				},
-				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": authOrgExec},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"hub": {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
 			},
-			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-				return "https://ingress", []byte(ingressCA), nil
+			getIngressHost: ingressFound,
+			dcConfig:       buildDisconnectedExtension("noexist"),
+			want:           nil,
+			wantErr:        `cannot find space hub context "noexist"`,
+		},
+		"DisconnectedGroup": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "upbound",
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "group",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"hub": {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
 			},
+			getIngressHost: ingressFound,
+			dcConfig:       buildDisconnectedExtension("hub"),
+			want: &Group{
+				Space: Space{
+					Org:        Organization{},
+					Name:       "hub",
+					Ingress:    "eu-west-1.ibm-cloud.com",
+					CA:         []byte(ingressCA),
+					HubContext: "hub",
+				},
+				Name: "group",
+			},
+			wantErr: "<nil>",
+		},
+		"DisconnectedControlPlane": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "upbound",
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "default",
+						Cluster:   "upbound",
+						AuthInfo:  "hub",
+					},
+					"hub": {
+						Namespace: "default",
+						Cluster:   "hub",
+						AuthInfo:  "hub",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"hub":     {Server: "https://hub:1234", CertificateAuthorityData: []byte(hubCA)},
+					"upbound": {Server: "https://eu-west-1.ibm-cloud.com/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp1/k8s", CertificateAuthorityData: []byte(ingressCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": &hubAuth},
+			},
+			getIngressHost: ingressFound,
+			dcConfig:       buildDisconnectedExtension("hub"),
 			want: &ControlPlane{
 				Group: Group{
 					Space: Space{
-						Ingress:  "https://ingress",
-						CA:       []byte(ingressCA),
-						AuthInfo: authOrgExec,
-						Name:     "ctp1",
+						Org:        Organization{},
+						Name:       "hub",
+						Ingress:    "eu-west-1.ibm-cloud.com",
+						CA:         []byte(ingressCA),
+						HubContext: "hub",
 					},
 					Name: "default",
 				},
@@ -483,22 +851,100 @@ xPWjLExASVeAdNehjgFcrfoc7ZWtJYeE42his0athGjS/fNK7PnjijpZn6h76hRB
 			},
 			wantErr: "<nil>",
 		},
-		"CloudSpace": {
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			upCtx := &upbound.Context{
+				Kubecfg: clientcmd.NewDefaultClientConfig(tt.conf, nil),
+			}
+			got, err := DeriveExistingDisconnectedState(context.Background(), upCtx, &tt.conf, &tt.dcConfig, tt.getIngressHost)
+			if diff := cmp.Diff(tt.wantErr, fmt.Sprintf("%v", err)); diff != "" {
+				t.Fatalf("DeriveExistingDisconnectedState(...): -want err, +got err:\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("DeriveExistingDisconnectedState(...): -want conf, +got conf:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDeriveExistingCloudState(t *testing.T) {
+	authOrgExec, _ := getOrgScopedAuthInfo(&upbound.Context{ProfileName: "profile"}, "org")
+
+	buildCloudExtension := func(org string) CloudConfiguration {
+		return CloudConfiguration{
+			Organization: org,
+		}
+	}
+
+	tests := map[string]struct {
+		conf        clientcmdapi.Config
+		cloudConfig CloudConfiguration
+
+		want    NavigationState
+		wantErr string
+	}{
+		"InvalidCluster": {
 			conf: clientcmdapi.Config{
 				CurrentContext: "upbound",
-				Contexts:       map[string]*clientcmdapi.Context{"upbound": {Namespace: "default", Cluster: "upbound", AuthInfo: "upbound"}},
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "default",
+						Cluster:   "upbound",
+						AuthInfo:  "upbound",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					// cluster is missing a `Server`
+					"upbound": {CertificateAuthorityData: []byte(ingressCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": authOrgExec},
+			},
+			cloudConfig: buildCloudExtension("org"),
+			want:        nil,
+			wantErr:     errParseSpaceContext.Error(),
+		},
+		"UnknownOrganization": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "upbound",
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "default",
+						Cluster:   "upbound",
+						AuthInfo:  "upbound",
+					},
+				},
 				Clusters: map[string]*clientcmdapi.Cluster{
 					"upbound": {Server: "https://eu-west-1.ibm-cloud.com", CertificateAuthorityData: []byte(ingressCA)},
 				},
 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": authOrgExec},
 			},
-			getIngressHost: ingressPublicNotFound,
+			cloudConfig: buildCloudExtension(""),
+			want:        &Root{},
+			wantErr:     "<nil>",
+		},
+		"CloudSpace": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "upbound",
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "default",
+						Cluster:   "upbound",
+						AuthInfo:  "upbound",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"upbound": {Server: "https://eu-west-1.ibm-cloud.com", CertificateAuthorityData: []byte(ingressCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": authOrgExec},
+			},
+			cloudConfig: buildCloudExtension("org"),
 			want: &Group{
 				Space: Space{
 					Org: Organization{
 						Name: "org",
 					},
-					Name:     "eu-west-1", // TODO: where does this come from?
+					Name:     "eu-west-1",
 					Ingress:  "eu-west-1.ibm-cloud.com",
 					CA:       []byte(ingressCA),
 					AuthInfo: authOrgExec,
@@ -507,16 +953,52 @@ xPWjLExASVeAdNehjgFcrfoc7ZWtJYeE42his0athGjS/fNK7PnjijpZn6h76hRB
 			},
 			wantErr: "<nil>",
 		},
+		"CloudGroup": {
+			conf: clientcmdapi.Config{
+				CurrentContext: "upbound",
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "group",
+						Cluster:   "upbound",
+						AuthInfo:  "upbound",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"upbound": {Server: "https://eu-west-1.ibm-cloud.com", CertificateAuthorityData: []byte(ingressCA)},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": authOrgExec},
+			},
+			cloudConfig: buildCloudExtension("org"),
+			want: &Group{
+				Space: Space{
+					Org: Organization{
+						Name: "org",
+					},
+					Name:     "eu-west-1",
+					Ingress:  "eu-west-1.ibm-cloud.com",
+					CA:       []byte(ingressCA),
+					AuthInfo: authOrgExec,
+				},
+				Name: "group",
+			},
+			wantErr: "<nil>",
+		},
 		"CloudControlPlane": {
 			conf: clientcmdapi.Config{
 				CurrentContext: "upbound",
-				Contexts:       map[string]*clientcmdapi.Context{"upbound": {Namespace: "default", Cluster: "upbound", AuthInfo: "upbound"}},
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {
+						Namespace: "default",
+						Cluster:   "upbound",
+						AuthInfo:  "upbound",
+					},
+				},
 				Clusters: map[string]*clientcmdapi.Cluster{
 					"upbound": {Server: "https://eu-west-1.ibm-cloud.com/apis/spaces.upbound.io/v1beta1/namespaces/default/controlplanes/ctp1/k8s", CertificateAuthorityData: []byte(ingressCA)},
 				},
 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": authOrgExec},
 			},
-			getIngressHost: ingressUnknownKind,
+			cloudConfig: buildCloudExtension("org"),
 			want: &ControlPlane{
 				Group: Group{
 					Space: Space{
@@ -534,63 +1016,18 @@ xPWjLExASVeAdNehjgFcrfoc7ZWtJYeE42his0athGjS/fNK7PnjijpZn6h76hRB
 			},
 			wantErr: "<nil>",
 		},
-		"UnknownCluster": {
-			conf: clientcmdapi.Config{
-				CurrentContext: "hub",
-				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "invalid", AuthInfo: "hub"}},
-				Clusters: map[string]*clientcmdapi.Cluster{
-					"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
-				},
-				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
-			},
-			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-				return "https://ingress", []byte(ingressCA), nil
-			},
-			want:    nil,
-			wantErr: `invalid configuration: cluster "invalid" was not found for context "hub"`,
-		},
-		"UnknownAuthInfo": {
-			conf: clientcmdapi.Config{
-				CurrentContext: "hub",
-				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "invalid"}},
-				Clusters: map[string]*clientcmdapi.Cluster{
-					"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
-				},
-				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
-			},
-			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-				return "https://ingress", []byte(ingressCA), nil
-			},
-			want:    nil,
-			wantErr: `invalid configuration: user "invalid" was not found for context "hub"`,
-		},
-		"UnknownContext": {
-			conf: clientcmdapi.Config{
-				CurrentContext: "invalid",
-				Contexts:       map[string]*clientcmdapi.Context{"hub": {Namespace: "default", Cluster: "hub", AuthInfo: "hub"}},
-				Clusters: map[string]*clientcmdapi.Cluster{
-					"hub": {Server: "https://hub", CertificateAuthorityData: []byte(hubCA)},
-				},
-				AuthInfos: map[string]*clientcmdapi.AuthInfo{"hub": {Token: "token"}},
-			},
-			getIngressHost: func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-				return "https://ingress", []byte(ingressCA), nil
-			},
-			want:    nil, // or do we want an error?
-			wantErr: `invalid configuration: context was not found for specified context: invalid`,
-		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			upCtx := &upbound.Context{
 				Kubecfg: clientcmd.NewDefaultClientConfig(tt.conf, nil),
 			}
-			got, err := deriveState(context.Background(), upCtx, &tt.conf, tt.getIngressHost)
+			got, err := DeriveExistingCloudState(upCtx, &tt.conf, &tt.cloudConfig)
 			if diff := cmp.Diff(tt.wantErr, fmt.Sprintf("%v", err)); diff != "" {
-				t.Fatalf("DeriveState(...): -want err, +got err:\n%s", diff)
+				t.Fatalf("DeriveExistingCloudState(...): -want err, +got err:\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("swapContext(...): -want conf, +got conf:\n%s", diff)
+				t.Errorf("DeriveExistingCloudState(...): -want conf, +got conf:\n%s", diff)
 			}
 		})
 	}

--- a/cmd/up/ctx/extension_types.go
+++ b/cmd/up/ctx/extension_types.go
@@ -24,7 +24,7 @@ import (
 
 // DisconnectedConfiguration is the configuration for a disconnected space
 type DisconnectedConfiguration struct {
-	HubCluster string `json:"hubCluster"`
+	HubContext string `json:"hubContext"`
 }
 
 // CloudConfiguration is the configuration of a cloud space
@@ -69,7 +69,7 @@ func NewCloudV1Alpha1SpaceExtension(org string) *SpaceExtension {
 	}
 }
 
-func NewDisconnectedV1Alpha1SpaceExtension(hubCluster string) *SpaceExtension {
+func NewDisconnectedV1Alpha1SpaceExtension(hubContext string) *SpaceExtension {
 	return &SpaceExtension{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       SpaceExtensionKind,
@@ -77,7 +77,7 @@ func NewDisconnectedV1Alpha1SpaceExtension(hubCluster string) *SpaceExtension {
 		},
 		Spec: &SpaceExtensionSpec{
 			Disconnected: &DisconnectedConfiguration{
-				HubCluster: hubCluster,
+				HubContext: hubContext,
 			},
 		},
 	}

--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -200,7 +200,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { // nolint:gocyclo // T
 			return m, tea.Quit
 		case key.Matches(msg, quitBinding):
 			if state, ok := m.state.(Accepting); ok {
-				msg, err := state.Accept(m.contextWriter)
+				msg, err := state.Accept(m.upCtx, m.contextWriter)
 				if err != nil {
 					m.err = err
 					return m, nil

--- a/internal/profile/kubeconfig.go
+++ b/internal/profile/kubeconfig.go
@@ -16,6 +16,7 @@ package profile
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,5 +32,5 @@ func GetIngressHost(ctx context.Context, cl client.Client) (host string, ca []by
 	}
 	host = mxpConfig.Data["ingress-host"]
 	ca = []byte(mxpConfig.Data["ingress-ca"])
-	return host, ca, nil
+	return strings.TrimPrefix(host, "https://"), ca, nil
 }

--- a/internal/upbound/kube_context.go
+++ b/internal/upbound/kube_context.go
@@ -58,6 +58,17 @@ func (c *Context) BuildCurrentContextClient() (client.Client, error) {
 	return sc, nil
 }
 
+func (c *Context) GetCurrentContextName() (string, error) {
+	// todo: Add support for overriding current context as part of CLI args
+
+	config, err := c.Kubecfg.RawConfig()
+	if err != nil {
+		return "", err
+	}
+
+	return config.CurrentContext, nil
+}
+
 func (c *Context) GetCurrentContext() (context *clientcmdapi.Context, cluster *clientcmdapi.Cluster, auth *clientcmdapi.AuthInfo, exists bool) {
 	// todo: Add support for overriding current context as part of CLI args
 
@@ -86,7 +97,7 @@ func (c *Context) GetCurrentContext() (context *clientcmdapi.Context, cluster *c
 	return context, cluster, auth, exists
 }
 
-func (c *Context) GetCurrentSpaceContextScope() (string, types.NamespacedName, bool) {
+func (c *Context) GetCurrentSpaceContextScope() (ingressHost string, resource types.NamespacedName, exists bool) {
 	context, cluster, _, exists := c.GetCurrentContext()
 	if !exists {
 		return "", types.NamespacedName{}, false
@@ -99,7 +110,7 @@ func (c *Context) GetCurrentSpaceContextScope() (string, types.NamespacedName, b
 	base, nsn, exists := profile.ParseSpacesK8sURL(strings.TrimSuffix(cluster.Server, "/"))
 	// we are inside a ctp scope
 	if exists {
-		return base, nsn, exists
+		return strings.TrimPrefix(base, "https://"), nsn, exists
 	}
 
 	// we aren't inside a group scope
@@ -107,5 +118,5 @@ func (c *Context) GetCurrentSpaceContextScope() (string, types.NamespacedName, b
 		return "", types.NamespacedName{}, false
 	}
 
-	return cluster.Server, types.NamespacedName{Namespace: context.Namespace}, true
+	return strings.TrimPrefix(cluster.Server, "https://"), types.NamespacedName{Namespace: context.Namespace}, true
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Related to https://github.com/upbound/up/issues/487

Refactor the code for deriving state using the extensions created as part of https://github.com/upbound/up/pull/491

The logic for deriving the state is now:
1. Load the current context, if none found then go to Cloud root navigation
2. Load the extensions
  a. If cloud space extension exists, call `DeriveExistingCloudState`
  b. If disconnected space extension exists, call `DeriveExistingDisconnectedState`
  c. If no extension exists, or extension invalid, call `DeriveNewState`

Each of the `DeriveExisting*State` methods uses the metadata from the extension to load the `Space{}` struct for their navigation state.

In order to get disconnected spaces working, `Space{}` now stores `HubContext` which is a pointer to the context in the current kubeconfig that points at the hub directly. When building a group kubeconfig for a `Space{}` which defines `HubContext`, we copy the values from the hub context cluster and hub context auth info instead of using the ingress.

NOTE: This PR does **not** re-use the hub cluster or authinfo. It will still create new `upbound` cluster and authoinfo every time a user runs `up ctx` - simply copying the values over. Re-using it is for a another PR.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

- New unit tests for all of the new `Derive*` methods
- Updated unit tests for all of the `Accept` methods to match the new hub/ingress logic
