### PR TITLE
ctx: Ignore empty path components in non-interactive mode

### DIFF
--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -280,6 +280,9 @@ func (c *Cmd) RunNonInteractive(ctx context.Context, upCtx *upbound.Context, nav
 	}
 	for _, s := range strings.Split(c.Argument, "/") {
 		switch s {
+		case "":
+			// Ignore empty path components. This allows for trailing slashes,
+			// as well as duplicate slashes.
 		case ".":
 		case "..":
 			back, ok := m.state.(Back)


### PR DESCRIPTION
### Description of your changes

Allow for trailing slashes (and also, as a side-effect, duplicate slashes) in
non-interactive mode by ignoring any empty path components when we parse the
path. This is especially helpful since we print a trailing slash on the path
when a user selects a context other than a control plane (space or group).

Fixes #581

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Manual testing with various non-interactive invocations:

```
$ up ctx upbound/upbound-aws-us-east-1
Kubeconfig context "upbound": Upbound upbound/upbound-aws-us-east-1/
$ up ctx upbound/upbound-aws-us-east-1/
Kubeconfig context "upbound": Upbound upbound/upbound-aws-us-east-1/
$ up ctx upbound/upbound-aws-us-east-1/default/
Kubeconfig context "upbound": Upbound upbound/upbound-aws-us-east-1/default/
$ up ctx upbound/upbound-aws-us-east-1///default////
Kubeconfig context "upbound": Upbound upbound/upbound-aws-us-east-1/default/
$ up ctx upbound/upbound-aws-us-east-1///default////test
Kubeconfig context "upbound": Upbound upbound/upbound-aws-us-east-1/default/test
$ up ctx upbound/upbound-aws-us-east-1///default////test
Kubeconfig context "upbound": Upbound upbound/upbound-aws-us-east-1/default/test////
```
