### PR TITLE
query+get: improve context awareness

### DIFF
--- a/internal/profile/urls.go
+++ b/internal/profile/urls.go
@@ -30,7 +30,7 @@ var (
 
 // ParseSpacesK8sURL parses a URL and returns the namespace and optionally the
 // controlplane name (if specified).
-func ParseSpacesK8sURL(url string) (base string, resource types.NamespacedName, matches bool) {
+func ParseSpacesK8sURL(url string) (base string, ctp types.NamespacedName, matches bool) {
 	m := controlPlaneRE.FindStringSubmatch(url)
 	if m == nil {
 		return "", types.NamespacedName{}, false
@@ -44,7 +44,7 @@ func ParseSpacesK8sURL(url string) (base string, resource types.NamespacedName, 
 
 // ParseMCPK8sURL attempts to parse a legacy MCP URL and returns the name of the
 // matching control plane if it matches
-func ParseMCPK8sURL(url string) (resource types.NamespacedName, matches bool) {
+func ParseMCPK8sURL(url string) (ctp types.NamespacedName, matches bool) {
 	m := legacyControlPlanePathRE.FindStringSubmatch(url)
 	if m == nil {
 		return types.NamespacedName{}, false

--- a/internal/upbound/kube_context.go
+++ b/internal/upbound/kube_context.go
@@ -18,12 +18,13 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up/internal/profile"
 	"github.com/upbound/up/internal/version"
@@ -108,7 +109,7 @@ func (c *Context) GetCurrentContext() (context *clientcmdapi.Context, cluster *c
 	return context, cluster, auth, exists
 }
 
-func (c *Context) GetCurrentSpaceContextScope() (ingressHost string, resource types.NamespacedName, inSpace bool) {
+func (c *Context) GetCurrentSpaceContextScope() (ingressHost string, ctp types.NamespacedName, inSpace bool) {
 	context, cluster, _, exists := c.GetCurrentContext()
 	if !exists {
 		return "", types.NamespacedName{}, false


### PR DESCRIPTION
This PR adds

- a pre-check of the Query API in version v1alpha1 and proper error messages to enable the feature gate or update `up`
- make `up query` work within a controlplane

Requires https://github.com/upbound/up/pull/586.