### PR TITLE
Unhide --token flag for login

### DIFF
--- a/cmd/up/login/login.go
+++ b/cmd/up/login/login.go
@@ -116,7 +116,7 @@ type LoginCmd struct {
 
 	Username string `short:"u" env:"UP_USER" xor:"identifier" help:"Username used to execute command."`
 	Password string `short:"p" env:"UP_PASSWORD" help:"Password for specified user. '-' to read from stdin."`
-	Token    string `short:"t" env:"UP_TOKEN" hidden:"" xor:"identifier" help:"Token used to execute command. '-' to read from stdin."`
+	Token    string `short:"t" env:"UP_TOKEN" xor:"identifier" help:"Upbound API token (personal access token) used to execute command. '-' to read from stdin."`
 
 	accountsEndpoint url.URL
 	// Common Upbound API configuration


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Unhide the `--token` flag for `up login`. This allows logging in with an Upbound access token. While mostly used by CI/automation, there was no strong reason to hide the flag from users. Note that the `xor` option will ensure you cannot specify a username and a token simultaneously.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

- `up login -h` shows the flag and help string

Login with token:
```
./up login --token=`cat my-upbound-token`
86dd1e7e-xxxx-xxxx-xxxx-a23d090axxx logged in

./up ctp list
GROUP   NAME       CROSSPLANE    SYNCED   READY   MESSAGE   AGE
test    ctp-kine   1.16.0-up.1   True     True              38d
```

Attempt login with mutually exclusive flags

```
./up login -u jastang -t MY_TOKEN
up: error: --username and --token can't be used together
```



