### PR TITLE
ctx: fix --short output to print the final state not the original state

### DIFF
--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -333,7 +333,7 @@ func (c *Cmd) RunNonInteractive(ctx context.Context, upCtx *upbound.Context, nav
 
 	// don't print anything else or we are going to pollute stdout
 	if c.Short {
-		fmt.Println(state.Breadcrumbs())
+		fmt.Println(m.state.Breadcrumbs())
 	} else {
 		fmt.Print(msg)
 	}


### PR DESCRIPTION
Fix bug in https://github.com/upbound/up/pull/577.

Responsible for https://github.com/upbound/spaces/pull/1387 failing tests.