### PR TITLE
query: Fix kubeconfig fetching in `up alpha query`

### DIFF
--- a/cmd/up/query/query.go
+++ b/cmd/up/query/query.go
@@ -61,7 +61,7 @@ func (c *QueryCmd) AfterApply(kongCtx *kong.Context) error { // nolint:gocyclo /
 			c.Group = ctp.Namespace
 		}
 	}
-	kubeconfig, err := upCtx.Kubecfg.RawConfig()
+	kubeconfig, err := upCtx.Kubecfg.ClientConfig()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description of your changes

Previously, we were binding an `api.Config` to the kong context, when the commands expect a `*rest.Config`. Bind the correct kind of config so that `up alpha query` works as expected.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manual verification that `up alpha query` can be used to exercise the query API.
