### PR TITLE
Show healthy column and read message from status for CTP list/get commands

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	spacefieldNames = []string{"GROUP", "NAME", "CROSSPLANE", "SYNCED", "READY", "MESSAGE", "AGE"}
+	spacefieldNames = []string{"GROUP", "NAME", "CROSSPLANE", "READY", "HEALTHY", "MESSAGE", "AGE"}
 )
 
 // BeforeReset is the first hook to run.
@@ -142,9 +142,9 @@ func extractSpaceFields(obj any) []string {
 		ctp.GetNamespace(),
 		ctp.GetName(),
 		v,
-		string(ctp.GetCondition(xpcommonv1.TypeSynced).Status),
 		string(ctp.GetCondition(xpcommonv1.TypeReady).Status),
-		ctp.Annotations["internal.spaces.upbound.io/message"],
+		string(ctp.GetCondition(spacesv1beta1.ConditionTypeHealthy).Status),
+		ctp.Status.Message,
 		formatAge(ptr.To(time.Since(ctp.CreationTimestamp.Time))),
 	}
 }

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -26,8 +26,8 @@ type Response struct {
 	Group             string
 	Name              string
 	CrossplaneVersion string
-	Synced            string
 	Ready             string
+	Healthy           string
 	Message           string
 	Age               *time.Duration
 

--- a/internal/controlplane/space/space.go
+++ b/internal/controlplane/space/space.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,8 +153,8 @@ func convert(ctp *resources.ControlPlane) *controlplane.Response {
 		Group:             ctp.GetNamespace(),
 		Name:              ctp.GetName(),
 		CrossplaneVersion: ctp.GetCrossplaneVersion(),
-		Synced:            string(ctp.GetCondition(xpcommonv1.TypeSynced).Status),
 		Ready:             string(ctp.GetCondition(xpcommonv1.TypeReady).Status),
+		Healthy:           string(ctp.GetCondition(v1beta1.ConditionTypeHealthy).Status),
 		Message:           ctp.GetMessage(),
 		Age:               ctp.GetAge(),
 		Cfg:               "",

--- a/internal/controlplane/space/space_test.go
+++ b/internal/controlplane/space/space_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"testing"
 
+	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
+
 	"github.com/google/go-cmp/cmp"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -427,9 +429,9 @@ func TestConvert(t *testing.T) {
 						Name:      "kubeconfig-ctp1",
 						Namespace: "default",
 					})
-					c.SetConditions([]xpcommonv1.Condition{xpcommonv1.ReconcileSuccess()}...)
 					c.SetConditions([]xpcommonv1.Condition{xpcommonv1.Available()}...)
-					c.SetAnnotations(map[string]string{"internal.spaces.upbound.io/message": ""})
+					c.SetConditions(spacesv1beta1.Healthy())
+					c.SetMessage("")
 
 					return c
 				}(),
@@ -439,8 +441,8 @@ func TestConvert(t *testing.T) {
 					Name:     "ctp1",
 					ID:       "mxp1",
 					Group:    "default",
-					Synced:   "True",
 					Ready:    "True",
+					Healthy:  "True",
 					ConnName: "kubeconfig-ctp1",
 					Message:  "",
 				},
@@ -458,9 +460,9 @@ func TestConvert(t *testing.T) {
 						Name:      "kubeconfig-ctp1",
 						Namespace: "default",
 					})
-					c.SetConditions(xpcommonv1.ReconcileSuccess())
 					c.SetConditions(xpcommonv1.Creating().WithMessage("something"))
-					c.SetAnnotations(map[string]string{"internal.spaces.upbound.io/message": "creating..."})
+					c.SetConditions(spacesv1beta1.Healthy())
+					c.SetMessage("creating...")
 
 					return c
 				}(),
@@ -470,8 +472,8 @@ func TestConvert(t *testing.T) {
 					Name:     "ctp1",
 					ID:       "mxp1",
 					Group:    "default",
-					Synced:   "True",
 					Ready:    "False",
+					Healthy:  "True",
 					Message:  "creating...",
 					ConnName: "kubeconfig-ctp1",
 				},
@@ -484,18 +486,18 @@ func TestConvert(t *testing.T) {
 					c := &resources.ControlPlane{}
 					c.SetName("ctp1")
 					c.SetControlPlaneID("mxp1")
-					c.SetConditions(xpcommonv1.ReconcileSuccess())
 					c.SetConditions([]xpcommonv1.Condition{xpcommonv1.Available()}...)
+					c.SetConditions(spacesv1beta1.Healthy())
 
 					return c
 				}(),
 			},
 			want: want{
 				resp: &controlplane.Response{
-					Name:   "ctp1",
-					ID:     "mxp1",
-					Synced: "True",
-					Ready:  "True",
+					Name:    "ctp1",
+					ID:      "mxp1",
+					Ready:   "True",
+					Healthy: "True",
 				},
 			},
 		},

--- a/internal/resources/controlplane.go
+++ b/internal/resources/controlplane.go
@@ -98,11 +98,15 @@ func (c *ControlPlane) GetCrossplaneVersion() string {
 }
 
 func (c *ControlPlane) GetMessage() string {
-	var ann map[string]string
-	if err := fieldpath.Pave(c.Object).GetValueInto("metadata.annotations", &ann); err != nil {
+	msg, err := fieldpath.Pave(c.Object).GetString("status.message")
+	if err != nil {
 		return ""
 	}
-	return ann["internal.spaces.upbound.io/message"]
+	return msg
+}
+
+func (c *ControlPlane) SetMessage(msg string) {
+	_ = fieldpath.Pave(c.Object).SetString("status.message", msg)
 }
 
 func (c *ControlPlane) GetAge() *time.Duration {


### PR DESCRIPTION
### Description of your changes

With Spaces v1.6.0 we did the following changes in the control plane resource affecting the get and list command outputs:
- We no longer show `SYNCED` column, and show a new `HEALTHY` column instead.
- We store the `MESSAGE` in `status.message` rather than `internal.spaces.upbound.io/message` annotation.

This PR adapts the up cli accordingly.

This was found as a bug in the last LBOP session.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
❯ kubectl get ctp
NAME    CROSSPLANE    READY   HEALTHY   MESSAGE                                                              AGE
test    1.15.3-up.1   True    False     Provisioning failed: cannot setup control plane API: cannot pro...   29m
test2   1.15.3-up.1   True    True

❯ go run ./cmd/up ctp list
GROUP     NAME    CROSSPLANE    READY   HEALTHY   MESSAGE                                                              AGE
default   test    1.15.3-up.1   True    False     Provisioning failed: cannot setup control plane API: cannot pro...   34m
default   test2   1.15.3-up.1   True    True                                                                           6m47s
```