### PR TITLE
ctx: Enable navigation between cloud and disconnected Spaces

### DIFF
--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -208,9 +208,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { // nolint:gocyclo // T
 			switch {
 			case key.Matches(msg, backNavBinding):
 				if state, ok := m.state.(Back); ok {
-					if state.CanBack() {
-						fn = state.Back
-					}
+					fn = state.Back
 				}
 			case key.Matches(msg, selectNavBinding):
 				if i, ok := m.list.SelectedItem().(item); ok {

--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -72,10 +72,6 @@ type item struct {
 
 	matchingTerms []string
 
-	// emptyList denotes that the item is marking that the list is empty, and
-	// should not be considered an element in the list itself
-	emptyList bool
-
 	// back denotes that the item will return the user to the previous menu
 	back bool
 
@@ -144,16 +140,10 @@ func NewList(items []list.Item) list.Model {
 	// check for initial cursor conditions
 	if len(items) > 1 {
 		nested := items[0].(item).back
-		empty := items[1].(item).emptyList
 
-		if nested && !empty {
+		if nested {
 			// move the cursor down below the '..' button
 			l.CursorDown()
-		}
-
-		if nested && empty {
-			// disable selecting the empty list item
-			l.KeyMap.CursorDown = key.NewBinding(key.WithDisabled())
 		}
 	}
 

--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -55,13 +55,20 @@ var quitBinding = key.NewBinding(
 
 type KeyFunc func(m model) (model, error)
 
+type padding struct {
+	top    int
+	bottom int
+	left   int
+	right  int
+}
+
 type item struct {
 	text string
 	kind string
 
 	onEnter KeyFunc
 
-	padding []int
+	padding padding
 
 	matchingTerms []string
 
@@ -100,9 +107,8 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	if index == m.Index() {
 		mainStyle = selectedItemStyle
 	}
-	if len(str.padding) > 0 {
-		mainStyle = mainStyle.Copy().Padding(str.padding...)
-	}
+	padding := str.padding
+	mainStyle = mainStyle.Copy().Padding(padding.top, padding.right, padding.bottom, padding.left)
 
 	var kind string
 	if str.kind != "" {
@@ -159,12 +165,7 @@ func (m model) ListHeight() int {
 	for _, i := range m.list.Items() {
 		itm := i.(item)
 		lines += 1 + strings.Count(itm.text, "\n")
-		switch len(itm.padding) {
-		case 1, 2:
-			lines += itm.padding[0]
-		case 3, 4:
-			lines += itm.padding[0] + itm.padding[2]
-		}
+		lines += itm.padding.top + itm.padding.bottom
 	}
 	lines += 2 // help text
 

--- a/cmd/up/ctx/list_test.go
+++ b/cmd/up/ctx/list_test.go
@@ -1,0 +1,249 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctx
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"gotest.tools/v3/assert"
+)
+
+func TestNewList_InitialCursorPlacement(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		items         []list.Item
+		expectedIndex int
+	}{
+		"empty list": {
+			items:         []list.Item{},
+			expectedIndex: 0,
+		},
+		"all items selectable": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2"},
+				item{text: "item 3"},
+			},
+			expectedIndex: 0,
+		},
+		"top item selectable": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 3", notSelectable: true},
+			},
+			expectedIndex: 0,
+		},
+		"top item unselectable": {
+			items: []list.Item{
+				item{text: "item 1", notSelectable: true},
+				item{text: "item 2"},
+				item{text: "item 3"},
+			},
+			expectedIndex: 1,
+		},
+		"top item back": {
+			items: []list.Item{
+				item{text: "item 1", back: true},
+				item{text: "item 2"},
+				item{text: "item 3"},
+			},
+			expectedIndex: 1,
+		},
+		"top two items undesirable": {
+			items: []list.Item{
+				item{text: "item 1", back: true},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 3"},
+			},
+			expectedIndex: 2,
+		},
+		"all items undesirable": {
+			items: []list.Item{
+				item{text: "item 1", back: true},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 3", notSelectable: true},
+			},
+			expectedIndex: 0,
+		},
+		"only item back": {
+			items: []list.Item{
+				item{text: "item 1", back: true},
+			},
+			expectedIndex: 0,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := model{
+				list: NewList(test.items),
+			}
+
+			assert.Equal(t, m.list.Index(), test.expectedIndex)
+		})
+	}
+}
+
+func TestMoveToSelectableItem(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		items         []list.Item
+		startingIndex int
+		key           rune
+		expectedIndex int
+	}{
+		"empty list, down": {
+			items:         []list.Item{},
+			startingIndex: 0,
+			key:           'j',
+			expectedIndex: 0,
+		},
+		"empty list, up": {
+			items:         []list.Item{},
+			startingIndex: 0,
+			key:           'k',
+			expectedIndex: 0,
+		},
+		"selectable item, down": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2"},
+			},
+			startingIndex: 0,
+			key:           'j',
+			expectedIndex: 0,
+		},
+		"selectable item, up": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2"},
+			},
+			startingIndex: 1,
+			key:           'k',
+			expectedIndex: 1,
+		},
+		"unselectable item, down": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 3"},
+			},
+			startingIndex: 1,
+			key:           'j',
+			expectedIndex: 2,
+		},
+		"unselectable item, up": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 3"},
+			},
+			startingIndex: 1,
+			key:           'k',
+			expectedIndex: 0,
+		},
+		"multiple unselectable items, down": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 2a", notSelectable: true},
+				item{text: "item 3"},
+			},
+			startingIndex: 1,
+			key:           'j',
+			expectedIndex: 3,
+		},
+		"multiple unselectable items, up": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 2a", notSelectable: true},
+				item{text: "item 3"},
+			},
+			startingIndex: 2,
+			key:           'k',
+			expectedIndex: 0,
+		},
+		"unselectable item at bottom of list, down": {
+			items: []list.Item{
+				item{text: "item 1"},
+				item{text: "item 2"},
+				item{text: "item 3", notSelectable: true},
+			},
+			startingIndex: 2,
+			key:           'j',
+			expectedIndex: 1,
+		},
+		"unselectable item at top of list, up": {
+			items: []list.Item{
+				item{text: "item 1", notSelectable: true},
+				item{text: "item 2"},
+				item{text: "item 3"},
+			},
+			startingIndex: 0,
+			key:           'k',
+			expectedIndex: 1,
+		},
+		"all unselectable items, down": {
+			items: []list.Item{
+				item{text: "item 1", notSelectable: true},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 3", notSelectable: true},
+			},
+			startingIndex: 1,
+			key:           'j',
+			expectedIndex: 0,
+		},
+		"all unselectable items, up": {
+			items: []list.Item{
+				item{text: "item 1", notSelectable: true},
+				item{text: "item 2", notSelectable: true},
+				item{text: "item 3", notSelectable: true},
+			},
+			startingIndex: 1,
+			key:           'k',
+			expectedIndex: 2,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := model{
+				list: NewList(test.items),
+			}
+			m.list.Select(test.startingIndex)
+			// Make sure Select() did what we want so our test is valid.
+			assert.Equal(t, m.list.Index(), test.startingIndex)
+
+			result := m.moveToSelectableItem(tea.KeyMsg{
+				Type:  tea.KeyRunes,
+				Runes: []rune{test.key},
+			})
+
+			assert.Equal(t, result.Index(), test.expectedIndex)
+		})
+	}
+}

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -210,7 +210,7 @@ func (d *Disconnected) Items(ctx context.Context, upCtx *upbound.Context, navCtx
 }
 
 func (d *Disconnected) breadcrumbs(styles breadcrumbStyle) string {
-	return upboundRootStyle.Render("Upbound ") + styles.previousLevel.Render("disconnected/")
+	return upboundRootStyle.Render("Upbound ") + styles.currentLevel.Render("disconnected/")
 }
 
 func (d *Disconnected) Breadcrumbs() string {
@@ -301,7 +301,7 @@ func (o *Organization) BackLabel() string {
 }
 
 func (o *Organization) breadcrumbs(styles breadcrumbStyle) string {
-	return upboundRootStyle.Render("Upbound ") + styles.previousLevel.Render(fmt.Sprintf("%s/", o.Name))
+	return upboundRootStyle.Render("Upbound ") + styles.currentLevel.Render(fmt.Sprintf("%s/", o.Name))
 }
 
 func (o *Organization) Breadcrumbs() string {
@@ -386,12 +386,12 @@ func (s *Space) breadcrumbs(styles breadcrumbStyle) string {
 		return s.Org.breadcrumbs(breadcrumbStyle{
 			currentLevel:  styles.previousLevel,
 			previousLevel: styles.previousLevel,
-		}) + styles.previousLevel.Render(fmt.Sprintf("%s/", s.Name))
+		}) + styles.currentLevel.Render(fmt.Sprintf("%s/", s.Name))
 	} else {
 		return (&Disconnected{}).breadcrumbs(breadcrumbStyle{
 			currentLevel:  styles.previousLevel,
 			previousLevel: styles.previousLevel,
-		}) + styles.previousLevel.Render(fmt.Sprintf("%s/", s.Name))
+		}) + styles.currentLevel.Render(fmt.Sprintf("%s/", s.Name))
 	}
 }
 
