### PR TITLE
feat(space-mirror): add resources based on kubeVersionPath

### DIFF
--- a/cmd/up/space/mirror/config.yaml
+++ b/cmd/up/space/mirror/config.yaml
@@ -14,10 +14,16 @@
 
 oci:
   - chart: "xpkg.upbound.io/spaces-artifacts/spaces"
-    subCharts:
+    subResources:
       - pathNavigatorType: uxpVersionsPath
-        chart: "xpkg.upbound.io/upbound/universal-crossplane"
-        image: "xpkg.upbound.io/upbound/crossplane"
+        chart: "xpkg.upbound.io/spaces-artifacts/universal-crossplane"
+        image: "xpkg.upbound.io/spaces-artifacts/crossplane"
+      - pathNavigatorType: kubeVersionPath
+        image: xpkg.upbound.io/spaces-artifacts/kube-apiserver
+      - pathNavigatorType: kubeVersionPath
+        image: xpkg.upbound.io/spaces-artifacts/kube-controller-manager
+      - pathNavigatorType: kubeVersionPath
+        image: xpkg.upbound.io/spaces-artifacts/kube-scheduler
     images:
       - image: "xpkg.upbound.io/spaces-artifacts/hyperspace"
         compatibleChartVersion: ">=1.6"
@@ -46,9 +52,6 @@ oci:
       - image: "xpkg.upbound.io/spaces-artifacts/etcd:3.5.6-0"
       - image: "xpkg.upbound.io/spaces-artifacts/external-secrets:v0.9.11-3.g8e279dea"
       - image: "xpkg.upbound.io/spaces-artifacts/kine:v0.0.0-224.g6a07aa9"
-      - image: "xpkg.upbound.io/spaces-artifacts/kube-apiserver:v1.28.6"
-      - image: "xpkg.upbound.io/spaces-artifacts/kube-controller-manager:v1.28.6"
-      - image: "xpkg.upbound.io/spaces-artifacts/kube-scheduler:v1.28.6"
       - image: "xpkg.upbound.io/spaces-artifacts/kube-state-metrics:v2.8.1-upbound003"
       - image: "xpkg.upbound.io/spaces-artifacts/kubectl:1.29"
       - image: "xpkg.upbound.io/spaces-artifacts/kyverno-background-controller:v1.11.4"
@@ -59,7 +62,7 @@ oci:
       - image: "xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook-openssl:3.1.4"
       - image: "xpkg.upbound.io/spaces-artifacts/opentelemetry-collector-contrib:0.98.0"
       - image: "xpkg.upbound.io/spaces-artifacts/uxp-bootstrapper:v1.10.4-up.2"
-        compatibleChartVersion: "1.6.x"
+        compatibleChartVersion: ">=1.6.x"
       - image: "xpkg.upbound.io/spaces-artifacts/uxp-bootstrapper:v1.10.1-up.1"
         compatibleChartVersion: "1.5.x"
       - image: "xpkg.upbound.io/spaces-artifacts/vcluster:0.15.7"

--- a/cmd/up/space/mirror/static_artifacts.go
+++ b/cmd/up/space/mirror/static_artifacts.go
@@ -16,7 +16,10 @@ package mirror
 
 import (
 	_ "embed"
+	"encoding/json"
 	"reflect"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 )
 
 // Embed the YAML file.
@@ -32,11 +35,48 @@ type UXPVersionsPath struct {
 	} `json:"controller"`
 }
 
+type KubeVersionPath struct {
+	ControlPlanes struct {
+		K8sVersion StringOrArray `json:"k8sVersion"`
+	} `json:"controlPlanes"`
+}
+
 func (j *UXPVersionsPath) GetSupportedVersions() ([]string, error) {
+	if len(j.Controller.Crossplane.SupportedVersions) == 0 {
+		return nil, errors.New("no supported versions found in UXPVersionsPath")
+	}
 	return j.Controller.Crossplane.SupportedVersions, nil
+}
+
+func (k *KubeVersionPath) GetSupportedVersions() ([]string, error) {
+	if len(k.ControlPlanes.K8sVersion) == 0 {
+		return nil, errors.New("no supported versions found in KubeVersionPath")
+	}
+	return k.ControlPlanes.K8sVersion, nil
 }
 
 // init function to return byte slice and oci.PathNavigator
 func initConfig() ([]byte, map[string]reflect.Type) {
-	return configFile, map[string]reflect.Type{"uxpVersionsPath": reflect.TypeOf(UXPVersionsPath{})}
+	return configFile, map[string]reflect.Type{
+		"uxpVersionsPath": reflect.TypeOf(UXPVersionsPath{}),
+		"kubeVersionPath": reflect.TypeOf(KubeVersionPath{}),
+	}
+}
+
+type StringOrArray []string
+
+func (s *StringOrArray) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*s = []string{single}
+		return nil
+	}
+
+	var array []string
+	if err := json.Unmarshal(data, &array); err == nil {
+		*s = array
+		return nil
+	}
+
+	return errors.New("data is neither a string nor an array of strings")
 }

--- a/cmd/up/space/mirror/types.go
+++ b/cmd/up/space/mirror/types.go
@@ -19,9 +19,9 @@ import (
 )
 
 type Repository struct {
-	Chart     string           `yaml:"chart"`
-	Images    []ImageReference `yaml:"images"`
-	SubCharts []SubChart       `yaml:"subCharts"`
+	Chart        string           `yaml:"chart"`
+	Images       []ImageReference `yaml:"images"`
+	SubResources []SubResource    `yaml:"subResources"`
 }
 
 type ImageReference struct {
@@ -29,11 +29,11 @@ type ImageReference struct {
 	CompatibleChartVersion string `yaml:"compatibleChartVersion,omitempty"`
 }
 
-type SubChart struct {
+type SubResource struct {
 	PathNavigator     oci.PathNavigator `yaml:"pathNavigator,omitempty"`
 	PathNavigatorType string            `yaml:"pathNavigatorType"`
-	Chart             string            `yaml:"chart"`
-	Image             string            `yaml:"image"`
+	Chart             string            `yaml:"chart,omitempty"`
+	Image             string            `yaml:"image,omitempty"`
 }
 
 type config struct {


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- switch uxp and crossplane base registry from `xpkg.upbound.io/universal-crossplane` and `xpkg.upbound.io/crossplane` to `xpkg.upbound.io/spaces-artifacts`
- add option to get kube-apiserver, kube-controller-manager, kube-scheduler based on `controlPlanes.k8sVersion` in spaces chart
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
up alpha space mirror --version=1.7.0-rc.0.204.gc8aff05e --to-dir=/tmp/test --dry-run
```
[...]
crane pull xpkg.upbound.io/spaces-artifacts/kube-apiserver:v1.29.6 /tmp/test/kube-apiserver-v1.29.6.tgz
crane pull xpkg.upbound.io/spaces-artifacts/kube-controller-manager:v1.29.6 /tmp/test/kube-controller-manager-v1.29.6.tgz
crane pull xpkg.upbound.io/spaces-artifacts/kube-scheduler:v1.29.6 /tmp/test/kube-scheduler-v1.29.6.tgz
[...]
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
