### PR TITLE
Remove default loading rules for explicit paths

### DIFF
--- a/cmd/up/ctx/writer.go
+++ b/cmd/up/ctx/writer.go
@@ -74,7 +74,8 @@ func (f *fileWriter) Write(config *clientcmdapi.Config) error {
 	pathOptions := clientcmd.NewDefaultPathOptions()
 	if f.fileOverride != "" {
 		pathOptions = &clientcmd.PathOptions{
-			GlobalFile: f.fileOverride,
+			GlobalFile:   f.fileOverride,
+			LoadingRules: &clientcmd.ClientConfigLoadingRules{},
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Fixes https://github.com/upbound/up/issues/562

With some Github searching, I found another project that sets the explicit output path here: https://github.com/kubernetes-sigs/kwok/blob/4f5fb135109ce234d8ccdb185ed041647bc4dd90/pkg/utils/kubeconfig/kubeconfig.go#L129-L132

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
$ ./_output/bin/darwin_arm64/up ctx upbound/upbound-aws-us-east-1/default/michael-test -f ../here.yaml
Switched kubeconfig context to: Upbound upbound/upbound-aws-us-east-1/default/michael-test
$ ls .. | grep here.yaml
here.yaml
```
