### PR TITLE
ctx: Dim unselectable items and improve wording for empty groups

### DIFF
--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -28,9 +28,10 @@ import (
 )
 
 var (
-	itemStyle         = lipgloss.NewStyle()
-	kindStyle         = lipgloss.NewStyle().Foreground(neutralColor)
-	selectedItemStyle = lipgloss.NewStyle().Foreground(upboundBrandColor)
+	itemStyle             = lipgloss.NewStyle()
+	unselectableItemStyle = lipgloss.NewStyle().Foreground(dimColor)
+	kindStyle             = lipgloss.NewStyle().Foreground(neutralColor)
+	selectedItemStyle     = lipgloss.NewStyle().Foreground(upboundBrandColor)
 )
 
 var backNavBinding = key.NewBinding(
@@ -102,6 +103,9 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	mainStyle := itemStyle
 	if index == m.Index() {
 		mainStyle = selectedItemStyle
+	}
+	if str.notSelectable {
+		mainStyle = unselectableItemStyle
 	}
 	padding := str.padding
 	mainStyle = mainStyle.Copy().Padding(padding.top, padding.right, padding.bottom, padding.left)

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -545,7 +545,7 @@ func (g *Group) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navCo
 	}
 
 	if len(ctps.Items) == 0 {
-		items = append(items, item{text: fmt.Sprintf("No control planes found in the %q group", g.Name), notSelectable: true})
+		items = append(items, item{text: fmt.Sprintf("No control planes found in group %q", g.Name), notSelectable: true})
 	}
 
 	items = append(items, item{text: fmt.Sprintf("Switch context to %q", fmt.Sprintf("%s/%s", g.Space.Name, g.Name)), onEnter: func(m model) (model, error) {

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -44,6 +44,7 @@ import (
 var (
 	upboundBrandColor = lipgloss.AdaptiveColor{Light: "#5e3ba5", Dark: "#af7efd"}
 	neutralColor      = lipgloss.AdaptiveColor{Light: "#4e5165", Dark: "#9a9ca7"}
+	dimColor          = lipgloss.AdaptiveColor{Light: "#9B9B9B", Dark: "#5C5C5C"}
 )
 
 var (


### PR DESCRIPTION
### Description of your changes

Make it clearer that unselectable items are unselectable by dimming them. We use the same color as the help bar, since it's appropriately subdued.

Also improve the wording for the unselectable message item in empty groups, as suggested by @mattheilman.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manual test with an empty group.
