### PR TITLE
ctx: Look up cloud/connected Space ingresses in parallel

### DIFF
--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -16,7 +16,6 @@ package ctx
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -313,10 +312,9 @@ func (o *Organization) Items(ctx context.Context, upCtx *upbound.Context, navCtx
 
 				ingress, err := navCtx.ingressReader.Get(ctx, space)
 				if err != nil {
-					if errors.Is(err, spaces.SpaceConnectionError) {
-						// we found the space to be unreachable
-						continue
-					}
+					// TODO(adamwg): Add an unselectable item for the Space with
+					// relevant text depending on the type of error.
+					continue
 				}
 
 				mu.Lock()


### PR DESCRIPTION
### Description of your changes

Similar to our recent change for disconnected Spaces, make the organization view more responsive by looking up all the cloud and connected Space ingresses in parallel.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manual testing with the two orgs I'm part of.
