### PR TITLE
Inject new user agent into all kube rest configs

### DIFF
--- a/cmd/up/controlplane/pkg/install.go
+++ b/cmd/up/controlplane/pkg/install.go
@@ -33,6 +33,7 @@ import (
 	"github.com/upbound/up/internal/resources"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
+	"github.com/upbound/up/internal/version"
 	"github.com/upbound/up/internal/xpkg"
 )
 
@@ -80,10 +81,13 @@ func (c *installCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) e
 	if err != nil {
 		return err
 	}
+	kubeconfig.UserAgent = version.UserAgent()
+
 	if upCtx.WrapTransport != nil {
 		kubeconfig.Wrap(upCtx.WrapTransport)
 	}
 
+	// todo(redbackthomson): Migrate to using client.Client for standardization
 	client, err := dynamic.NewForConfig(kubeconfig)
 	if err != nil {
 		return err

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -37,6 +37,7 @@ import (
 	"github.com/upbound/up-sdk-go/service/organizations"
 	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/version"
 )
 
 var (
@@ -286,6 +287,7 @@ func (s *Space) GetClient(upCtx *upbound.Context) (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	rest.UserAgent = version.UserAgent()
 
 	return client.New(rest, client.Options{})
 }

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/upbound/up/internal/install/helm"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
+	"github.com/upbound/up/internal/version"
 )
 
 const (
@@ -60,7 +61,9 @@ func (c *destroyCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	kubeconfig.UserAgent = version.UserAgent()
 
+	// todo(redbackthomson): Migrate to using client.Client for standardization
 	kClient, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
 		return err

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -35,6 +35,7 @@ import (
 	"github.com/upbound/up/internal/kube"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
+	"github.com/upbound/up/internal/version"
 )
 
 const (
@@ -95,7 +96,9 @@ func (c *upgradeCmd) AfterApply(quiet config.QuietFlag) error { //nolint:gocyclo
 	if err != nil {
 		return err
 	}
+	kubeconfig.UserAgent = version.UserAgent()
 
+	// todo(redbackthomson): Migrate to using client.Client for standardization
 	kClient, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
 		return err

--- a/cmd/up/trace/cmd.go
+++ b/cmd/up/trace/cmd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/upbound/up/cmd/up/query"
 	"github.com/upbound/up/cmd/up/query/resource"
 	"github.com/upbound/up/internal/upbound"
+	"github.com/upbound/up/internal/version"
 )
 
 type Cmd struct {
@@ -81,6 +82,7 @@ func (c *Cmd) Run(ctx context.Context, kongCtx *kong.Context, upCtx *upbound.Con
 	if err != nil {
 		return err
 	}
+	kubeconfig.UserAgent = version.UserAgent()
 
 	_, ctp, isSpace := upCtx.GetCurrentSpaceContextScope()
 

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -40,12 +40,10 @@ import (
 	upboundv1alpha1 "github.com/upbound/up-sdk-go/apis/upbound/v1alpha1"
 	"github.com/upbound/up/internal/config"
 	"github.com/upbound/up/internal/profile"
+	"github.com/upbound/up/internal/version"
 )
 
 const (
-	// UserAgent is the default user agent to use to make requests to the
-	// Upbound API.
-	UserAgent = "up-cli"
 	// CookieName is the default cookie name used to identify a session token.
 	CookieName = "SID"
 
@@ -266,7 +264,7 @@ func (c *Context) buildSDKConfig(endpoint *url.URL) (*up.Config, error) {
 			Jar:       cj,
 			Transport: tr,
 		}
-		u.UserAgent = UserAgent
+		u.UserAgent = version.UserAgent()
 	})
 	return up.NewConfig(func(conf *up.Config) {
 		conf.Client = client
@@ -309,7 +307,7 @@ func (c *Context) BuildControllerClientConfig() (*rest.Config, error) {
 		Host:      c.APIEndpoint.String(),
 		APIPath:   controllerClientPath,
 		Transport: tr,
-		UserAgent: UserAgent,
+		UserAgent: version.UserAgent(),
 	}
 
 	if c.Profile.Session != "" {
@@ -387,7 +385,7 @@ func (c *Context) BuildCloudSpaceRestConfig(ctx context.Context, spaceName, prof
 		return nil, err
 	}
 
-	restCfg.UserAgent = UserAgent
+	restCfg.UserAgent = version.UserAgent()
 
 	return restCfg, nil
 }

--- a/internal/upbound/flags.go
+++ b/internal/upbound/flags.go
@@ -19,6 +19,8 @@ import (
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/upbound/up/internal/version"
 )
 
 // Flags are common flags used by commands that interact with Upbound.
@@ -75,6 +77,7 @@ func (f *KubeFlags) AfterApply() error {
 	if err != nil {
 		return err
 	}
+	restConfig.UserAgent = version.UserAgent()
 	f.config = restConfig
 
 	ns, _, err := loader.Namespace()

--- a/internal/upbound/kube_context.go
+++ b/internal/upbound/kube_context.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/upbound/up/internal/profile"
+	"github.com/upbound/up/internal/version"
 )
 
 // HasValidContext returns true if the kube configuration attached to the
@@ -46,6 +47,8 @@ func (c *Context) BuildCurrentContextClient() (client.Client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get kube config")
 	}
+
+	rest.UserAgent = version.UserAgent()
 
 	// todo(redbackthomson): Delete once spaces-api is able to accept protobuf
 	// requests

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
@@ -27,6 +28,8 @@ import (
 )
 
 const (
+	productName = "up-cli"
+
 	// 5 seconds should be more than enough time.
 	clientTimeout = 5 * time.Second
 	cliURL        = "https://cli.upbound.io/stable/current/version"
@@ -49,6 +52,10 @@ var (
 	agentVersion string
 	target       string = string(ReleaseTargetDebug)
 )
+
+func UserAgent() string {
+	return fmt.Sprintf("%s/%s (%s; %s)", productName, version, runtime.GOOS, runtime.GOARCH)
+}
 
 // GetVersion returns the current build version.
 func GetVersion() string {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

- Update UserAgent to be `up-cli/<version> (<os>; <arch>)`
- Inject user agent into all kube rest clients
- Add TODO to remove any references to the raw client config, where `client.Client` cannot be used

Example user agent: `up-cli/v0.30.0-rc.0.15.g18bb4f5.dirty (darwin; arm64)`

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~~

### How has this code been tested

Running `up ctx <path>` makes multiple calls to spaces, and we can see the requests in the envoy logs:
```json
{"downstreamLocalAddress":"10.88.4.252:8443","downstreamRemoteAddress":"10.138.0.37:0","protocol":"HTTP/1.1","startTime":"2024-05-09T23:03:29.593Z","upstreamHost":"10.96.29.179:8443","userAgent":"up-cli/v0.30.0-rc.0.15.g18bb4f5.dirty (darwin; arm64)","upstreamServiceTime":"14","path":"/api/v1","responseCode":200,"requestId":"","downstreamRequestTTLB":0,"bytesSent":192,"responseHeadersBytes":193,"authority":"upbound-gcp-us-west-1.space.mxe.upbound.services","responseFlags":"-","httpMethod":"GET","responseCodeDetails":"via_upstream","upstreamCluster":"mxe-api","upstreamDuration":16,"upstreamRequestTTLB":11,"downstreamResponseTTLB":0,"routeName":"mxe-api","responseTrailersBytes":0,"bytesReceived":0,"xForwardedFor":"10.138.0.37","clientDuration":16
```
