### PR TITLE
ctx: Improve performance and make UI more responsive

### DIFF
--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -28,10 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
@@ -386,7 +386,7 @@ func (c *Cmd) kubeContextWriter(upCtx *upbound.Context) kubeContextWriter {
 	}
 }
 
-type getIngressHostFn func(ctx context.Context, cl client.Client) (host string, ca []byte, err error)
+type getIngressHostFn func(ctx context.Context, cl corev1client.ConfigMapsGetter) (host string, ca []byte, err error)
 
 // DeriveState returns the navigation state based on the current context set in
 // the given kubeconfig
@@ -430,7 +430,7 @@ func DeriveNewState(ctx context.Context, conf *clientcmdapi.Config, getIngressHo
 		return &Root{}, nil // nolint:nilerr
 	}
 
-	cl, err := client.New(rest, client.Options{})
+	cl, err := corev1client.NewForConfig(rest)
 	if err != nil {
 		return &Root{}, nil // nolint:nilerr
 	}
@@ -480,7 +480,7 @@ func DeriveExistingDisconnectedState(ctx context.Context, upCtx *upbound.Context
 			return &Root{}, nil // nolint:nilerr
 		}
 
-		cl, err := client.New(rest, client.Options{})
+		cl, err := corev1client.NewForConfig(rest)
 		if err != nil {
 			return &Root{}, nil // nolint:nilerr
 		}

--- a/cmd/up/ctx/cmd_test.go
+++ b/cmd/up/ctx/cmd_test.go
@@ -23,9 +23,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/upbound/up/internal/spaces"
 	"github.com/upbound/up/internal/upbound"
