### PR TITLE
docs: use -0.rc as tag to fix sorting and mention cache invalidation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ This is a slimmed-down version of the release process described [here](https://g
    desired version (e.g. `v0.25.0`).
 1. **build/publish**: Run the `CI` action on the release-branch (**not on the tag!**).
 1. **tag next pre-release**: Run the `tag` action on the main development branch
-   with the `rc.0` for the next release (e.g. `v0.26.0-rc.0`).
+   with the `-0.rc.0` for the next release (e.g. `v0.26.0-0.rc.0`).
 1. **verify**: Verify all artifacts have been published successfully, perform
    sanity testing.
    - Check in https://cli.upbound.io/stable?prefix=build/release-0.25/v0.25.0.
@@ -49,6 +49,7 @@ This is a slimmed-down version of the release process described [here](https://g
    - "Generate release notes" from previous release ("auto" might not work).
    - Make sure the release notes are complete, presize and well formatted.
    - Publish the well authored Github release.
+1. **invalidate cache**: If needed see the internal Notion documentation.
 1. **wait for CDN**: Wait for CloudFront to distribute the artifacts, e.g. wait
    until `curl -sL https://cli.upbound.io | sh -x && ./up version` gives the new
    release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ This is a slimmed-down version of the release process described [here](https://g
    desired version (e.g. `v0.25.0`).
 1. **build/publish**: Run the `CI` action on the release-branch (**not on the tag!**).
 1. **tag next pre-release**: Run the `tag` action on the main development branch
-   with the `-0.rc.0` for the next release (e.g. `v0.26.0-0.rc.0`).
+   with the `-0.rc.0` for the next release (e.g. `v0.26.0-0.rc.0`). (**NOTE**:
+   we added the `-0.` prefix to allow correctly sorting release candidates)
 1. **verify**: Verify all artifacts have been published successfully, perform
    sanity testing.
    - Check in https://cli.upbound.io/stable?prefix=build/release-0.25/v0.25.0.
@@ -49,7 +50,7 @@ This is a slimmed-down version of the release process described [here](https://g
    - "Generate release notes" from previous release ("auto" might not work).
    - Make sure the release notes are complete, presize and well formatted.
    - Publish the well authored Github release.
-1. **invalidate cache**: If needed see the internal Notion documentation.
+1. **invalidate CDN cache**: If needed see the internal Notion documentation.
 1. **wait for CDN**: Wait for CloudFront to distribute the artifacts, e.g. wait
    until `curl -sL https://cli.upbound.io | sh -x && ./up version` gives the new
    release.


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Turns out that according to the semver [spec](https://semver.org/#spec-item-9) sorting results in `1.0.0-1 < 1.0.0-rc.1`, so we switch to `-0.rc.1` so that it results in correctly sorting them `1.0.0-0.rc.1 < 1.0.0-1`.

Added reference to internal documentation about cache invalidation.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

N.A.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
