### PR TITLE
Support `up ctx . --short` for space

### DIFF
--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -310,6 +310,8 @@ func (c *Cmd) RunRelative(ctx context.Context, upCtx *upbound.Context, initialSt
 	if c.File != "-" {
 		if c.Short {
 			switch state := m.state.(type) {
+			case *Space:
+				fmt.Printf("%s/%s\n", state.Org.Name, state.Name)
 			case *Group:
 				fmt.Printf("%s/%s/%s\n", state.Space.Org.Name, state.Space.Name, state.Name)
 			case *ControlPlane:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Previously, using `up ctx . -s` when your kubeconfig is set at a space level would print nothing.

This pull request adds support for `up ctx . -s`:

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
$ ./up ctx ..
Kubeconfig context "upbound" switched to: Upbound upbound/upbound-aws-us-east-1/
$ ./up ctx . -s
upbound/upbound-aws-us-east-1
```
