### PR TITLE
up ctx: Add menu item for connecting to a control plane

### DIFF
--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -71,6 +71,9 @@ type item struct {
 
 	// back denotes that the item will return the user to the previous menu
 	back bool
+
+	// notSelectable marks an item as unselectable in the list and will be skipped in navigation
+	notSelectable bool
 }
 
 func (i item) FilterValue() string { return "" }
@@ -257,5 +260,31 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { // nolint:gocyclo // T
 
 	var cmd tea.Cmd
 	m.list, cmd = m.list.Update(msg)
+
+	m.list = m.moveToSelectableItem(msg)
+
 	return m, cmd
+}
+
+func (m model) moveToSelectableItem(msg tea.Msg) list.Model {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m.list
+	}
+
+	for {
+		if i, ok := m.list.SelectedItem().(item); ok {
+			if !i.notSelectable {
+				break
+			}
+		}
+		switch {
+		case key.Matches(keyMsg, m.list.KeyMap.CursorUp):
+			m.list.CursorUp()
+
+		case key.Matches(keyMsg, m.list.KeyMap.CursorDown):
+			m.list.CursorDown()
+		}
+	}
+	return m.list
 }

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -428,7 +428,7 @@ func (g *Group) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 	*/
 
 	if len(ctps.Items) == 0 {
-		items = append(items, item{text: "No ControlPlanes found", emptyList: true})
+		items = append(items, item{text: "No control planes found in group", emptyList: true})
 	}
 
 	return items, nil
@@ -466,15 +466,13 @@ var _ Back = &ControlPlane{}
 func (ctp *ControlPlane) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item, error) {
 	return []list.Item{
 		item{text: "..", kind: "controlplanes", onEnter: ctp.Back, back: true},
-		/*
-			item{text: fmt.Sprintf("Connect to %s", ctp.NamespacedName), onEnter: KeyFunc(func(ctx context.Context, upCtx *upbound.Context, m model) (model, error) {
-				msg, err := ctp.Accept(ctx, upCtx)
-				if err != nil {
-					return m, err
-				}
-				return m.WithTermination(msg, nil), nil
-			}), padding: []int{1, 0, 0}},
-		*/
+		item{text: fmt.Sprintf("Connect to %s", ctp.NamespacedName().Name), onEnter: KeyFunc(func(m model) (model, error) {
+			msg, err := ctp.Accept(m.upCtx, m.contextWriter)
+			if err != nil {
+				return m, err
+			}
+			return m.WithTermination(msg, nil), nil
+		}), padding: []int{1, 0, 0}},
 	}, nil
 }
 


### PR DESCRIPTION
### Description of your changes

This PR adds a menu item to the space/group/control plane views that allows users to select it which saves the context and exits, just like q/f10.

Fixes https://github.com/upbound/up/issues/502

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
tested locally

screenshots:

Control plane:
<img width="728" alt="Screenshot 2024-05-10 at 4 54 48 PM" src="https://github.com/upbound/up/assets/27781468/c728538d-3476-419f-9015-5c1a0b092f15">

Group:
<img width="929" alt="Screenshot 2024-05-10 at 4 53 42 PM" src="https://github.com/upbound/up/assets/27781468/56508c09-4234-4f07-860b-fb22fe14d714">

Space:
<img width="707" alt="Screenshot 2024-05-10 at 4 53 06 PM" src="https://github.com/upbound/up/assets/27781468/bc109cd6-1504-4512-b807-2e1589958237">




