### PR TITLE
feat(mirror): add alpha space mirror cmd

### DIFF
--- a/cmd/up/main.go
+++ b/cmd/up/main.go
@@ -69,6 +69,7 @@ func (c *cli) AfterApply(ctx *kong.Context) error { //nolint:unparam
 	}
 
 	printer := upterm.DefaultObjPrinter
+	printer.DryRun = c.DryRun
 	printer.Format = c.Format
 	printer.Pretty = c.Pretty
 	printer.Quiet = c.Quiet
@@ -93,6 +94,7 @@ type cli struct {
 	Format config.Format    `name:"format" enum:"default,json,yaml" default:"default" help:"Format for get/list commands. Can be: json, yaml, default"`
 	Quiet  config.QuietFlag `short:"q" name:"quiet" help:"Suppress all output."`
 	Pretty bool             `name:"pretty" help:"Pretty print output."`
+	DryRun bool             `name:"dry-run" help:"dry-run output."`
 
 	License licenseCmd `cmd:"" help:"Print Up license information."`
 

--- a/cmd/up/space/mirror/mirror.go
+++ b/cmd/up/space/mirror/mirror.go
@@ -1,0 +1,209 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up/internal/oci"
+	"github.com/upbound/up/internal/upterm"
+)
+
+type Cmd struct {
+	ToDir   string `optional:"" help:"Specify the path to the local directory where images will be exported as .tgz files." short:"t"`
+	To      string `optional:"" help:"Specify the destination registry." short:"d"`
+	Version string `required:"" help:"Specify the specific Spaces version for which you want to mirror the images." short:"v"`
+}
+
+type spinner struct {
+	*pterm.SpinnerPrinter
+}
+
+func (s spinner) Start(text ...interface{}) (Printer, error) {
+	return s.SpinnerPrinter.Start(text...)
+}
+
+func (j *uxpVersionsPath) GetSupportedVersions() ([]string, error) {
+	return j.Controller.Crossplane.SupportedVersions, nil
+}
+
+// Run executes the mirror command.
+func (c *Cmd) Run(ctx context.Context, printer upterm.ObjectPrinter) (rErr error) { //nolint:gocyclo
+
+	if c.ToDir != "" {
+		info, err := os.Stat(c.ToDir)
+		switch {
+		case os.IsNotExist(err):
+			// Directory does not exist, create it
+			if err := os.MkdirAll(c.ToDir, os.ModePerm); err != nil {
+				return fmt.Errorf("failed to create directory: %w", err)
+			}
+		case err != nil:
+			// An error occurred while trying to check the directory
+			return fmt.Errorf("failed to check directory: %w", err)
+		case !info.IsDir():
+			// Path exists but is not a directory
+			return fmt.Errorf("path exists but is not a directory")
+		}
+
+		// Add trailing slash if needed
+		if !strings.HasSuffix(c.ToDir, "/") {
+			c.ToDir += "/"
+		}
+	}
+
+	// remove leading v
+	c.Version = strings.TrimPrefix(c.Version, "v")
+
+	// use crane auth from local keychain
+	craneAuth := []crane.Option{
+		crane.WithAuthFromKeychain(authn.DefaultKeychain),
+	}
+
+	for _, repo := range artifacts.oci {
+		if err := c.mirrorWithExtraImages(ctx, printer, repo, craneAuth); err != nil {
+			return fmt.Errorf("mirror artifacts failed: %w", err)
+		}
+	}
+
+	for _, image := range artifacts.images {
+		if err := c.mirrorArtifact(printer, image, craneAuth); err != nil {
+			return fmt.Errorf("mirror artifacts failed: %w", err)
+		}
+	}
+
+	if !printer.DryRun {
+		if len(c.ToDir) > 1 {
+			pterm.Println("\nSuccessfully exported artifacts for spaces!")
+		}
+		if len(c.To) > 1 {
+			pterm.Println("\nSuccessfully mirrored artifacts for spaces!")
+		}
+	}
+
+	return nil
+}
+
+func (c *Cmd) mirrorWithExtraImages(ctx context.Context, printer upterm.ObjectPrinter, repo repository, craneAuth []crane.Option) error { //nolint:gocyclo
+	setupStyling(printer)
+	upterm.DefaultObjPrinter.Pretty = true
+
+	if !printer.DryRun {
+		if len(c.ToDir) > 1 {
+			pterm.Println("Export artifacts for spaces ...")
+		}
+		if len(c.To) > 1 {
+			pterm.Println("Mirroring mirrored artifacts for spaces ...")
+		}
+	}
+
+	DefaultSpinner = &spinner{upterm.CheckmarkSuccessSpinner}
+
+	s := logAndStartSpinner(printer, "Scanning tags to export...")
+
+	// check if version is available
+	tags, err := oci.ListTags(ctx, repo.chart)
+	if err != nil {
+		return fmt.Errorf("listing tags: %w", err)
+	}
+
+	if !oci.TagExists(tags, c.Version) {
+		return fmt.Errorf("version %s not found in the list of tags for %s", c.Version, repo.chart)
+	}
+
+	if !printer.DryRun {
+		s.Success("Scanning tags to export...")
+	}
+	// mirror main chart
+	if err := c.mirrorArtifact(printer, fmt.Sprintf("%s:%s", repo.chart, c.Version), craneAuth); err != nil {
+		return fmt.Errorf("mirroring chart: %w", err)
+	}
+
+	for _, subChart := range repo.subCharts {
+		if subChart.pathNavigator != nil {
+			// extract path from values from main chart
+			versions, err := oci.GetValuesFromChart(repo.chart, c.Version, subChart.pathNavigator)
+			if err != nil {
+				return fmt.Errorf("unable to extract: %w", err)
+			}
+			for _, version := range versions {
+				// mirror sub chart
+				if err := c.mirrorArtifact(printer, fmt.Sprintf("%s:%s", subChart.chart, version), craneAuth); err != nil {
+					return fmt.Errorf("mirroring image %s: %w", subChart.chart, err)
+				}
+				// mirror image for sub chart
+				if err := c.mirrorArtifact(printer, fmt.Sprintf("%s:v%s", subChart.image, version), craneAuth); err != nil {
+					return fmt.Errorf("mirroring image %s: %w", subChart.chart, err)
+				}
+			}
+
+		}
+	}
+
+	for _, image := range repo.images {
+		// mirror all other images with same tag than main chart
+		if err := c.mirrorArtifact(printer, fmt.Sprintf("%s:v%s", image, c.Version), craneAuth); err != nil {
+			return fmt.Errorf("mirroring image %s: %w", image, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Cmd) mirrorArtifact(printer upterm.ObjectPrinter, artifact string, craneAuth []crane.Option) error {
+
+	path := fmt.Sprintf("%s%s.tgz", c.ToDir, oci.GetArtifactName(artifact))
+	rawArtifactName := oci.RemoveDomainAndOrg(artifact)
+
+	if printer.DryRun {
+		if len(c.ToDir) > 1 {
+			pterm.Printfln("crane pull %s %s", artifact, path)
+		}
+		if len(c.To) > 1 {
+			pterm.Printfln("crane copy %s %s/%s", artifact, c.To, rawArtifactName)
+		}
+		return nil
+	}
+
+	if len(c.ToDir) > 1 {
+		img, err := crane.Pull(artifact, craneAuth...)
+		if err != nil {
+			return fmt.Errorf("pulling image: %w", err)
+		}
+		follow := fmt.Sprintf("save artifact %s ...", artifact)
+		s := logAndStartSpinner(printer, follow)
+		if err := crane.Save(img, artifact, path); err != nil {
+			s.Fail(follow)
+			return fmt.Errorf("saving tarball %s: %w", path, err)
+		}
+		s.Success(follow)
+	} else {
+		follow := fmt.Sprintf("mirror artifact %s to %s", rawArtifactName, c.To)
+		s := logAndStartSpinner(printer, follow)
+		if err := crane.Copy(artifact, fmt.Sprintf("%s/%s", c.To, rawArtifactName), craneAuth...); err != nil {
+			s.Fail(follow)
+			return fmt.Errorf("push failed %s: %w", artifact, err)
+		}
+		s.Success(follow)
+	}
+	return nil
+}

--- a/cmd/up/space/mirror/spinner.go
+++ b/cmd/up/space/mirror/spinner.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"github.com/pterm/pterm"
+
+	"github.com/upbound/up/internal/upterm"
+)
+
+// DefaultSpinner is the default spinner used by all the other subpackages, by
+// default it's just a no-op.
+var DefaultSpinner Spinner = noopSpinner{}
+
+// noopSpinner is a spinner that does nothing.
+type noopSpinner struct{}
+
+func (noopSpinner) Start(_ ...interface{}) (Printer, error) {
+	return &noopPrinter{}, nil
+}
+
+// noopPrinter is a spinner printer that does nothing.
+type noopPrinter struct{}
+
+func (n noopPrinter) Success(_ ...interface{}) {}
+
+func (n noopPrinter) Fail(_ ...interface{}) {}
+
+func (n noopPrinter) UpdateText(_ string) {}
+
+// Spinner is an interface for creating Printers.
+type Spinner interface {
+	Start(text ...interface{}) (Printer, error)
+}
+
+// Printer is an interface for printing through a spinner.
+type Printer interface {
+	Success(msg ...interface{})
+	Fail(msg ...interface{})
+	UpdateText(text string)
+}
+
+// setupStyling to enable or disable styling for dry-run disabled.
+func setupStyling(printer upterm.ObjectPrinter) {
+	if !printer.DryRun {
+		pterm.EnableStyling()
+	} else {
+		pterm.DisableStyling()
+	}
+}
+
+// logAndStartSpinner to enable or disable spinner for dry-run disabled.
+func logAndStartSpinner(printer upterm.ObjectPrinter, message string) *pterm.SpinnerPrinter {
+	if printer.DryRun {
+		return nil
+	}
+	spinnerInstance, _ := DefaultSpinner.Start(message)
+	return spinnerInstance.(*pterm.SpinnerPrinter)
+}

--- a/cmd/up/space/mirror/static_artifacts.go
+++ b/cmd/up/space/mirror/static_artifacts.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+var artifacts = config{
+	oci: []repository{
+		{
+			// spaces chart
+			// version given by --version in cmd
+			chart: "xpkg.upbound.io/spaces-artifacts/spaces",
+			// searchPath list all supported uxp versions in spaces chart
+			subCharts: []subChart{
+				{
+					pathNavigator: &uxpVersionsPath{},
+					chart:         "xpkg.upbound.io/upbound/universal-crossplane",
+					image:         "xpkg.upbound.io/upbound/crossplane",
+				},
+			},
+			// all images with the same tag then spaces helm-chart
+			// version given by --version in cmd
+			images: []string{
+				"xpkg.upbound.io/spaces-artifacts/hyperspace",
+				"xpkg.upbound.io/spaces-artifacts/mxe-composition-templates",
+				"xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook",
+				"xpkg.upbound.io/spaces-artifacts/mxp-benchmark",
+				"xpkg.upbound.io/spaces-artifacts/mxp-charts",
+				"xpkg.upbound.io/spaces-artifacts/mxp-control-plane",
+				"xpkg.upbound.io/spaces-artifacts/mxp-host-cluster-worker",
+				"xpkg.upbound.io/spaces-artifacts/mxp-host-cluster",
+				"xpkg.upbound.io/spaces-artifacts/opentelemetry-collector-spaces",
+				"xpkg.upbound.io/spaces-artifacts/provider-host-cluster",
+			},
+		},
+	},
+	// additional images for prerequisits
+	images: []string{
+		"xpkg.upbound.io/spaces-artifacts/mcp-connector:0.6.0",
+		"xpkg.upbound.io/spaces-artifacts/mcp-connector-server:v0.6.0",
+		"xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1",
+		"xpkg.upbound.io/crossplane-contrib/provider-helm:v0.19.0",
+		"xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.14.0",
+	},
+}

--- a/cmd/up/space/mirror/types.go
+++ b/cmd/up/space/mirror/types.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import "github.com/upbound/up/internal/oci"
+
+type repository struct {
+	chart     string
+	images    []string
+	subCharts []subChart
+}
+
+type subChart struct {
+	pathNavigator oci.PathNavigator
+	chart         string
+	image         string
+}
+
+type uxpVersionsPath struct {
+	Controller struct {
+		Crossplane struct {
+			SupportedVersions []string `json:"supportedVersions"`
+		} `json:"crossplane"`
+	} `json:"controller"`
+}
+
+type config struct {
+	oci    []repository
+	images []string
+}

--- a/cmd/up/space/space.go
+++ b/cmd/up/space/space.go
@@ -18,6 +18,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/upbound/up/cmd/up/space/billing"
+	"github.com/upbound/up/cmd/up/space/mirror"
 	"github.com/upbound/up/internal/feature"
 	"github.com/upbound/up/internal/upbound"
 )
@@ -41,6 +42,7 @@ type Cmd struct {
 	Destroy destroyCmd `cmd:"" help:"Remove the Upbound Spaces deployment."`
 	Upgrade upgradeCmd `cmd:"" help:"Upgrade the Upbound Spaces deployment."`
 	List    listCmd    `cmd:"" help:"List all accessible spaces in Upbound."`
+	Mirror  mirror.Cmd `cmd:"" maturity:"alpha" help:"List of all OCI artifacts required for Spaces."`
 
 	Billing billing.Cmd `cmd:""`
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/alecthomas/assert/v2 v2.1.0
 	github.com/alecthomas/chroma v0.10.0
 	github.com/alecthomas/kong v0.8.0
 	github.com/aws/aws-sdk-go v1.44.313
@@ -37,6 +38,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.8.4
 	github.com/upbound/up-sdk-go v0.3.1-0.20240624053239-92e3d908f65f
 	github.com/upbound/up/pkg/migration v0.0.0-00010101000000-000000000000
 	github.com/willabides/kongplete v0.3.0
@@ -74,6 +76,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.3.0 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
+	github.com/alecthomas/repr v0.1.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
@@ -82,6 +85,7 @@ require (
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/invopop/jsonschema v0.12.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
@@ -90,6 +94,7 @@ require (
 	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/muesli/roff v0.1.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -1,0 +1,62 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/crane"
+)
+
+// ListTagsFunc is a type for the ListTags function
+type ListTagsFunc func(repo string, options ...crane.Option) ([]string, error)
+
+// DefaultListTags is the default implementation of ListTagsFunc
+var DefaultListTags ListTagsFunc = crane.ListTags
+
+// GetArtifactName extracts the artifact name from the chart reference and replaces ':' with '-'
+func GetArtifactName(artifact string) string {
+	parts := strings.Split(artifact, "/")
+	artifactPathName := parts[len(parts)-1]
+	return strings.ReplaceAll(artifactPathName, ":", "-")
+}
+
+// RemoveDomainAndOrg removes the domain and organization from the repository URL
+func RemoveDomainAndOrg(src string) string {
+	parts := strings.SplitN(src, "/", 3)
+	if len(parts) == 3 {
+		return parts[2]
+	}
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return src
+}
+
+// TagExists checks if a specific version exists in the list of tags
+func TagExists(tags []string, version string) bool {
+	for _, tag := range tags {
+		if tag == version {
+			return true
+		}
+	}
+	return false
+}
+
+// ListTags lists the tags for a given repository
+func ListTags(ctx context.Context, repository string) ([]string, error) {
+	return DefaultListTags(repository)
+}

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -1,0 +1,175 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/google/go-containerregistry/pkg/crane"
+)
+
+// TestGetArtifactName tests the GetArtifactName function
+func TestGetArtifactName(t *testing.T) {
+	tests := []struct {
+		name     string
+		artifact string
+		expected string
+	}{
+		{
+			name:     "Basic Case",
+			artifact: "oci://xpkg.upbound.io/spaces-artifacts/spaces:1.0.0",
+			expected: "spaces-1.0.0",
+		},
+		{
+			name:     "No Version",
+			artifact: "xpkg.upbound.io/spaces-artifacts/spaces",
+			expected: "spaces",
+		},
+		{
+			name:     "Multiple Colons",
+			artifact: "oci://xpkg.upbound.io/spaces-artifacts/spaces:1.0.0:latest",
+			expected: "spaces-1.0.0-latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetArtifactName(tt.artifact)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestRemoveDomainAndOrg tests the RemoveDomainAndOrg function
+func TestRemoveDomainAndOrg(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      string
+		expected string
+	}{
+		{
+			name:     "Basic Case",
+			src:      "xpkg.upbound.io/org/repo",
+			expected: "repo",
+		},
+		{
+			name:     "Missing Parts",
+			src:      "repo",
+			expected: "repo",
+		},
+		{
+			name:     "Only Domain",
+			src:      "xpkg.upbound.io/repo",
+			expected: "repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RemoveDomainAndOrg(tt.src)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestTagExists tests the TagExists function
+func TestTagExists(t *testing.T) {
+	tests := []struct {
+		name     string
+		tags     []string
+		version  string
+		expected bool
+	}{
+		{
+			name:     "Tag Exists",
+			tags:     []string{"1.0.0", "1.1.0", "1.2.0"},
+			version:  "1.1.0",
+			expected: true,
+		},
+		{
+			name:     "Tag Does Not Exist",
+			tags:     []string{"1.0.0", "1.1.0", "1.2.0"},
+			version:  "2.0.0",
+			expected: false,
+		},
+		{
+			name:     "Empty Tags",
+			tags:     []string{},
+			version:  "1.0.0",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TagExists(tt.tags, tt.version)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestListTags tests the ListTags function
+func TestListTags(t *testing.T) {
+	tests := []struct {
+		name       string
+		repository string
+		mockTags   []string
+		mockError  error
+		expected   []string
+		expectErr  bool
+	}{
+		{
+			name:       "Successful Tag Listing",
+			repository: "spaces",
+			mockTags:   []string{"1.0.0", "1.1.0", "1.2.0"},
+			mockError:  nil,
+			expected:   []string{"1.0.0", "1.1.0", "1.2.0"},
+			expectErr:  false,
+		},
+		{
+			name:       "Error in Tag Listing",
+			repository: "spaces",
+			mockTags:   nil,
+			mockError:  errors.New("failed to list tags"),
+			expected:   nil,
+			expectErr:  true,
+		},
+	}
+
+	originalListTags := DefaultListTags
+	defer func() { DefaultListTags = originalListTags }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DefaultListTags = func(repo string, options ...crane.Option) ([]string, error) {
+				if repo == tt.repository {
+					return tt.mockTags, tt.mockError
+				}
+				return nil, nil
+			}
+
+			result, err := ListTags(context.Background(), tt.repository)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/internal/oci/values.go
+++ b/internal/oci/values.go
@@ -1,0 +1,132 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/cli"
+)
+
+type PathNavigator interface {
+	GetSupportedVersions() ([]string, error)
+}
+
+// LoaderFunc is a function type for loading charts
+type LoaderFunc func(name string) (*chart.Chart, error)
+
+// PullFunc is a function type for pulling charts
+type PullFunc func(src, version string) (string, error)
+
+// GetValuesFromChart fetches the supported versions from a Helm chart specified by the chart and version parameters.
+func GetValuesFromChart[T PathNavigator](chart, version string, pathNavigator T) ([]string, error) {
+	return getValuesFromChartWithLoaderAndPull(chart, version, pathNavigator, loader.Load, defaultPullFunc)
+}
+
+// getValuesFromChartWithLoaderAndPull is a helper function that fetches the supported versions
+// from a Helm chart specified by the chart and version parameters. It allows custom loader and
+// pull functions to be provided for more flexible testing and use cases.
+func getValuesFromChartWithLoaderAndPull[T PathNavigator](chart, version string, pathNavigator T, loaderFunc LoaderFunc, pullFunc PullFunc) ([]string, error) {
+	src := fmt.Sprintf("oci://%s", chart)
+	settings := cli.New()
+
+	actionConfig := new(action.Configuration)
+	if err := actionConfig.Init(
+		settings.RESTClientGetter(),
+		settings.Namespace(),
+		"configmap",
+		log.Printf,
+	); err != nil {
+		return nil, fmt.Errorf("failed to initialize Helm action configuration: %w", err)
+	}
+
+	tempDir, err := pullFunc(src, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull chart: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			log.Printf("failed to remove temporary directory: %v", err)
+		}
+	}()
+
+	chartPath := filepath.Join(tempDir, GetArtifactName(chart))
+	loadedChart, err := loaderFunc(chartPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load chart: %w", err)
+	}
+
+	valuesJSON, err := json.Marshal(loadedChart.Values)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal chart values: %w", err)
+	}
+
+	if err := json.Unmarshal(valuesJSON, &pathNavigator); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal chart values: %w", err)
+	}
+
+	return pathNavigator.GetSupportedVersions()
+}
+
+// defaultPullFunc is the default implementation of the PullFunc type for pulling charts.
+func defaultPullFunc(src, version string) (string, error) {
+	settings := cli.New()
+	actionConfig := new(action.Configuration)
+	if err := actionConfig.Init(
+		settings.RESTClientGetter(),
+		settings.Namespace(),
+		"configmap",
+		log.Printf,
+	); err != nil {
+		return "", fmt.Errorf("failed to initialize Helm action configuration: %w", err)
+	}
+
+	f, err := os.MkdirTemp("", "untar")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+
+	co := action.ChartPathOptions{
+		PassCredentialsAll: true,
+		Version:            version,
+	}
+
+	opts := []action.PullOpt{
+		action.WithConfig(actionConfig),
+	}
+
+	pull := action.NewPullWithOpts(opts...)
+	pull.ChartPathOptions = co
+	pull.Untar = true
+	pull.Settings = settings
+	pull.DestDir = f
+
+	_, err = pull.Run(src)
+	if err != nil {
+		if removeErr := os.RemoveAll(f); removeErr != nil {
+			log.Printf("failed to remove temporary directory: %v", removeErr)
+		}
+		return "", fmt.Errorf("failed to pull chart: %w", err)
+	}
+
+	return f, nil
+}

--- a/internal/oci/values_test.go
+++ b/internal/oci/values_test.go
@@ -46,7 +46,11 @@ func mockLoaderLoad(name string) (*chart.Chart, error) {
 }
 
 func mockPullRun(src, version string) (string, error) {
-	return os.TempDir(), nil
+	dir, err := os.MkdirTemp("", "mock")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	return dir, nil
 }
 
 // TestGetValuesFromChart tests the GetValuesFromChart function

--- a/internal/oci/values_test.go
+++ b/internal/oci/values_test.go
@@ -1,0 +1,130 @@
+// Copyright 2024 Upbound Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// MockPathNavigator is a mock implementation of PathNavigator for testing
+type MockPathNavigator struct {
+	SupportedVersions []string `json:"supportedVersions"`
+}
+
+func (m *MockPathNavigator) GetSupportedVersions() ([]string, error) {
+	return m.SupportedVersions, nil
+}
+
+// Mock functions
+func mockLoaderLoad(name string) (*chart.Chart, error) {
+	return &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name: name,
+		},
+		Values: map[string]interface{}{
+			"supportedVersions": []string{"v1", "v2", "v3"},
+		},
+	}, nil
+}
+
+func mockPullRun(src, version string) (string, error) {
+	return os.TempDir(), nil
+}
+
+// TestGetValuesFromChart tests the GetValuesFromChart function
+func TestGetValuesFromChart(t *testing.T) {
+	// Setup mock functions and data
+	chartName := "test-chart"
+	version := "1.0.0"
+	supportedVersions := []string{"v1", "v2", "v3"}
+
+	mockNavigator := &MockPathNavigator{}
+	mockNavigator.SupportedVersions = supportedVersions
+
+	// Run the function
+	versions, err := getValuesFromChartWithLoaderAndPull(chartName, version, mockNavigator, mockLoaderLoad, mockPullRun)
+	require.NoError(t, err)
+	assert.Equal(t, supportedVersions, versions)
+}
+
+// TestGetValuesFromChart_PullError tests the GetValuesFromChart function when Pull fails
+func TestGetValuesFromChart_PullError(t *testing.T) {
+	// Setup mock functions and data
+	chartName := "test-chart"
+	version := "1.0.0"
+
+	mockNavigator := &MockPathNavigator{}
+
+	// Mock Pull function to simulate an error
+	mockPullRunError := func(src, version string) (string, error) {
+		return "", fmt.Errorf("failed to pull chart")
+	}
+
+	// Run the function
+	_, err := getValuesFromChartWithLoaderAndPull(chartName, version, mockNavigator, mockLoaderLoad, mockPullRunError)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to pull chart")
+}
+
+// TestGetValuesFromChart_LoadError tests the GetValuesFromChart function when Load fails
+func TestGetValuesFromChart_LoadError(t *testing.T) {
+	// Setup mock functions and data
+	chartName := "test-chart"
+	version := "1.0.0"
+
+	mockNavigator := &MockPathNavigator{}
+
+	// Mock the loader function to simulate an error
+	loaderFuncError := func(name string) (*chart.Chart, error) {
+		return nil, fmt.Errorf("failed to load chart")
+	}
+
+	// Run the function
+	_, err := getValuesFromChartWithLoaderAndPull(chartName, version, mockNavigator, loaderFuncError, mockPullRun)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load chart")
+}
+
+// TestGetValuesFromChart_JSONError tests the GetValuesFromChart function when JSON unmarshalling fails
+func TestGetValuesFromChart_JSONError(t *testing.T) {
+	// Setup mock functions and data
+	chartName := "test-chart"
+	version := "1.0.0"
+
+	mockNavigator := &MockPathNavigator{}
+
+	// Mock chart values with invalid JSON
+	loaderFuncError := func(name string) (*chart.Chart, error) {
+		return &chart.Chart{
+			Metadata: &chart.Metadata{
+				Name: name,
+			},
+			Values: map[string]interface{}{
+				"supportedVersions": func() {}, // Invalid type for JSON marshaling
+			},
+		}, nil
+	}
+
+	// Run the function
+	_, err := getValuesFromChartWithLoaderAndPull(chartName, version, mockNavigator, loaderFuncError, mockPullRun)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal chart values")
+}

--- a/internal/upterm/printer.go
+++ b/internal/upterm/printer.go
@@ -46,6 +46,7 @@ type Printer interface {
 type ObjectPrinter struct {
 	Quiet  config.QuietFlag
 	Pretty bool
+	DryRun bool
 	Format config.Format
 
 	TablePrinter *pterm.TablePrinter
@@ -55,6 +56,7 @@ var (
 	DefaultObjPrinter = ObjectPrinter{
 		Quiet:        false,
 		Pretty:       false,
+		DryRun:       false,
 		Format:       config.Default,
 		TablePrinter: pterm.DefaultTable.WithSeparator("   "),
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
add `up alpha space mirror` command

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
docker login docker.io/haarchri
docker login xpkg.upbound.io
```

dry-run:
```
up alpha space mirror --version 1.6.0-rc.0.75.gc383bddc --to-dir /tmp/tt      --dry-run
crane pull xpkg.upbound.io/spaces-artifacts/spaces:1.6.0-rc.0.75.gc383bddc /tmp/tt/spaces-1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.1-up.1 /tmp/tt/universal-crossplane-1.14.1-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.1-up.1 /tmp/tt/crossplane-v1.14.1-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.2-up.1 /tmp/tt/universal-crossplane-1.14.2-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.2-up.1 /tmp/tt/crossplane-v1.14.2-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.3-up.1 /tmp/tt/universal-crossplane-1.14.3-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.3-up.1 /tmp/tt/crossplane-v1.14.3-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.4-up.1 /tmp/tt/universal-crossplane-1.14.4-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.4-up.1 /tmp/tt/crossplane-v1.14.4-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.5-up.1 /tmp/tt/universal-crossplane-1.14.5-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.5-up.1 /tmp/tt/crossplane-v1.14.5-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.6-up.1 /tmp/tt/universal-crossplane-1.14.6-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.6-up.1 /tmp/tt/crossplane-v1.14.6-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.7-up.1 /tmp/tt/universal-crossplane-1.14.7-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.7-up.1 /tmp/tt/crossplane-v1.14.7-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.8-up.1 /tmp/tt/universal-crossplane-1.14.8-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.8-up.1 /tmp/tt/crossplane-v1.14.8-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.14.9-up.1 /tmp/tt/universal-crossplane-1.14.9-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.14.9-up.1 /tmp/tt/crossplane-v1.14.9-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.15.0-up.1 /tmp/tt/universal-crossplane-1.15.0-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.15.0-up.1 /tmp/tt/crossplane-v1.15.0-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.15.1-up.1 /tmp/tt/universal-crossplane-1.15.1-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.15.1-up.1 /tmp/tt/crossplane-v1.15.1-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.15.2-up.1 /tmp/tt/universal-crossplane-1.15.2-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.15.2-up.1 /tmp/tt/crossplane-v1.15.2-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.15.3-up.1 /tmp/tt/universal-crossplane-1.15.3-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.15.3-up.1 /tmp/tt/crossplane-v1.15.3-up.1.tgz
crane pull xpkg.upbound.io/upbound/universal-crossplane:1.16.0-up.1 /tmp/tt/universal-crossplane-1.16.0-up.1.tgz
crane pull xpkg.upbound.io/upbound/crossplane:v1.16.0-up.1 /tmp/tt/crossplane-v1.16.0-up.1.tgz
crane pull xpkg.upbound.io/spaces-artifacts/hyperspace:v1.6.0-rc.0.75.gc383bddc /tmp/tt/hyperspace-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mxe-composition-templates:v1.6.0-rc.0.75.gc383bddc /tmp/tt/mxe-composition-templates-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook:v1.6.0-rc.0.75.gc383bddc /tmp/tt/mxp-authz-webhook-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mxp-benchmark:v1.6.0-rc.0.75.gc383bddc /tmp/tt/mxp-benchmark-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mxp-charts:v1.6.0-rc.0.75.gc383bddc /tmp/tt/mxp-charts-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mxp-control-plane:v1.6.0-rc.0.75.gc383bddc /tmp/tt/mxp-control-plane-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mxp-host-cluster-worker:v1.6.0-rc.0.75.gc383bddc /tmp/tt/mxp-host-cluster-worker-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mxp-host-cluster:v1.6.0-rc.0.75.gc383bddc /tmp/tt/mxp-host-cluster-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/opentelemetry-collector-spaces:v1.6.0-rc.0.75.gc383bddc /tmp/tt/opentelemetry-collector-spaces-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/provider-host-cluster:v1.6.0-rc.0.75.gc383bddc /tmp/tt/provider-host-cluster-v1.6.0-rc.0.75.gc383bddc.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mcp-connector:0.6.0 /tmp/tt/mcp-connector-0.6.0.tgz
crane pull xpkg.upbound.io/spaces-artifacts/mcp-connector-server:v0.6.0 /tmp/tt/mcp-connector-server-v0.6.0.tgz
crane pull xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1 /tmp/tt/function-auto-ready-v0.2.1.tgz
crane pull xpkg.upbound.io/crossplane-contrib/provider-helm:v0.19.0 /tmp/tt/provider-helm-v0.19.0.tgz
crane pull xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.14.0 /tmp/tt/provider-kubernetes-v0.14.0.tgz

```
do it:
```
up alpha space mirror --version 1.6.0-rc.0.75.gc383bddc --to-dir /tmp/tt           
Export artifacts for spaces ...
  ✓   Scanning tags to export...                                                                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/spaces:1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.1-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.1-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.2-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.2-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.3-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.3-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.4-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.4-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.5-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.5-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.6-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.6-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.7-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.7-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.8-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.8-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.14.9-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.14.9-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.15.0-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.15.0-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.15.1-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.15.1-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.15.2-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.15.2-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.15.3-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.15.3-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/upbound/universal-crossplane:1.16.0-up.1 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/upbound/crossplane:v1.16.0-up.1 ...                                                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/hyperspace:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                                       
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mxe-composition-templates:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                        
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                                
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mxp-benchmark:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                                    
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mxp-charts:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                                       
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mxp-control-plane:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                                
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mxp-host-cluster-worker:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                          
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mxp-host-cluster:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                                 
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/opentelemetry-collector-spaces:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/provider-host-cluster:v1.6.0-rc.0.75.gc383bddc ...                                                                                                                                                                            
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mcp-connector:0.6.0 ...                                                                                                                                                                                                       
  ✓   save artifact xpkg.upbound.io/spaces-artifacts/mcp-connector-server:v0.6.0 ...                                                                                                                                                                                               
  ✓   save artifact xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1 ...                                                                                                                                                                                              
  ✓   save artifact xpkg.upbound.io/crossplane-contrib/provider-helm:v0.19.0 ...                                                                                                                                                                                                   
  ✓   save artifact xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.14.0 ...             

Successfully exported artifacts for spaces!

```                                                                                                                                                                                


test:
```
(⎈|kind-local-dev:N/A)➜  up git:(main) ✗ ls -ali /tmp/tt
total 1221624
58953423 drwxr-xr-x@ 46 haarchri  wheel      1472 Jul  4 18:54 .
56926202 drwxrwxrwt   5 root      wheel       160 Jul  4 18:53 ..
58953540 -rw-r--r--@  1 haarchri  wheel  16992256 Jul  4 18:52 crossplane-v1.14.1-up.1.tgz
58953567 -rw-r--r--@  1 haarchri  wheel  16993280 Jul  4 18:52 crossplane-v1.14.2-up.1.tgz
58953591 -rw-r--r--@  1 haarchri  wheel  16993792 Jul  4 18:52 crossplane-v1.14.3-up.1.tgz
58953685 -rw-r--r--@  1 haarchri  wheel  16993280 Jul  4 18:52 crossplane-v1.14.4-up.1.tgz
58954108 -rw-r--r--@  1 haarchri  wheel  16993280 Jul  4 18:52 crossplane-v1.14.5-up.1.tgz
58954134 -rw-r--r--@  1 haarchri  wheel  16997888 Jul  4 18:52 crossplane-v1.14.6-up.1.tgz
58954158 -rw-r--r--@  1 haarchri  wheel  17005568 Jul  4 18:52 crossplane-v1.14.7-up.1.tgz
58954186 -rw-r--r--@  1 haarchri  wheel  17009152 Jul  4 18:52 crossplane-v1.14.8-up.1.tgz
58954211 -rw-r--r--@  1 haarchri  wheel  17019392 Jul  4 18:53 crossplane-v1.14.9-up.1.tgz
58954262 -rw-r--r--@  1 haarchri  wheel  17192960 Jul  4 18:53 crossplane-v1.15.0-up.1.tgz
58954284 -rw-r--r--@  1 haarchri  wheel  17198080 Jul  4 18:53 crossplane-v1.15.1-up.1.tgz
58954320 -rw-r--r--@  1 haarchri  wheel  17216512 Jul  4 18:53 crossplane-v1.15.2-up.1.tgz
58954346 -rw-r--r--@  1 haarchri  wheel  17031680 Jul  4 18:53 crossplane-v1.15.3-up.1.tgz
58954370 -rw-r--r--@  1 haarchri  wheel  17506304 Jul  4 18:53 crossplane-v1.16.0-up.1.tgz
58954539 -rw-r--r--@  1 haarchri  wheel  31868416 Jul  4 18:54 function-auto-ready-v0.2.1.tgz
58954389 -rw-r--r--@  1 haarchri  wheel  47513600 Jul  4 18:53 hyperspace-v1.6.0-rc.0.75.gc383bddc.tgz
58954517 -rw-r--r--@  1 haarchri  wheel      7168 Jul  4 18:54 mcp-connector-0.6.0.tgz
58954524 -rw-r--r--@  1 haarchri  wheel  75195392 Jul  4 18:54 mcp-connector-server-v0.6.0.tgz
58954406 -rw-r--r--@  1 haarchri  wheel  32329216 Jul  4 18:53 mxe-composition-templates-v1.6.0-rc.0.75.gc383bddc.tgz
58954423 -rw-r--r--@  1 haarchri  wheel  31065088 Jul  4 18:53 mxp-authz-webhook-v1.6.0-rc.0.75.gc383bddc.tgz
58954434 -rw-r--r--@  1 haarchri  wheel  17417728 Jul  4 18:53 mxp-benchmark-v1.6.0-rc.0.75.gc383bddc.tgz
58954445 -rw-r--r--@  1 haarchri  wheel  23655424 Jul  4 18:53 mxp-charts-v1.6.0-rc.0.75.gc383bddc.tgz
58954458 -rw-r--r--@  1 haarchri  wheel     17920 Jul  4 18:53 mxp-control-plane-v1.6.0-rc.0.75.gc383bddc.tgz
58954478 -rw-r--r--@  1 haarchri  wheel     15360 Jul  4 18:53 mxp-host-cluster-v1.6.0-rc.0.75.gc383bddc.tgz
58954470 -rw-r--r--@  1 haarchri  wheel     23552 Jul  4 18:53 mxp-host-cluster-worker-v1.6.0-rc.0.75.gc383bddc.tgz
58954487 -rw-r--r--@  1 haarchri  wheel  64558592 Jul  4 18:53 opentelemetry-collector-spaces-v1.6.0-rc.0.75.gc383bddc.tgz
58954557 -rw-r--r--@  1 haarchri  wheel  21144576 Jul  4 18:54 provider-helm-v0.19.0.tgz
58954504 -rw-r--r--@  1 haarchri  wheel     16384 Jul  4 18:54 provider-host-cluster-v1.6.0-rc.0.75.gc383bddc.tgz
58954566 -rw-r--r--@  1 haarchri  wheel  17370112 Jul  4 18:54 provider-kubernetes-v0.14.0.tgz
58953436 -rw-r--r--@  1 haarchri  wheel     27136 Jul  4 18:52 spaces-1.6.0-rc.0.75.gc383bddc.tgz
58953529 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.1-up.1.tgz
58953557 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.2-up.1.tgz
58953583 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.3-up.1.tgz
58953605 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.4-up.1.tgz
58954099 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.5-up.1.tgz
58954123 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.6-up.1.tgz
58954151 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.7-up.1.tgz
58954175 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.8-up.1.tgz
58954203 -rw-r--r--@  1 haarchri  wheel     15872 Jul  4 18:52 universal-crossplane-1.14.9-up.1.tgz
58954240 -rw-r--r--@  1 haarchri  wheel     14848 Jul  4 18:53 universal-crossplane-1.15.0-up.1.tgz
58954275 -rw-r--r--@  1 haarchri  wheel     15360 Jul  4 18:53 universal-crossplane-1.15.1-up.1.tgz
58954308 -rw-r--r--@  1 haarchri  wheel     15360 Jul  4 18:53 universal-crossplane-1.15.2-up.1.tgz
58954335 -rw-r--r--@  1 haarchri  wheel     15360 Jul  4 18:53 universal-crossplane-1.15.3-up.1.tgz
58954363 -rw-r--r--@  1 haarchri  wheel     15360 Jul  4 18:53 universal-crossplane-1.16.0-up.1.tgz
```


dry-run:
```
up alpha space mirror --version 1.6.0-rc.0.75.gc383bddc --to docker.io/haarchri --dry-run
crane copy xpkg.upbound.io/spaces-artifacts/spaces:1.6.0-rc.0.75.gc383bddc docker.io/haarchri/spaces:1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.1-up.1 docker.io/haarchri/universal-crossplane:1.14.1-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.1-up.1 docker.io/haarchri/crossplane:v1.14.1-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.2-up.1 docker.io/haarchri/universal-crossplane:1.14.2-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.2-up.1 docker.io/haarchri/crossplane:v1.14.2-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.3-up.1 docker.io/haarchri/universal-crossplane:1.14.3-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.3-up.1 docker.io/haarchri/crossplane:v1.14.3-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.4-up.1 docker.io/haarchri/universal-crossplane:1.14.4-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.4-up.1 docker.io/haarchri/crossplane:v1.14.4-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.5-up.1 docker.io/haarchri/universal-crossplane:1.14.5-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.5-up.1 docker.io/haarchri/crossplane:v1.14.5-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.6-up.1 docker.io/haarchri/universal-crossplane:1.14.6-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.6-up.1 docker.io/haarchri/crossplane:v1.14.6-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.7-up.1 docker.io/haarchri/universal-crossplane:1.14.7-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.7-up.1 docker.io/haarchri/crossplane:v1.14.7-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.8-up.1 docker.io/haarchri/universal-crossplane:1.14.8-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.8-up.1 docker.io/haarchri/crossplane:v1.14.8-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.14.9-up.1 docker.io/haarchri/universal-crossplane:1.14.9-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.14.9-up.1 docker.io/haarchri/crossplane:v1.14.9-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.15.0-up.1 docker.io/haarchri/universal-crossplane:1.15.0-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.15.0-up.1 docker.io/haarchri/crossplane:v1.15.0-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.15.1-up.1 docker.io/haarchri/universal-crossplane:1.15.1-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.15.1-up.1 docker.io/haarchri/crossplane:v1.15.1-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.15.2-up.1 docker.io/haarchri/universal-crossplane:1.15.2-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.15.2-up.1 docker.io/haarchri/crossplane:v1.15.2-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.15.3-up.1 docker.io/haarchri/universal-crossplane:1.15.3-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.15.3-up.1 docker.io/haarchri/crossplane:v1.15.3-up.1
crane copy xpkg.upbound.io/upbound/universal-crossplane:1.16.0-up.1 docker.io/haarchri/universal-crossplane:1.16.0-up.1
crane copy xpkg.upbound.io/upbound/crossplane:v1.16.0-up.1 docker.io/haarchri/crossplane:v1.16.0-up.1
crane copy xpkg.upbound.io/spaces-artifacts/hyperspace:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/hyperspace:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mxe-composition-templates:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/mxe-composition-templates:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/mxp-authz-webhook:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mxp-benchmark:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/mxp-benchmark:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mxp-charts:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/mxp-charts:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mxp-control-plane:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/mxp-control-plane:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mxp-host-cluster-worker:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/mxp-host-cluster-worker:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mxp-host-cluster:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/mxp-host-cluster:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/opentelemetry-collector-spaces:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/opentelemetry-collector-spaces:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/provider-host-cluster:v1.6.0-rc.0.75.gc383bddc docker.io/haarchri/provider-host-cluster:v1.6.0-rc.0.75.gc383bddc
crane copy xpkg.upbound.io/spaces-artifacts/mcp-connector:0.6.0 docker.io/haarchri/mcp-connector:0.6.0
crane copy xpkg.upbound.io/spaces-artifacts/mcp-connector-server:v0.6.0 docker.io/haarchri/mcp-connector-server:v0.6.0
crane copy xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1 docker.io/haarchri/function-auto-ready:v0.2.1
crane copy xpkg.upbound.io/crossplane-contrib/provider-helm:v0.19.0 docker.io/haarchri/provider-helm:v0.19.0
crane copy xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.14.0 docker.io/haarchri/provider-kubernetes:v0.14.0

```
do it:
```
up alpha space mirror --version 1.6.0-rc.0.75.gc383bddc --to docker.io/haarchri          
Mirroring mirrored artifacts for spaces ...
  ✓   Scanning tags to export...                                                                                                                                                                                                                                                   
  ✓   mirror artifact spaces:1.6.0-rc.0.75.gc383bddc to docker.io/haarchri                                                                                                                                                                                                         
  ✓   mirror artifact universal-crossplane:1.14.1-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.1-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.2-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.2-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.3-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.3-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.4-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.4-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.5-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.5-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.6-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.6-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.7-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.7-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.8-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.8-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.14.9-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.14.9-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.15.0-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.15.0-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.15.1-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.15.1-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.15.2-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.15.2-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.15.3-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.15.3-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact universal-crossplane:1.16.0-up.1 to docker.io/haarchri                                                                                                                                                                                                       
  ✓   mirror artifact crossplane:v1.16.0-up.1 to docker.io/haarchri                                                                                                                                                                                                                
  ✓   mirror artifact hyperspace:v1.6.0-rc.0.75.gc383bddc to docker.io/haarchri     
  ✓   mirror artifact mxe-composition-templates:v1.6.0-rc.0.75.gc383bddc to docker.io/haarchri                                                                                                                                 
  ✓   mirror artifact mxp-authz-webhook:v1.6.0-rc.0.75.gc383bddc to docker.io/haarchri                                                                                                                     
  ✓   mirror artifact mxp-benchmark:v1.6.0-rc.0.75.gc383bddc to docker.io/haarchri                                               
  ✓   mirror artifact mxp-charts:v1.6.0-rc.0.75.gc383bddc to docker.io/haarchri     
  ✓   mirror artifact mxp-control-plane:v1.6.0-rc.0.75.gc383bddc  to docker.io/haarchri     
  ✓   mirror artifact mxp-host-cluster-worker:v1.6.0-rc.0.75.gc383bddc to docker.io/haarchri          
  ✓   mirror artifact mxp-host-cluster:v1.6.0-rc.0.75.gc383bddc to docker.io/haarchri     
  ✓   mirror artifact opentelemetry-collector-spaces:v1.6.0-rc.0.75.gc383bddc  to docker.io/haarchri     
  ✓   mirror artifact provider-host-cluster:v1.6.0-rc.0.75.gc383bddc  to docker.io/haarchri     
  ✓   mirror artifact mcp-connector:0.6.0  to docker.io/haarchri     
  ✓   mirror artifact mcp-connector-server:v0.6.0 to docker.io/haarchri     
  ✓   mirror artifact function-auto-ready:v0.2.1 to docker.io/haarchri     
  ✓   mirror artifact provider-helm:v0.19.0 to docker.io/haarchri     
  ✓   mirror artifact provider-kubernetes:v0.14.0 to docker.io/haarchri
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
