### PR TITLE
xpkg: Support function dependencies

### DIFF
--- a/internal/xpkg/dep/manager/utils.go
+++ b/internal/xpkg/dep/manager/utils.go
@@ -21,21 +21,29 @@ import (
 )
 
 // ConvertToV1beta1 converts v1.Dependency types to v1beta1.Dependency types.
-func ConvertToV1beta1(in metav1.Dependency) v1beta1.Dependency {
+func ConvertToV1beta1(in metav1.Dependency) (v1beta1.Dependency, bool) {
 	betaD := v1beta1.Dependency{
 		Constraints: in.Version,
 	}
-	if in.Provider != nil && in.Configuration == nil {
+
+	switch {
+	case in.Provider != nil:
 		betaD.Package = *in.Provider
 		betaD.Type = v1beta1.ProviderPackageType
-	}
 
-	if in.Configuration != nil && in.Provider == nil {
+	case in.Configuration != nil:
 		betaD.Package = *in.Configuration
 		betaD.Type = v1beta1.ConfigurationPackageType
+
+	case in.Function != nil:
+		betaD.Package = *in.Function
+		betaD.Type = v1beta1.FunctionPackageType
+
+	default:
+		return betaD, false
 	}
 
-	return betaD
+	return betaD, true
 }
 
 // ConvertToV1alpha1 converts v1.Dependency types to v1alpha1.Dependency types.

--- a/internal/xpkg/dep/marshaler/xpkg/marshaler.go
+++ b/internal/xpkg/dep/marshaler/xpkg/marshaler.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	xpmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
+	xpmetav1beta1 "github.com/crossplane/crossplane/apis/pkg/meta/v1beta1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
@@ -156,12 +157,16 @@ func processPackage(pkg linter.Package) (*ParsedPackage, error) {
 	meta := metas[0]
 	var linter linter.Linter
 	var pkgType v1beta1.PackageType
-	if meta.GetObjectKind().GroupVersionKind().Kind == xpmetav1.ConfigurationKind {
+	switch meta.GetObjectKind().GroupVersionKind().Kind {
+	case xpmetav1.ConfigurationKind:
 		linter = xpkg.NewConfigurationLinter()
 		pkgType = v1beta1.ConfigurationPackageType
-	} else {
+	case xpmetav1.ProviderKind:
 		linter = xpkg.NewProviderLinter()
 		pkgType = v1beta1.ProviderPackageType
+	case xpmetav1beta1.FunctionKind:
+		linter = xpkg.NewFunctionLinter()
+		pkgType = v1beta1.FunctionPackageType
 	}
 	if err := linter.Lint(pkg); err != nil {
 		return nil, errors.Wrap(err, errLintPackage)

--- a/internal/xpkg/scheme/scheme.go
+++ b/internal/xpkg/scheme/scheme.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	pkgmetav1alpha1 "github.com/crossplane/crossplane/apis/pkg/meta/v1alpha1"
+	pkgmetav1beta1 "github.com/crossplane/crossplane/apis/pkg/meta/v1beta1"
 )
 
 // BuildMetaScheme builds the default scheme used for identifying metadata in a
@@ -31,6 +32,9 @@ import (
 func BuildMetaScheme() (*runtime.Scheme, error) {
 	metaScheme := runtime.NewScheme()
 	if err := pkgmetav1alpha1.SchemeBuilder.AddToScheme(metaScheme); err != nil {
+		return nil, err
+	}
+	if err := pkgmetav1beta1.SchemeBuilder.AddToScheme(metaScheme); err != nil {
 		return nil, err
 	}
 	if err := pkgmetav1.SchemeBuilder.AddToScheme(metaScheme); err != nil {

--- a/internal/xpkg/snapshot/meta.go
+++ b/internal/xpkg/snapshot/meta.go
@@ -91,7 +91,11 @@ func (m *MetaValidator) Validate(ctx context.Context, data any) *validate.Result
 	errs = append(errs, validateAPIVersion(o))
 
 	for i, d := range pkg.GetDependencies() {
-		cd := manager.ConvertToV1beta1(d)
+		cd, ok := manager.ConvertToV1beta1(d)
+		if !ok {
+			errs = append(errs, fmt.Errorf("invalid dependency at position %d", i))
+			continue
+		}
 		for _, v := range m.validators {
 			errs = append(errs, v.validate(ctx, i, cd))
 		}

--- a/internal/xpkg/workspace/meta/meta.go
+++ b/internal/xpkg/workspace/meta/meta.go
@@ -34,6 +34,7 @@ const (
 	errInvalidMetaFile           = "invalid meta type supplied"
 	errMetaContainsDupeDep       = "meta file contains duplicate dependency"
 	errUnsupportedPackageVersion = "unsupported package version supplied"
+	errInvalidDep                = "meta file contains invalid dependency"
 )
 
 // Meta provides helpful methods for interacting with a metafile's
@@ -59,7 +60,11 @@ func (m *Meta) DependsOn() ([]v1beta1.Dependency, error) {
 
 	out := make([]v1beta1.Dependency, len(pkg.GetDependencies()))
 	for i, d := range pkg.GetDependencies() {
-		out[i] = manager.ConvertToV1beta1(d)
+		dep, ok := manager.ConvertToV1beta1(d)
+		if !ok {
+			return nil, errors.New(errInvalidDep)
+		}
+		out[i] = dep
 	}
 
 	return out, nil


### PR DESCRIPTION
### Description of your changes

Previously, running `up xpkg dep` in a package containing compositions that use functions would produce an error: `resources in Composition are malformed`. Simiarly, `up xpls` would panic when started on a package with function dependencies.

Update the metadata parser to support function dependencies and the composition parser to support pipelines so that `up xpkg dep` and `up xpls` have at least basic functionality when using functions. Providing useful validation of function pipelines is left as future work.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Local testing with [configuration-getting-started](https://github.com/upbound/configuration-getting-started).
