### PR TITLE
fix(up/query): print right kind with multiple resources

### DIFF
--- a/cmd/up/query/run.go
+++ b/cmd/up/query/run.go
@@ -134,7 +134,7 @@ func (c *cmd) Run(ctx context.Context, kongCtx *kong.Context, upCtx *upbound.Con
 	// send queries and collect objects
 	var infos []*cliresource.Info
 	gks := sets.New[runtimeschema.GroupKind]()
-	for _, spec := range querySpecs {
+	for qi, spec := range querySpecs {
 		var cursor string
 		var page int
 		for {
@@ -200,7 +200,7 @@ func (c *cmd) Run(ctx context.Context, kongCtx *kong.Context, upCtx *upbound.Con
 								// used to switch to another printer. We don't know
 								// the resource anyway and it has no impact on the
 								// output other than creation of a new printer.
-								Resource: fmt.Sprintf("table-%d", i),
+								Resource: fmt.Sprintf("table-%d", qi+i),
 							},
 							GroupVersionKind: runtimeschema.GroupVersionKind{
 								Group:   tbl.GroupVersionKind.Group,


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes https://github.com/upbound/up/issues/599.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Manually running the command from the issue:
```
go run github.com/upbound/up/cmd/up alpha query providers,providerrevision
NAME                                      INSTALLED   HEALTHY   PACKAGE                                                  AGE
provider.pkg.crossplane.io/provider-nop   True        True      xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1   17d

NAME                                                           HEALTHY   REVISION   IMAGE                                                    STATE    DEP-FOUND   DEP-INSTALLED   AGE
providerrevision.pkg.crossplane.io/provider-nop-ecc25c121431   True      1          xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.1   Active                               17d
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
