### PR TITLE
Print the connect agent version in `up version`

### DIFF
--- a/cmd/up/version/version.go
+++ b/cmd/up/version/version.go
@@ -52,8 +52,16 @@ Client:
 Server:
   Crossplane Version:	{{.CrossplaneVersion}}
   Spaces Controller Version:	{{.SpacesControllerVersion}}
-{{- end}}{{- end}}`
+{{- end}}{{- end}}
+
+{{- if ne .ConnectAgent nil}}
+Connect Agent:
+  Connect Agent Version: {{.ConnectAgent}}
+{{- end}}`
 )
+
+// TODO(jastang): remove hardcoded version if/when we support agent update.
+type connectAgentVersion string
 
 type clientVersion struct {
 	Arch      string `json:"arch,omitempty" yaml:"arch,omitempty"`
@@ -69,8 +77,9 @@ type serverVersion struct {
 }
 
 type versionInfo struct {
-	Client clientVersion  `json:"client" yaml:"client"`
-	Server *serverVersion `json:"server,omitempty" yaml:"server,omitempty"`
+	Client       clientVersion       `json:"client" yaml:"client"`
+	ConnectAgent connectAgentVersion `json:"agent" yaml:"agent"`
+	Server       *serverVersion      `json:"server,omitempty" yaml:"server,omitempty"`
 }
 
 type Cmd struct {
@@ -155,6 +164,8 @@ func (c *Cmd) BuildVersionInfo(ctx context.Context, kongCtx *kong.Context, upCtx
 	if v.Server.SpacesControllerVersion == "" {
 		v.Server.SpacesControllerVersion = versionUnknown
 	}
+
+	v.ConnectAgent = connectAgentVersion(version.AgentVersion())
 
 	return v
 }


### PR DESCRIPTION


### Description of your changes

Give users a bit more info when attaching a space to Upbound.

The agent version is hardcoded for now but we may support more functions like update in the future.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
➜  darwin_arm64 ./up version
Client:
  Version:     v0.29.0-rc.0.168.gcf62706.dirty
  Go Version:  go1.22.2
  Git Commit:  cf62706
  OS/Arch:     darwin/arm64
Server:
  Crossplane Version:        v1.15.3-up.1
  Spaces Controller Version: Upbound Cloud Managed
Connect Agent:
  Connect Agent Version: 0.0.0-408.g343d295
  ```
