### PR TITLE
Fix "xpkg dep" with function dependencies

### DIFF
--- a/internal/xpkg/dep/marshaler/xpkg/marshaler.go
+++ b/internal/xpkg/dep/marshaler/xpkg/marshaler.go
@@ -213,7 +213,7 @@ func finalizePkg(pkg *ParsedPackage) (*ParsedPackage, error) { // nolint:gocyclo
 }
 
 func determineDeps(o runtime.Object) ([]v1beta1.Dependency, error) {
-	pkg, ok := scheme.TryConvertToPkg(o, &xpmetav1.Provider{}, &xpmetav1.Configuration{})
+	pkg, ok := scheme.TryConvertToPkg(o, &xpmetav1.Provider{}, &xpmetav1.Configuration{}, &xpmetav1beta1.Function{})
 	if !ok {
 		return nil, errors.New(errFailedToConvertMetaToPackage)
 	}
@@ -230,14 +230,20 @@ func convertToV1beta1(in xpmetav1.Dependency) v1beta1.Dependency {
 	betaD := v1beta1.Dependency{
 		Constraints: in.Version,
 	}
-	if in.Provider != nil && in.Configuration == nil {
+
+	if in.Provider != nil {
 		betaD.Package = *in.Provider
 		betaD.Type = v1beta1.ProviderPackageType
 	}
 
-	if in.Configuration != nil && in.Provider == nil {
+	if in.Configuration != nil {
 		betaD.Package = *in.Configuration
 		betaD.Type = v1beta1.ConfigurationPackageType
+	}
+
+	if in.Function != nil {
+		betaD.Package = *in.Function
+		betaD.Type = v1beta1.FunctionPackageType
 	}
 
 	return betaD


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Before this change, up was giving an error when we tried to download a package with a function dependency.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested
```
./up xpkg dep xpkg.upbound.io/upbound/configuration-aws-network
xpkg.upbound.io/upbound/configuration-aws-network added to xpkg cache
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