@@ -562,7 +562,7 @@ func (g *Group) breadcrumbs(styles breadcrumbStyle) string {
 	return g.Space.breadcrumbs(breadcrumbStyle{
 		currentLevel:  styles.previousLevel,
 		previousLevel: styles.previousLevel,
-	}) + styles.previousLevel.Render(fmt.Sprintf("%s/", g.Name))
+	}) + styles.currentLevel.Render(fmt.Sprintf("%s/", g.Name))
 }
 
 func (g *Group) Breadcrumbs() string {
@@ -603,9 +603,9 @@ func (ctp *ControlPlane) Items(ctx context.Context, upCtx *upbound.Context, navC
 func (ctp *ControlPlane) breadcrumbs(styles breadcrumbStyle) string {
 	// use current level to highlight the entire breadcrumb chain
 	return ctp.Group.breadcrumbs(breadcrumbStyle{
-		currentLevel:  styles.currentLevel,
-		previousLevel: styles.currentLevel,
-	}) + pathSegmentStyle.Render(ctp.Name)
+		currentLevel:  styles.previousLevel,
+		previousLevel: styles.previousLevel,
+	}) + styles.currentLevel.Render(ctp.Name)
 }
 
 func (ctp *ControlPlane) Breadcrumbs() string {

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -16,6 +16,7 @@ package ctx
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,7 +24,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,7 +69,7 @@ type Accepting interface {
 type Back interface {
 	NavigationState
 	Back(m model) (model, error)
-	CanBack() bool
+	BackLabel() string
 }
 
 type AcceptingFunc func(ctx context.Context, upCtx *upbound.Context) error
@@ -99,7 +99,7 @@ var defaultBreadcrumbStyle = breadcrumbStyle{
 
 type Root struct{}
 
-func (r *Root) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navContext) ([]list.Item, error) { //nolint:gocyclo
+func (r *Root) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navContext) ([]list.Item, error) {
 	cfg, err := upCtx.BuildSDKConfig()
 	if err != nil {
 		return nil, err
@@ -107,20 +107,38 @@ func (r *Root) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navCon
 
 	client := organizations.NewClient(cfg)
 
+	items := make([]list.Item, 0, 1)
+
 	orgs, err := client.List(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "error listing organizations")
+		// We want `up ctx` to be usable for disconnected spaces even if the
+		// user isn't logged in or can't connect to Upbound. Return a friendly
+		// message instead of an error.
+		items = append(items, item{ //nolint:nilerr
+			text:          "Could not list Upbound organizations; are you logged in?",
+			notSelectable: true,
+		})
 	}
 
-	items := make([]list.Item, 0, len(orgs))
 	for _, org := range orgs {
 		items = append(items, item{text: org.DisplayName, kind: "organization", matchingTerms: []string{org.Name}, onEnter: func(m model) (model, error) {
 			m.state = &Organization{Name: org.Name}
 			return m, nil
 		}})
 	}
+
 	sort.Sort(sortedItems(items))
-	return items, nil
+	return append(items, item{
+		text: "Disconnected Spaces",
+		onEnter: func(m model) (model, error) {
+			m.state = &Disconnected{}
+			return m, nil
+		},
+		padding: padding{
+			top: 1,
+		},
+		matchingTerms: []string{"disconnected"},
+	}), nil
 }
 
 func (r *Root) breadcrumbs() string {
@@ -129,6 +147,83 @@ func (r *Root) breadcrumbs() string {
 
 func (r *Root) Breadcrumbs() string {
 	return r.breadcrumbs()
+}
+
+type Disconnected struct{}
+
+func (d *Disconnected) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navContext) ([]list.Item, error) {
+	kubeconfig, err := upCtx.Kubecfg.RawConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]list.Item, 0, 1)
+	items = append(items, item{text: "..", kind: d.BackLabel(), onEnter: d.Back, back: true})
+
+	for name, kubectx := range kubeconfig.Contexts {
+		spacesExt, err := upbound.GetSpaceExtension(kubectx)
+		if err != nil {
+			continue
+		}
+		if spacesExt != nil {
+			// This is an up-managed context, which means it's either a cloud
+			// Space, or a disconnected Space represented by some other
+			// kubeconfig context, which we'll find later.
+			continue
+		}
+
+		// If the context points at a Space, it will have a ConfigMap containing
+		// the Space's ingress information. If we can't fetch the ConfigMap for
+		// any reason, assume the context isn't a Space.
+
+		rest, err := clientcmd.NewDefaultClientConfig(kubeconfig, &clientcmd.ConfigOverrides{
+			CurrentContext: name,
+		}).ClientConfig()
+		if err != nil {
+			continue
+		}
+
+		cl, err := client.New(rest, client.Options{})
+		if err != nil {
+			continue
+		}
+
+		ingressHost, ingressCA, err := profile.GetIngressHost(ctx, cl)
+		if err != nil {
+			continue
+		}
+
+		items = append(items, item{text: name, kind: "space", onEnter: func(m model) (model, error) {
+			m.state = &Space{
+				Name: name,
+				Ingress: spaces.SpaceIngress{
+					Host:   ingressHost,
+					CAData: ingressCA,
+				},
+				HubContext: name,
+			}
+			return m, nil
+		}})
+	}
+
+	return items, nil
+}
+
+func (d *Disconnected) breadcrumbs(styles breadcrumbStyle) string {
+	return upboundRootStyle.Render("Upbound ") + styles.previousLevel.Render("disconnected/")
+}
+
+func (d *Disconnected) Breadcrumbs() string {
+	return d.breadcrumbs(defaultBreadcrumbStyle)
+}
+
+func (d *Disconnected) Back(m model) (model, error) {
+	m.state = &Root{}
+	return m, nil
+}
+
+func (d *Disconnected) BackLabel() string {
+	return "home"
 }
 
 var _ Back = &Organization{}
@@ -160,7 +255,7 @@ func (o *Organization) Items(ctx context.Context, upCtx *upbound.Context, navCtx
 	}
 
 	items := make([]list.Item, 0)
-	items = append(items, item{text: "..", kind: "organizations", onEnter: o.Back, back: true})
+	items = append(items, item{text: "..", kind: o.BackLabel(), onEnter: o.Back, back: true})
 	for _, space := range l.Items {
 		if mode, ok := space.ObjectMeta.Labels[upboundv1alpha1.SpaceModeLabelKey]; ok {
 			if mode == string(upboundv1alpha1.ModeLegacy) {
@@ -201,8 +296,8 @@ func (o *Organization) Back(m model) (model, error) {
 	return m, nil
 }
 
-func (o *Organization) CanBack() bool {
-	return true
+func (o *Organization) BackLabel() string {
+	return "home"
 }
 
 func (o *Organization) breadcrumbs(styles breadcrumbStyle) string {
@@ -246,9 +341,7 @@ func (s *Space) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navCo
 	}
 
 	items := make([]list.Item, 0, len(nss.Items)+3)
-	if s.CanBack() {
-		items = append(items, item{text: "..", kind: "spaces", onEnter: s.Back, back: true})
-	}
+	items = append(items, item{text: "..", kind: s.BackLabel(), onEnter: s.Back, back: true})
 	for _, ns := range nss.Items {
 		items = append(items, item{text: ns.Name, kind: "group", onEnter: func(m model) (model, error) {
 			m.state = &Group{Space: *s, Name: ns.Name}
@@ -272,23 +365,34 @@ func (s *Space) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navCo
 }
 
 func (s *Space) Back(m model) (model, error) {
-	m.state = &s.Org
+	if s.IsCloud() {
+		m.state = &s.Org
+	} else {
+		m.state = &Disconnected{}
+	}
 	return m, nil
+}
+
+func (s *Space) BackLabel() string {
+	return "spaces"
 }
 
 func (s *Space) IsCloud() bool {
 	return s.Org.Name != ""
 }
 
-func (s *Space) CanBack() bool {
-	return s.IsCloud()
-}
-
 func (s *Space) breadcrumbs(styles breadcrumbStyle) string {
-	return s.Org.breadcrumbs(breadcrumbStyle{
-		currentLevel:  styles.previousLevel,
-		previousLevel: styles.previousLevel,
-	}) + styles.previousLevel.Render(fmt.Sprintf("%s/", s.Name))
+	if s.IsCloud() {
+		return s.Org.breadcrumbs(breadcrumbStyle{
+			currentLevel:  styles.previousLevel,
+			previousLevel: styles.previousLevel,
+		}) + styles.previousLevel.Render(fmt.Sprintf("%s/", s.Name))
+	} else {
+		return (&Disconnected{}).breadcrumbs(breadcrumbStyle{
+			currentLevel:  styles.previousLevel,
+			previousLevel: styles.previousLevel,
+		}) + styles.previousLevel.Render(fmt.Sprintf("%s/", s.Name))
+	}
 }
 
 func (s *Space) Breadcrumbs() string {
@@ -430,7 +534,7 @@ func (g *Group) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navCo
 	}
 
 	items := make([]list.Item, 0, len(ctps.Items)+3)
-	items = append(items, item{text: "..", kind: "groups", onEnter: g.Back, back: true})
+	items = append(items, item{text: "..", kind: g.BackLabel(), onEnter: g.Back, back: true})
 
 	for _, ctp := range ctps.Items {
 		items = append(items, item{text: ctp.Name, kind: "controlplane", onEnter: func(m model) (model, error) {
@@ -470,8 +574,8 @@ func (g *Group) Back(m model) (model, error) {
 	return m, nil
 }
 
-func (g *Group) CanBack() bool {
-	return true
+func (g *Group) BackLabel() string {
+	return "groups"
 }
 
 // ControlPlane provides the navigation node for a concrete controlplane.
@@ -485,7 +589,7 @@ var _ Back = &ControlPlane{}
 
 func (ctp *ControlPlane) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navContext) ([]list.Item, error) {
 	return []list.Item{
-		item{text: "..", kind: "controlplanes", onEnter: ctp.Back, back: true},
+		item{text: "..", kind: ctp.BackLabel(), onEnter: ctp.Back, back: true},
 		item{text: fmt.Sprintf("Connect to %q and quit", ctp.NamespacedName().Name), onEnter: KeyFunc(func(m model) (model, error) {
 			msg, err := ctp.Accept(m.upCtx, m.navContext)
 			if err != nil {
@@ -513,8 +617,8 @@ func (ctp *ControlPlane) Back(m model) (model, error) {
 	return m, nil
 }
 
-func (ctp *ControlPlane) CanBack() bool {
-	return true
+func (ctp *ControlPlane) BackLabel() string {
+	return "controlplanes"
 }
 
 func (ctp *ControlPlane) NamespacedName() types.NamespacedName {

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	google.golang.org/api v0.164.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
+	gotest.tools/v3 v3.5.1
 	helm.sh/helm/v3 v3.12.0
 	k8s.io/api v0.29.1
 	k8s.io/apiextensions-apiserver v0.29.1

--- a/go.sum
+++ b/go.sum
@@ -1464,8 +1464,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
-gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 helm.sh/helm/v3 v3.12.0 h1:rOq2TPVzg5jt4q5ermAZGZFxNW2uQhKjRhBneAutMEM=
 helm.sh/helm/v3 v3.12.0/go.mod h1:8K/469yxjUMu6BaD2EagCitkPjELUL/l2AgCO142G94=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
In the root/home screen of `up ctx`, include "Disconnected Spaces" alongside the list of cloud organizations. The "Disconnected Spaces" section lists all kubeconfig contexts that contain a Space, as determined by either the spaces extension being present in the config, or the mxp ConfigMap being present in the cluster.
  
Since the home screen is now available regardless of the user's current kubeconfig context, display a message (rather than an error) if we're unable to list organizations from cloud. This ensures that users who aren't logged in (because they use only disconnected Spaces) can still use `up ctx`.

This also makes it necessary to improve how we handle cursor manipulation in the list view. We programmatically manipulate the cursor in two cases:
  
1. When constructing the list of items, to place the cursor below the "back" item in the list if it exists.
2. When the cursor comes across an unselectable item, to "skip" it.
  
We now need to also handle unselectable items in case (1), and case (2) didn't correctly handle lists with unselectable items at the beginning or end.
  
Consolidate this handling by introducing some helper functions that handle the cursor movement and correctly handle the corner cases. We handle unselectable items at the beginning or end of lists by "bouncing" back in the direction the user was moving until we hit a selectable item; in the corner case where all items are unselectable we'll end up with an unselectable item selected, which is probably the best we can do given the constraints of the list library.

Fixes #542 