### PR TITLE
Fix ctx writing kubeconfig to stdout with current path

### DIFF
--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -322,7 +322,7 @@ func (c *Cmd) RunNonInteractive(ctx context.Context, upCtx *upbound.Context, nav
 
 	// final step if we moved: accept the state
 	msg := fmt.Sprintf("Kubeconfig context %q: %s\n", c.KubeContext, withUpboundPrefix(m.state.Breadcrumbs()))
-	if m.state.Breadcrumbs() != initialState.Breadcrumbs() {
+	if m.state.Breadcrumbs() != initialState.Breadcrumbs() || c.File == "-" {
 		accepting, ok := m.state.(Accepting)
 		if !ok {
 			return fmt.Errorf("cannot move context to: %s", m.state.Breadcrumbs())
@@ -334,11 +334,14 @@ func (c *Cmd) RunNonInteractive(ctx context.Context, upCtx *upbound.Context, nav
 		}
 	}
 
-	// don't print anything else or we are going to pollute stdout
-	if c.Short {
-		fmt.Println(m.state.Breadcrumbs())
-	} else {
-		fmt.Print(msg)
+	// if printing the kubeconfig to stdout, don't print anything els
+	if c.File != "-" {
+		// don't print anything else or we are going to pollute stdout
+		if c.Short {
+			fmt.Println(m.state.Breadcrumbs())
+		} else {
+			fmt.Print(msg)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Currently, using `up ctx . -f -` prints nothing to stdout. A user would expect that it prints a fresh kubeconfig connecting to the current ctp/group/space configured in the kubeconfig.

This pull request ensures that `up ctx .` always accepts the changes (which triggers writing to stdout) when using `-f -`. It also ensures that stdout isn't polluted by printing the context breadcrumbs after printing the kubeconfig.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
$ up ctx . -f -
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: ...
    server: ...
  name: upbound
contexts:
- context:
    cluster: upbound
    extensions:
    - extension:
        apiVersion: upbound.io/v1alpha1
        kind: SpaceExtension
        spec:
          cloud:
            organization: upbound
            space: upbound-gcp-us-west-1
      name: spaces.upbound.io/space
    namespace: default
    user: upbound
  name: upbound
current-context: upbound
kind: Config
preferences: {}
users:
- name: upbound
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      args:
      - organization
      - token
      command: up
      env:
      - name: ORGANIZATION
        value: upbound
      - name: UP_PROFILE
        value: dev
      interactiveMode: IfAvailable
      provideClusterInfo: false
```