### PR TITLE
Add a version constraint for the mxp-authz-webhook Chart's images

### DIFF
--- a/cmd/up/space/mirror/config.yaml
+++ b/cmd/up/space/mirror/config.yaml
@@ -30,7 +30,8 @@ oci:
       - image: "xpkg.upbound.io/spaces-artifacts/mxe-composition-templates"
         compatibleChartVersion: "1.5.x"
       - image: "xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook"
-      # compatibleChartVersion: "1.5.x" # Will be removed with https://github.com/upbound/spaces/pull/1393
+        # starting from v1.7.0, mxp-authz-webhook chart is removed
+        compatibleChartVersion: "<=1.6.x"
       - image: "xpkg.upbound.io/spaces-artifacts/mxp-benchmark"
       - image: "xpkg.upbound.io/spaces-artifacts/mxp-charts"
       - image: "xpkg.upbound.io/spaces-artifacts/mxp-control-plane"
@@ -64,6 +65,8 @@ oci:
       - image: "xpkg.upbound.io/spaces-artifacts/kyverno-kyvernopre:v1.11.4"
       - image: "xpkg.upbound.io/spaces-artifacts/kyverno-reports-controller:v1.11.4"
       - image: "xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook-openssl:3.1.4"
+        # starting from v1.7.0, mxp-authz-webhook chart is removed
+        compatibleChartVersion: "<=1.6.x"
       - image: "xpkg.upbound.io/spaces-artifacts/opentelemetry-collector-contrib:0.98.0"
       - image: "xpkg.upbound.io/spaces-artifacts/uxp-bootstrapper:v1.10.4-up.2"
         compatibleChartVersion: ">=1.6.x"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
Starting with Spaces v1.17.0, we would like to remove the mxp-authz-webhook Chart. This PR adds the version constraint `<=1.6.x` on the `xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook` & `xpkg.upbound.io/spaces-artifacts/mxp-authz-webhook-openssl` images so that starting from Spaces v1.17.0, they will no longer be mirrored.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
