### PR TITLE
Fix condition where current context points nowhere

### DIFF
--- a/cmd/up/ctx/actions.go
+++ b/cmd/up/ctx/actions.go
@@ -41,8 +41,7 @@ func (s *Space) Accept(upCtx *upbound.Context, writer kubeContextWriter) (msg st
 		return "", err
 	}
 
-	prev, _ := upCtx.GetCurrentContextName()
-	return fmt.Sprintf(contextSwitchedFmt, prev, s.Breadcrumbs()), nil
+	return fmt.Sprintf(contextSwitchedFmt, s.Breadcrumbs()), nil
 }
 
 // Accept upserts the "upbound" kubeconfig context and cluster to the chosen
@@ -60,8 +59,7 @@ func (g *Group) Accept(upCtx *upbound.Context, writer kubeContextWriter) (msg st
 		return "", err
 	}
 
-	prev, _ := upCtx.GetCurrentContextName()
-	return fmt.Sprintf(contextSwitchedFmt, prev, g.Breadcrumbs()), nil
+	return fmt.Sprintf(contextSwitchedFmt, g.Breadcrumbs()), nil
 }
 
 // Accept upserts a controlplane context and cluster to the chosen kubeconfig.
@@ -78,6 +76,5 @@ func (ctp *ControlPlane) Accept(upCtx *upbound.Context, writer kubeContextWriter
 		return "", err
 	}
 
-	prev, _ := upCtx.GetCurrentContextName()
-	return fmt.Sprintf(contextSwitchedFmt, prev, ctp.Breadcrumbs()), nil
+	return fmt.Sprintf(contextSwitchedFmt, ctp.Breadcrumbs()), nil
 }

--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	contextSwitchedFmt = "Added new context to kubeconfig: %s\n"
+	contextSwitchedFmt = "Switched kubeconfig context to: %s\n"
 )
 
 var (
@@ -181,8 +181,14 @@ func activateContext(conf *clientcmdapi.Config, sourceContext, preferredContext 
 	}
 	if conf.CurrentContext == preferredContext {
 		conf.Contexts[preferredContext] = source
-		conf.Contexts[preferredContext+upboundPreviousContextSuffix] = current
-		newLastContext = preferredContext + upboundPreviousContextSuffix
+
+		if current == nil {
+			delete(conf.Contexts, preferredContext+upboundPreviousContextSuffix)
+			newLastContext = conf.CurrentContext
+		} else {
+			conf.Contexts[preferredContext+upboundPreviousContextSuffix] = current
+			newLastContext = preferredContext + upboundPreviousContextSuffix
+		}
 	} else {
 		// For other <-> upbound-previous, keep "other" for last context
 		conf.Contexts[preferredContext] = source

--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	contextSwitchedFmt = "Kubeconfig context %q switched to: %s\n"
+	contextSwitchedFmt = "Added new context to kubeconfig: %s\n"
 )
 
 var (
@@ -152,7 +152,7 @@ func (c *Cmd) RunSwap(ctx context.Context, upCtx *upbound.Context) error { // no
 	if err := writeLastContext(oldContext); err != nil {
 		return err
 	}
-	fmt.Printf(contextSwitchedFmt, c.KubeContext, state.Breadcrumbs())
+	fmt.Printf(contextSwitchedFmt, state.Breadcrumbs())
 	return nil
 }
 
@@ -177,10 +177,7 @@ func activateContext(conf *clientcmdapi.Config, sourceContext, preferredContext 
 	}
 	var current *clientcmdapi.Context
 	if conf.CurrentContext != "" {
-		current, ok = conf.Contexts[conf.CurrentContext]
-		if !ok {
-			return nil, "", fmt.Errorf("no %q context found", conf.CurrentContext)
-		}
+		current = conf.Contexts[conf.CurrentContext]
 	}
 	if conf.CurrentContext == preferredContext {
 		conf.Contexts[preferredContext] = source
@@ -219,7 +216,7 @@ func activateContext(conf *clientcmdapi.Config, sourceContext, preferredContext 
 	if conf.Contexts[preferredContext].AuthInfo == preferredContext+upboundPreviousContextSuffix {
 		prev := conf.AuthInfos[preferredContext+upboundPreviousContextSuffix]
 		if prev == nil {
-			return nil, "", fmt.Errorf("no %q authInfo found", preferredContext+upboundPreviousContextSuffix)
+			return nil, "", fmt.Errorf("no %q user found", preferredContext+upboundPreviousContextSuffix)
 		}
 		if current := conf.AuthInfos[preferredContext]; current == nil {
 			delete(conf.AuthInfos, preferredContext+upboundPreviousContextSuffix)

--- a/cmd/up/ctx/cmd_test.go
+++ b/cmd/up/ctx/cmd_test.go
@@ -285,7 +285,17 @@ func TestSwapContext(t *testing.T) {
 			},
 			last:      "upbound-previous",
 			preferred: "upbound",
-			wantErr:   `no "upbound" context found`,
+			wantConf: &clientcmdapi.Config{
+				CurrentContext: "upbound",
+				Contexts: map[string]*clientcmdapi.Context{
+					"upbound": {Namespace: "namespace1", Cluster: "upbound", AuthInfo: "upbound"},
+					"other":   {Namespace: "other", Cluster: "other", AuthInfo: "other"},
+				},
+				Clusters:  map[string]*clientcmdapi.Cluster{"upbound": {Server: "server1"}, "upbound-previous": {Server: "server2"}, "other": {Server: "other"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": {Token: "token1"}, "upbound-previous": {Token: "token2"}, "other": {Token: "other"}},
+			},
+			wantLast: "upbound",
+			wantErr:  `<nil>`,
 		},
 		"LastNotFound": {
 			conf: &clientcmdapi.Config{


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fixes https://github.com/upbound/up/issues/513

Since we no longer depend on a valid current context, I thought the message that was output when a user switches contexts didn't make sense anymore. It was sometimes even showing `Kubeconfig context "" switched to: ...` which just feels like a mistake. So this PR also updates the output for a successful save and quit to be:
```
$ ./up ctx ./ctp1
Switched kubeconfig context to: Upbound upbound/upbound-aws-us-east-1/default/ctp1
```

The [plan](https://github.com/upbound/up/issues/497) is to eventually rename the exported context to include the group and ctp name, so we would show that instead of the breadcrumbs. But at least this describes that we're adding a new context.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
