### PR TITLE
ctp: Allow version and upgrade channel to be specified in create

### DIFF
--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -16,8 +16,10 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/alecthomas/kong"
+	"github.com/blang/semver/v4"
 	"github.com/pkg/errors"
 	"github.com/pterm/pterm"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,10 +33,34 @@ import (
 type createCmd struct {
 	Name  string `arg:"" required:"" help:"Name of control plane."`
 	Group string `short:"g" default:"" help:"The control plane group that the control plane is contained in. This defaults to the group specified in the current context"`
+
+	Crossplane struct {
+		Version     string `default:"" help:"The version of Universal Crossplane to use. The default depends on the selected auto-upgrade channel."`
+		AutoUpgrade struct {
+			Channel string `default:"Stable" help:"The Crossplane auto-upgrade channel to use. Must be one of: None, Patch, Stable, Rapid" enum:"None,Patch,Stable,Rapid"`
+		} `embed:""`
+	} `embed:"" prefix:"crossplane-"`
+
 	// todo(redbackthomson): Support all overrides for control planes
 	// ConfigurationName *string `help:"The optional name of the Configuration."`
 
 	SecretName string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`
+}
+
+// Validate performs custom argument validation for the create command.
+func (c *createCmd) Validate() error {
+	// TODO(adamwg): This validation should probably happen on the server side,
+	// at which point we could remove it here.
+	if c.Crossplane.Version != "" {
+		if c.Crossplane.AutoUpgrade.Channel != string(spacesv1beta1.CrossplaneUpgradeNone) {
+			return fmt.Errorf("upgrade channel must be %q to specify a version", string(spacesv1beta1.CrossplaneUpgradeNone))
+		}
+		_, err := semver.Parse(c.Crossplane.Version)
+		if err != nil {
+			return fmt.Errorf("invalid Crossplane version specified: %w; do not prefix the version with a 'v'", err)
+		}
+	}
+	return nil
 }
 
 // AfterApply sets default values in command after assignment and validation.
@@ -57,6 +83,16 @@ func (c *createCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound
 			Name:      c.Name,
 			Namespace: c.Group,
 		},
+	}
+
+	if c.Crossplane.Version != "" {
+		ctp.Spec.Crossplane.Version = &c.Crossplane.Version
+	}
+	if c.Crossplane.AutoUpgrade.Channel != "" {
+		ch := spacesv1beta1.CrossplaneUpgradeChannel(c.Crossplane.AutoUpgrade.Channel)
+		ctp.Spec.Crossplane.AutoUpgradeSpec = &spacesv1beta1.CrossplaneAutoUpgradeSpec{
+			Channel: &ch,
+		}
 	}
 
 	if err := client.Create(ctx, ctp); err != nil {

--- a/cmd/up/controlplane/create.go
+++ b/cmd/up/controlplane/create.go
@@ -41,9 +41,6 @@ type createCmd struct {
 		} `embed:""`
 	} `embed:"" prefix:"crossplane-"`
 
-	// todo(redbackthomson): Support all overrides for control planes
-	// ConfigurationName *string `help:"The optional name of the Configuration."`
-
 	SecretName string `help:"The name of the control plane's secret. Defaults to 'kubeconfig-{control plane name}'. Only applicable for Space control planes."`
 }
 


### PR DESCRIPTION
### Description of your changes

Add flags to specify the desired Crossplane version and upgrade channel in the
`up ctp create` command. Return an error if a version is specified with a
release channel other than `None`, since the server will accept a spec with a
version specified but ignore it in favor of the release channel's current
version.

For now, we don't have a programmatic way to fetch the valid release channels so
we hard-code the options. Similarly, we don't have an API to fetch supported
versions so we can't list them for the user in the CLI.

Fixes #541

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manual testing of the following cases:

* `up ctp create` without the new arguments works as before.
* `up ctp create --version=1.14.8-up.1 --channel=None` is successful and the ctp has the right version.
* `up ctp create --version=1.14.8-up.1` throws an error since the default release channel is `Stable`.
* `up ctp create --channel=Rapid` is successful and the ctp has the right release channel.
