### PR TITLE
ctx: Always re-enable nav when updating model

### DIFF
--- a/cmd/up/ctx/list.go
+++ b/cmd/up/ctx/list.go
@@ -225,6 +225,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { // nolint:gocyclo // T
 
 	case model:
 		m = msg
+		m = m.withNavEnabled()
 		m.list.StopSpinner()
 		if m.termination != nil {
 			return m, tea.Quit
@@ -273,7 +274,6 @@ func (m model) updateListState(fn KeyFunc) func() tea.Msg {
 	return func() tea.Msg {
 		newState, err := fn(m)
 		if err != nil {
-			m = m.withNavEnabled()
 			m.err = err
 			return m
 		}
@@ -281,7 +281,6 @@ func (m model) updateListState(fn KeyFunc) func() tea.Msg {
 
 		items, err := m.state.Items(context.Background(), m.upCtx, m.navContext)
 		if err != nil {
-			m = m.withNavEnabled()
 			m.err = err
 			return m
 		}


### PR DESCRIPTION
### Description of your changes

Previously, we weren't re-enabling navigation in the happy-path case where we get a new model back from `updateListState`. This didn't prevent navigation from working, since the new model has a new list with a fresh keymap, but it did prevent us from ever disabling nav again, since `navDisabled` was stuck on true.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Manual testing with both errors and non-error cases.
