### PR TITLE
Change up ctx padding and naming

### DIFF
--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -249,13 +249,13 @@ func (s *Space) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 		items = append(items, item{text: "No groups found", notSelectable: true})
 	}
 
-	items = append(items, item{text: fmt.Sprintf("Switch kubeconfig to %q and quit", s.Name), onEnter: func(m model) (model, error) {
+	items = append(items, item{text: fmt.Sprintf("Switch context to %q", s.Name), onEnter: func(m model) (model, error) {
 		msg, err := s.Accept(m.upCtx, m.contextWriter)
 		if err != nil {
 			return m, err
 		}
 		return m.WithTermination(msg, nil), nil
-	}, padding: []int{1, 0, 0}})
+	}})
 
 	return items, nil
 }
@@ -432,13 +432,13 @@ func (g *Group) Items(ctx context.Context, upCtx *upbound.Context) ([]list.Item,
 		items = append(items, item{text: fmt.Sprintf("No control planes found in the %q group", g.Name), notSelectable: true})
 	}
 
-	items = append(items, item{text: fmt.Sprintf("Switch kubeconfig to %q and quit", fmt.Sprintf("%s/%s", g.Space.Name, g.Name)), onEnter: func(m model) (model, error) {
+	items = append(items, item{text: fmt.Sprintf("Switch context to %q", fmt.Sprintf("%s/%s", g.Space.Name, g.Name)), onEnter: func(m model) (model, error) {
 		msg, err := g.Accept(m.upCtx, m.contextWriter)
 		if err != nil {
 			return m, err
 		}
 		return m.WithTermination(msg, nil), nil
-	}, padding: []int{1, 0, 0}})
+	}})
 
 	return items, nil
 }
@@ -481,7 +481,7 @@ func (ctp *ControlPlane) Items(ctx context.Context, upCtx *upbound.Context) ([]l
 				return m, err
 			}
 			return m.WithTermination(msg, nil), nil
-		}), padding: []int{1, 0, 0}},
+		})},
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Follow up of https://github.com/upbound/up/pull/510

Fixing nits from comments:
- Removing padding in the line items
- Changing the item text to "Switch context to ..."

![image](https://github.com/upbound/up/assets/1841682/40922ad6-d42d-4b2f-9f4c-6203b955b474)

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
