### PR TITLE
Fix CRUD on control planes within group scope

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -56,7 +56,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	kongCtx.Bind(upCtx)
 
 	// we can't use control planes from inside a control plane
-	if _, _, ok := upCtx.GetCurrentSpaceContextScope(); ok {
+	if _, ctp, exists := upCtx.GetCurrentSpaceContextScope(); exists && ctp.Name != "" {
 		return errors.New("cannot view control planes from inside a control plane context. Use 'up ctx ..' to go up to the group context")
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fixes https://github.com/upbound/up/issues/503

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
```
$ up ./default
Kubeconfig context "kind-spaces-1.4" switched to: Upbound /kind-spaces-1.4/default/
$ up ctp list
GROUP     NAME            CROSSPLANE    SYNCED   READY   MESSAGE   AGE
default   controlplane1   1.14.8-up.1   True     True              141m
```