@@ -637,13 +637,13 @@ func TestSwapContext(t *testing.T) {
 func TestDeriveNewState(t *testing.T) {
 	hubAuth := clientcmdapi.AuthInfo{}
 
-	ingressFound := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+	ingressFound := func(ctx context.Context, cl corev1client.ConfigMapsGetter) (host string, ca []byte, err error) {
 		return "eu-west-1.ibm-cloud.com", []byte(ingressCA), nil
 	}
-	ingressPublicNotFound := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+	ingressPublicNotFound := func(ctx context.Context, cl corev1client.ConfigMapsGetter) (host string, ca []byte, err error) {
 		return "", nil, kerrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "ingress-public")
 	}
-	ingressErr := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+	ingressErr := func(ctx context.Context, cl corev1client.ConfigMapsGetter) (host string, ca []byte, err error) {
 		return "", nil, errors.New("unknown error!")
 	}
 
@@ -774,7 +774,7 @@ func TestDeriveNewState(t *testing.T) {
 func TestDeriveExistingDisconnectedState(t *testing.T) {
 	hubAuth := clientcmdapi.AuthInfo{}
 
-	ingressFound := func(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
+	ingressFound := func(ctx context.Context, cl corev1client.ConfigMapsGetter) (host string, ca []byte, err error) {
 		return "eu-west-1.ibm-cloud.com", []byte(ingressCA), nil
 	}
 

--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -120,7 +121,9 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 func NewList(items []list.Item) list.Model {
 	l := list.New(items, itemDelegate{}, 80, 3)
 
-	l.SetShowTitle(false)
+	l.SetShowTitle(true)
+	l.Styles.Title = lipgloss.NewStyle()
+	l.SetSpinner(spinner.MiniDot)
 	l.SetShowHelp(true)
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(false)
@@ -150,7 +153,7 @@ func NewList(items []list.Item) list.Model {
 }
 
 func (m model) ListHeight() int {
-	lines := 0
+	lines := 2 // title bar
 	for _, i := range m.list.Items() {
 		itm := i.(item)
 		lines += 1 + strings.Count(itm.text, "\n")
@@ -166,12 +169,14 @@ func (m model) View() string {
 		return ""
 	}
 
+	m.list.Title = m.state.Breadcrumbs()
 	l := m.list.View()
+
 	if m.err != nil {
-		return fmt.Sprintf("%s\n\n%s\nError: %v", m.state.Breadcrumbs(), l, m.err)
+		return fmt.Sprintf("%s\nError: %v", l, m.err)
 	}
 
-	return fmt.Sprintf("%s\n\n%s", m.state.Breadcrumbs(), l)
+	return l
 }
 
 func (m model) Init() tea.Cmd {
@@ -202,47 +207,25 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { // nolint:gocyclo // T
 			}
 
 		case key.Matches(msg, selectNavBinding):
-			fallthrough
+			if i, ok := m.list.SelectedItem().(item); ok {
+				// Disable keys and run the spinner while the state updates.
+				m.list.KeyMap = list.KeyMap{}
+				return m, tea.Sequence(m.list.StartSpinner(), m.updateListState(i.onEnter))
+			}
+
 		case key.Matches(msg, backNavBinding):
-			var fn KeyFunc
-			switch {
-			case key.Matches(msg, backNavBinding):
-				if state, ok := m.state.(Back); ok {
-					fn = state.Back
-				}
-			case key.Matches(msg, selectNavBinding):
-				if i, ok := m.list.SelectedItem().(item); ok {
-					fn = i.onEnter
-				}
+			if state, ok := m.state.(Back); ok {
+				// Disable keys and run the spinner while the state updates.
+				m.list.KeyMap = list.KeyMap{}
+				return m, tea.Sequence(m.list.StartSpinner(), m.updateListState(state.Back))
 			}
-			if fn != nil {
-				newState, err := fn(m)
-				if err != nil {
-					m.err = err
-					return m, nil
-				}
-				m = newState
+		}
 
-				items, err := m.state.Items(context.Background(), m.upCtx, m.navContext)
-				if err != nil {
-					m.err = err
-					return m, nil
-				}
-
-				// recreate the list to reset the cursor position
-				m.list = NewList(items)
-				m.list.SetHeight(min(m.windowHeight-2, m.ListHeight()))
-				if _, ok := m.state.(Accepting); ok {
-					m.list.KeyMap.Quit = quitBinding
-				} else {
-					m.list.KeyMap.Quit = key.NewBinding(key.WithDisabled())
-				}
-
-				if m.termination != nil {
-					return m, tea.Quit
-				}
-			}
-			return m, nil
+	case model:
+		m = msg
+		m.list.StopSpinner()
+		if m.termination != nil {
+			return m, tea.Quit
 		}
 	}
 
@@ -252,6 +235,33 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { // nolint:gocyclo // T
 	m.list = m.moveToSelectableItem(msg)
 
 	return m, cmd
+}
+
+func (m model) updateListState(fn KeyFunc) func() tea.Msg {
+	return func() tea.Msg {
+		newState, err := fn(m)
+		if err != nil {
+			m.err = err
+			return nil
+		}
+		m = newState
+
+		items, err := m.state.Items(context.Background(), m.upCtx, m.navContext)
+		m.err = err
+
+		// recreate the list to reset the cursor position
+		if items != nil {
+			m.list = NewList(items)
+			m.list.SetHeight(min(m.windowHeight-2, m.ListHeight()))
+			if _, ok := m.state.(Accepting); ok {
+				m.list.KeyMap.Quit = quitBinding
+			} else {
+				m.list.KeyMap.Quit = key.NewBinding(key.WithDisabled())
+			}
+		}
+
+		return m
+	}
 }
 
 func (m model) moveToSelectableItem(msg tea.Msg) list.Model {

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -30,6 +30,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/utils/ptr"
@@ -210,7 +211,7 @@ func spaceItemFromKubeContext(ctx context.Context, kubeconfig clientcmdapi.Confi
 		return nil, err
 	}
 
-	cl, err := client.New(rest, client.Options{})
+	cl, err := corev1client.NewForConfig(rest)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/profile/kubeconfig.go
+++ b/internal/profile/kubeconfig.go
@@ -18,18 +18,18 @@ import (
 	"context"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // GetIngressHost returns the ingress host of the Spaces cfg points to. If the
 // ingress is not configured, it returns an empty string.
-func GetIngressHost(ctx context.Context, cl client.Client) (host string, ca []byte, err error) {
-	mxpConfig := &corev1.ConfigMap{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: "ingress-public", Namespace: "upbound-system"}, mxpConfig); err != nil {
+func GetIngressHost(ctx context.Context, cl corev1client.ConfigMapsGetter) (host string, ca []byte, err error) {
+	mxpConfig, err := cl.ConfigMaps("upbound-system").Get(ctx, "ingress-public", metav1.GetOptions{})
+	if err != nil {
 		return "", nil, err
 	}
+
 	host = mxpConfig.Data["ingress-host"]
 	ca = []byte(mxpConfig.Data["ingress-ca"])
 	return strings.TrimPrefix(host, "https://"), ca, nil


### PR DESCRIPTION
### Description of your changes

Use a timeout of 2 seconds when trying to fetch the ingress information for a disconnected Space and attempt to fetch them all in parallel. This should prevent us from hanging forever if a particular kubeconfig context is unreachable or misbehaving. To further help with slow contexts, avoid the overhead of controller-runtime's REST mapping by using the typed client-go client to fetch the ingress ConfigMap.

To make the UI feel more responsive when requests are slow, update the item list asynchronously to the main update loop of the TUI and trigger an update once we have our items. This lets us run a spinner while the items are being updated. As part of this change, switch from generating our own title to using the list widget's built-in title bar, which doesn't change how the TUI looks at all, but lets us leverage the built-in spinner capability of the list widget.

Fixes #549

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

To test the handling of slow or broken contexts, I did the following:

1. Added 50 contexts to my kubeconfig pointing at `localhost:65432`, which doesn't have any cluster listening on it.
2. Ran `nc -kl 65432` to simulate a server accepting requests but not responding.

This lets me observe the new timeout, which I verified we're hitting by adding some temporary debug logging.

Also tested navigating through the tree and selecting contexts as normal to ensure the spinner change didn't break anything.
