### PR TITLE
ctx: unify path string

### DIFF
--- a/cmd/up/ctx/actions.go
+++ b/cmd/up/ctx/actions.go
@@ -41,7 +41,7 @@ func (s *Space) Accept(upCtx *upbound.Context, navCtx *navContext) (msg string, 
 		return "", err
 	}
 
-	return fmt.Sprintf(contextSwitchedFmt, s.Breadcrumbs()), nil
+	return fmt.Sprintf(contextSwitchedFmt, withUpboundPrefix(s.Breadcrumbs())), nil
 }
 
 // Accept upserts the "upbound" kubeconfig context and cluster to the chosen
@@ -59,7 +59,7 @@ func (g *Group) Accept(upCtx *upbound.Context, navCtx *navContext) (msg string, 
 		return "", err
 	}
 
-	return fmt.Sprintf(contextSwitchedFmt, g.Breadcrumbs()), nil
+	return fmt.Sprintf(contextSwitchedFmt, withUpboundPrefix(g.Breadcrumbs())), nil
 }
 
 // Accept upserts a controlplane context and cluster to the chosen kubeconfig.
@@ -76,5 +76,5 @@ func (ctp *ControlPlane) Accept(upCtx *upbound.Context, navCtx *navContext) (msg
 		return "", err
 	}
 
-	return fmt.Sprintf(contextSwitchedFmt, ctp.Breadcrumbs()), nil
+	return fmt.Sprintf(contextSwitchedFmt, withUpboundPrefix(ctp.Breadcrumbs())), nil
 }

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -147,7 +147,7 @@ func (r *Root) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navCon
 }
 
 func (r *Root) breadcrumbs() string {
-	return upboundRootStyle.Render("Upbound")
+	return ""
 }
 
 func (r *Root) Breadcrumbs() string {
@@ -241,7 +241,7 @@ func spaceItemFromKubeContext(ctx context.Context, kubeconfig clientcmdapi.Confi
 }
 
 func (d *Disconnected) breadcrumbs(styles breadcrumbStyle) string {
-	return upboundRootStyle.Render("Upbound ") + styles.currentLevel.Render("disconnected/")
+	return styles.currentLevel.Render("disconnected/")
 }
 
 func (d *Disconnected) Breadcrumbs() string {
@@ -374,7 +374,7 @@ func (o *Organization) BackLabel() string {
 }
 
 func (o *Organization) breadcrumbs(styles breadcrumbStyle) string {
-	return upboundRootStyle.Render("Upbound ") + styles.currentLevel.Render(fmt.Sprintf("%s/", o.Name))
+	return styles.currentLevel.Render(fmt.Sprintf("%s/", o.Name))
 }
 
 func (o *Organization) Breadcrumbs() string {

--- a/cmd/up/ctx/navigation.go
+++ b/cmd/up/ctx/navigation.go
@@ -146,12 +146,8 @@ func (r *Root) Items(ctx context.Context, upCtx *upbound.Context, navCtx *navCon
 	}), nil
 }
 
-func (r *Root) breadcrumbs() string {
-	return ""
-}
-
 func (r *Root) Breadcrumbs() string {
-	return r.breadcrumbs()
+	return ""
 }
 
 type Disconnected struct{}


### PR DESCRIPTION
The path string printed after every command should be working as argument, i.e. it is supposed like an absolute identifier of a context like a control plane. This was not the case before this PR. Especially the `up ctx . --short` output was its own code path with invalid string generation (e.g. lacking the `disconnected/` prefix).

Fixes: #575