### PR TITLE
ctx: Correctly handle errors on selection, including kubeconfig verification timeouts

### DIFF
--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -91,6 +91,9 @@ type model struct {
 	windowHeight int
 	list         list.Model
 
+	navDisabled    bool
+	disabledKeyMap list.KeyMap
+
 	state NavigationState
 	err   error
 

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -75,6 +76,7 @@ func VerifyKubeConfig(wrapTransport transport.WrapperFunc) func(cfg *api.Config)
 		if err != nil {
 			return err
 		}
+		restConfig.Timeout = 2 * time.Second
 		if wrapTransport != nil {
 			restConfig.Wrap(wrapTransport)
 		}


### PR DESCRIPTION
### Description of your changes

Previously, if we hit an error in the `onEnter` function when a user selected an item, we would get stuck completely: the spinner would keep spinning forever. If we hit an error when listing items for a new screen, the error would be displayed but the user wouldn't be able to navigate.

Fix both issues by correctly handling the errors. In both cases, we re-enable the keymap and return the existing model, so the user can continue to navigate.

A glaring example of this issue was if we tried to select a context that was unreachable. We would time out trying to validate the kubeconfig and sit spinning forever. Add a 2 second timeout to the kubeconfig validation to ensure we don't spin for too long, even though we now won't get stuck forever.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manual testing with unreachable disconnected spaces and spaces I don't have permission to access. Both cases would previously get stuck, and now don't.
