### PR TITLE
Add explicit group label to namespace

### DIFF
--- a/cmd/up/group/create.go
+++ b/cmd/up/group/create.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/upterm"
 )
@@ -37,6 +38,9 @@ func (c *createCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, upCtx
 	group := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.Name,
+			Labels: map[string]string{
+				spacesv1beta1.ControlPlaneGroupLabelKey: "true",
+			},
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Without adding an explicit group label to a namespace, it won't appear in `up group list`. It is confusing to users to run `up group create` and then the namespace not show up in `up group list` because it doesn't have the group label applied. This pull request explicitly adds the label, so that it immediately appears in the list of groups. 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested against disconnected and cloud spaces

![image](https://github.com/upbound/up/assets/1841682/f0a23330-ca5f-4251-9f8b-4572bf9a2354)

