### PR TITLE
ctx: Add space name to kubeconfig extension

### DIFF
--- a/cmd/up/ctx/actions_test.go
+++ b/cmd/up/ctx/actions_test.go
@@ -166,7 +166,7 @@ func TestDisconnectedGroupAccept(t *testing.T) {
 }
 
 func TestCloudGroupAccept(t *testing.T) {
-	spaceExtension := upbound.NewCloudV1Alpha1SpaceExtension("org")
+	spaceExtension := upbound.NewCloudV1Alpha1SpaceExtension("org", "space")
 	extensionMap := map[string]runtime.Object{upbound.ContextExtensionKeySpace: spaceExtension}
 	spaceAuth := clientcmdapi.AuthInfo{Token: "space"}
 
@@ -500,7 +500,7 @@ func TestDisconnectedControlPlaneAccept(t *testing.T) {
 }
 
 func TestCloudControlPlaneAccept(t *testing.T) {
-	spaceExtension := upbound.NewCloudV1Alpha1SpaceExtension("org")
+	spaceExtension := upbound.NewCloudV1Alpha1SpaceExtension("org", "space")
 	extensionMap := map[string]runtime.Object{upbound.ContextExtensionKeySpace: spaceExtension}
 
 	tests := map[string]struct {

--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -546,7 +546,12 @@ func DeriveExistingCloudState(upCtx *upbound.Context, conf *clientcmdapi.Config,
 		return nil, errParseSpaceContext
 	}
 
-	spaceName := strings.TrimPrefix(strings.Split(ingress, ".")[0], "https://")
+	spaceName := cloud.SpaceName
+	if spaceName == "" {
+		// The space name wasn't always present in the extension. Fall back to
+		// the old behavior of deriving it from the ingress URL.
+		spaceName = strings.TrimPrefix(strings.Split(ingress, ".")[0], "https://")
+	}
 	space := Space{
 		Org:  *org,
 		Name: spaceName,

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -577,7 +577,7 @@ func (s *Space) buildClient(upCtx *upbound.Context, resource types.NamespacedNam
 	}
 
 	if s.IsCloud() {
-		refContext.Extensions[upbound.ContextExtensionKeySpace] = upbound.NewCloudV1Alpha1SpaceExtension(s.Org.Name)
+		refContext.Extensions[upbound.ContextExtensionKeySpace] = upbound.NewCloudV1Alpha1SpaceExtension(s.Org.Name, s.Name)
 	} else {
 		refContext.Extensions[upbound.ContextExtensionKeySpace] = upbound.NewDisconnectedV1Alpha1SpaceExtension(s.HubContext)
 	}

--- a/internal/upbound/extension_types.go
+++ b/internal/upbound/extension_types.go
@@ -30,6 +30,7 @@ type DisconnectedConfiguration struct {
 // CloudConfiguration is the configuration of a cloud space
 type CloudConfiguration struct {
 	Organization string `json:"organization"`
+	SpaceName    string `json:"space"`
 }
 
 // SpaceExtensionSpec is the spec of SpaceExtension
@@ -55,7 +56,7 @@ var (
 	SpaceExtensionKind = reflect.TypeOf(SpaceExtension{}).Name()
 )
 
-func NewCloudV1Alpha1SpaceExtension(org string) *SpaceExtension {
+func NewCloudV1Alpha1SpaceExtension(org, space string) *SpaceExtension {
 	return &SpaceExtension{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       SpaceExtensionKind,
@@ -64,6 +65,7 @@ func NewCloudV1Alpha1SpaceExtension(org string) *SpaceExtension {
 		Spec: &SpaceExtensionSpec{
 			Cloud: &CloudConfiguration{
 				Organization: org,
+				SpaceName:    space,
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

Previously, we parsed the ingress URL to determine the name of the Space when
deriving initial state. This was correct for cloud spaces, but not for connected
spaces, since they use a URL starting with `proxy.`.

Add the name of the space to our kubeconfig extension and use it as the space
name when deriving state if it's present. If it's not present, fall back to the
old behavior (in case anyone has a pre-existing kubeconfig with the old
extension in it).

Fixes #557

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Added/updated unit tests to cover the new code paths, and tested manually with cloud, connected, and disconnected Spaces.
