### PR TITLE
Remove ineffective trailing "\n"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,8 @@ if [ $BIN = "up" ]; then
   echo up version
   echo
   echo "Visit https://upbound.io to get started. 🚀"
-  echo "Have a nice day! 👋\n"
+  echo "Have a nice day! 👋"
+  echo
 fi
 
 if [ $BIN = "docker-credential-up" ]; then
@@ -94,5 +95,6 @@ if [ $BIN = "docker-credential-up" ]; then
   echo docker-credential-up -v
   echo
   echo 'Add "xpkg.upbound.io": "up" to the "credHelpers" section of your Docker config file. 🚀'
-  echo "Have a nice day! 👋\n"
+  echo "Have a nice day! 👋"
+  echo
 fi


### PR DESCRIPTION
### Description of your changes
Removes the trailing "\n" from this output:
```
Up downloaded successfully!
By proceeding, you are accepting to comply with terms and conditions in https://licenses.upbound.io/upbound-software-license.html

Run the following commands to finish installation:

sudo mv up /usr/local/bin/
up version

Visit https://upbound.io to get started. 🚀
Have a nice day! 👋\n                               <==================
```

I have:

- [X] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
N/A
