### PR TITLE
Rename up space attach/detach to up space connect/disconnect

### DIFF
--- a/cmd/up/space/space.go
+++ b/cmd/up/space/space.go
@@ -36,13 +36,13 @@ func (c *Cmd) BeforeReset(p *kong.Path, maturity feature.Maturity) error {
 
 // Cmd contains commands for interacting with spaces.
 type Cmd struct {
-	Attach  attachCmd  `cmd:"" maturity:"alpha" help:"Connect an Upbound Space to the Upbound web console."`
-	Detach  detachCmd  `cmd:"" maturity:"alpha" help:"Detach an Upbound Space from the Upbound web console."`
-	Init    initCmd    `cmd:"" help:"Initialize an Upbound Spaces deployment."`
-	Destroy destroyCmd `cmd:"" help:"Remove the Upbound Spaces deployment."`
-	Upgrade upgradeCmd `cmd:"" help:"Upgrade the Upbound Spaces deployment."`
-	List    listCmd    `cmd:"" help:"List all accessible spaces in Upbound."`
-	Mirror  mirror.Cmd `cmd:"" maturity:"alpha" help:"List of all OCI artifacts required for Spaces."`
+	Connect    connectCmd    `cmd:"" help:"Connect an Upbound Space to the Upbound web console." aliases:"attach"`
+	Destroy    destroyCmd    `cmd:"" help:"Remove the Upbound Spaces deployment."`
+	Disconnect disconnectCmd `cmd:"" help:"Disconnect an Upbound Space from the Upbound web console." aliases:"detach"`
+	Init       initCmd       `cmd:"" help:"Initialize an Upbound Spaces deployment."`
+	List       listCmd       `cmd:"" help:"List all accessible spaces in Upbound."`
+	Mirror     mirror.Cmd    `cmd:"" maturity:"alpha" help:"List of all OCI artifacts required for Spaces."`
+	Upgrade    upgradeCmd    `cmd:"" help:"Upgrade the Upbound Spaces deployment."`
 
 	Billing billing.Cmd `cmd:""`
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

- Rename the `up space attach/detach` command to `up space connect/disconnect` with aliases to maintain backward compatibility.
- Update all references to "attach" verbiage to now reference "connect"

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
