### PR TITLE
Setup logging

### DIFF
--- a/cmd/up/controlplane/connector/install.go
+++ b/cmd/up/controlplane/connector/install.go
@@ -22,10 +22,11 @@ import (
 	"strconv"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up-sdk-go/service/accounts"
 	"github.com/upbound/up-sdk-go/service/tokens"
@@ -56,9 +57,6 @@ func (c *installCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) e
 	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
 	if err != nil {
 		return err
-	}
-	if upCtx.WrapTransport != nil {
-		kubeconfig.Wrap(upCtx.WrapTransport)
 	}
 
 	mgr, err := helm.NewManager(kubeconfig,

--- a/cmd/up/controlplane/connector/uninstall.go
+++ b/cmd/up/controlplane/connector/uninstall.go
@@ -33,9 +33,6 @@ func (c *uninstallCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context)
 	if err != nil {
 		return err
 	}
-	if upCtx.WrapTransport != nil {
-		kubeconfig.Wrap(upCtx.WrapTransport)
-	}
 
 	mgr, err := helm.NewManager(kubeconfig,
 		connectorName,

--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -53,6 +53,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
 	kongCtx.Bind(upCtx)
 
 	// we can't use control planes from inside a control plane
@@ -75,6 +76,7 @@ func PredictControlPlanes() complete.Predictor {
 		if err != nil {
 			return nil
 		}
+		upCtx.SetupLogging()
 
 		client, err := upCtx.BuildCurrentContextClient()
 		if err != nil {

--- a/cmd/up/controlplane/pkg/install.go
+++ b/cmd/up/controlplane/pkg/install.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pterm/pterm"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up/internal/kube"
 	"github.com/upbound/up/internal/resources"
@@ -82,10 +83,6 @@ func (c *installCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) e
 		return err
 	}
 	kubeconfig.UserAgent = version.UserAgent()
-
-	if upCtx.WrapTransport != nil {
-		kubeconfig.Wrap(upCtx.WrapTransport)
-	}
 
 	// todo(redbackthomson): Migrate to using client.Client for standardization
 	client, err := dynamic.NewForConfig(kubeconfig)

--- a/cmd/up/controlplane/pullsecret/create.go
+++ b/cmd/up/controlplane/pullsecret/create.go
@@ -18,9 +18,10 @@ import (
 	"context"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up/internal/kube"
 	"github.com/upbound/up/internal/upbound"
@@ -39,9 +40,6 @@ func (c *createCmd) AfterApply(kongCtx *kong.Context, upCtx *upbound.Context) er
 	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
 	if err != nil {
 		return err
-	}
-	if upCtx.WrapTransport != nil {
-		kubeconfig.Wrap(upCtx.WrapTransport)
 	}
 	client, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {

--- a/cmd/up/ctx/cmd.go
+++ b/cmd/up/ctx/cmd.go
@@ -17,7 +17,6 @@ package ctx
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -31,8 +30,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
 	"github.com/upbound/up/internal/kube"
@@ -68,6 +65,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
 	kongCtx.Bind(upCtx)
 
 	return nil
@@ -109,8 +107,6 @@ func (m model) WithTermination(msg string, err error) model {
 }
 
 func (c *Cmd) Run(ctx context.Context, kongCtx *kong.Context, upCtx *upbound.Context) error {
-	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
-
 	// find profile and derive controlplane from kubeconfig
 	po := clientcmd.NewDefaultPathOptions()
 	conf, err := po.GetStartingConfig()
@@ -348,6 +344,8 @@ func (c *Cmd) RunNonInteractive(ctx context.Context, upCtx *upbound.Context, nav
 }
 
 func (c *Cmd) RunInteractive(ctx context.Context, kongCtx *kong.Context, upCtx *upbound.Context, navCtx *navContext, initialState NavigationState) error {
+	upCtx.HideLogging()
+
 	// start interactive mode
 	m := model{
 		state:      initialState,
@@ -388,7 +386,7 @@ func (c *Cmd) kubeContextWriter(upCtx *upbound.Context) kubeContextWriter {
 		upCtx:            upCtx,
 		fileOverride:     c.File,
 		kubeContext:      c.KubeContext,
-		verify:           kube.VerifyKubeConfig(upCtx.WrapTransport),
+		verify:           kube.VerifyKubeConfig(),
 		writeLastContext: writeLastContext,
 		modifyConfig:     clientcmd.ModifyConfig,
 	}

--- a/cmd/up/group/cmd.go
+++ b/cmd/up/group/cmd.go
@@ -18,11 +18,12 @@ import (
 	"strconv"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
 	"github.com/upbound/up/internal/feature"
@@ -50,6 +51,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
 
 	// we can't use groups from inside a control plane
 	if _, ctp, inSpace := upCtx.GetCurrentSpaceContextScope(); !inSpace {

--- a/cmd/up/login/login.go
+++ b/cmd/up/login/login.go
@@ -30,11 +30,12 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/golang-jwt/jwt"
 	"github.com/mdp/qrterminal/v3"
 	"github.com/pkg/browser"
 	"github.com/pterm/pterm"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up-sdk-go/service/userinfo"
 	uphttp "github.com/upbound/up/internal/http"
@@ -72,6 +73,8 @@ func (c *LoginCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
+
 	// NOTE(hasheddan): client timeout is handled with request context.
 	// TODO(hasheddan): we can't use the typical up-sdk-go client here because
 	// we need to read session cookie from body. We should add support in the
@@ -80,9 +83,6 @@ func (c *LoginCmd) AfterApply(kongCtx *kong.Context) error {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: upCtx.InsecureSkipTLSVerify, //nolint:gosec
 		},
-	}
-	if upCtx.WrapTransport != nil {
-		tr = upCtx.WrapTransport(tr)
 	}
 	c.client = &http.Client{
 		Transport: tr,

--- a/cmd/up/login/logout.go
+++ b/cmd/up/login/logout.go
@@ -19,8 +19,9 @@ import (
 	"net/http"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/pterm/pterm"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up-sdk-go"
 
@@ -41,6 +42,8 @@ func (c *LogoutCmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
+
 	cfg, err := upCtx.BuildSDKConfig()
 	if err != nil {
 		return err

--- a/cmd/up/organization/organization.go
+++ b/cmd/up/organization/organization.go
@@ -48,6 +48,8 @@ func PredictOrgs() complete.Predictor {
 		if err != nil {
 			return nil
 		}
+		upCtx.SetupLogging()
+
 		cfg, err := upCtx.BuildSDKConfig()
 		if err != nil {
 			return nil

--- a/cmd/up/organization/token.go
+++ b/cmd/up/organization/token.go
@@ -44,6 +44,7 @@ func (c *tokenCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
 
 	kongCtx.Bind(upCtx)
 	return nil

--- a/cmd/up/profile/profile.go
+++ b/cmd/up/profile/profile.go
@@ -43,6 +43,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
 
 	kongCtx.Bind(upCtx)
 	return nil

--- a/cmd/up/query/get.go
+++ b/cmd/up/query/get.go
@@ -53,6 +53,7 @@ func (c *GetCmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
 
 	// load current kubeconfig context
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()

--- a/cmd/up/query/query.go
+++ b/cmd/up/query/query.go
@@ -55,6 +55,7 @@ func (c *QueryCmd) AfterApply(kongCtx *kong.Context) error { // nolint:gocyclo /
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
 
 	kubeconfig, err := upCtx.Kubecfg.ClientConfig()
 	if err != nil {

--- a/cmd/up/query/run.go
+++ b/cmd/up/query/run.go
@@ -88,10 +88,6 @@ func (c *cmd) Run(ctx context.Context, kongCtx *kong.Context, upCtx *upbound.Con
 	}
 	gkNames, categoryNames := SplitGroupKindAndCategories(tgns)
 
-	if upCtx.WrapTransport != nil {
-		kubeconfig.Wrap(upCtx.WrapTransport)
-	}
-
 	// pre-check that the server supports the v1alpha1 query API
 	if err := checkQueryAPIAvailability(kubeconfig); err != nil {
 		return err

--- a/cmd/up/repository/repository.go
+++ b/cmd/up/repository/repository.go
@@ -49,6 +49,8 @@ func PredictRepos() complete.Predictor {
 		if err != nil {
 			return nil
 		}
+		upCtx.SetupLogging()
+
 		cfg, err := upCtx.BuildSDKConfig()
 		if err != nil {
 			return nil

--- a/cmd/up/robot/robot.go
+++ b/cmd/up/robot/robot.go
@@ -57,6 +57,8 @@ func PredictRobots() complete.Predictor {
 		if err != nil {
 			return nil
 		}
+		upCtx.SetupLogging()
+
 		cfg, err := upCtx.BuildSDKConfig()
 		if err != nil {
 			return nil

--- a/cmd/up/space/connect.go
+++ b/cmd/up/space/connect.go
@@ -93,6 +93,8 @@ func (c *connectCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
+
 	cfg, err := upCtx.BuildSDKConfig()
 	if err != nil {
 		return err

--- a/cmd/up/space/destroy.go
+++ b/cmd/up/space/destroy.go
@@ -56,6 +56,7 @@ func (c *destroyCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
 
 	kubeconfig, err := upCtx.Kubecfg.ClientConfig()
 	if err != nil {

--- a/cmd/up/space/disconect.go
+++ b/cmd/up/space/disconect.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/google/uuid"
 	"github.com/pterm/pterm"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -31,6 +30,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	upboundv1alpha1 "github.com/upbound/up-sdk-go/apis/upbound/v1alpha1"
 	sdkerrs "github.com/upbound/up-sdk-go/errors"
@@ -72,6 +73,8 @@ func (c *disconnectCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
+
 	cfg, err := upCtx.BuildSDKConfig()
 	if err != nil {
 		return err

--- a/cmd/up/space/init.go
+++ b/cmd/up/space/init.go
@@ -23,10 +23,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/alecthomas/kong"
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/feature"
-	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pterm/pterm"
 	"golang.org/x/exp/maps"
 	"helm.sh/helm/v3/pkg/chart"
@@ -40,6 +36,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/yaml"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
 	upboundv1alpha1 "github.com/upbound/up-sdk-go/apis/upbound/v1alpha1"
 	"github.com/upbound/up/cmd/up/space/defaults"
@@ -141,6 +142,7 @@ func (c *initCmd) AfterApply(kongCtx *kong.Context, quiet config.QuietFlag) erro
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
 
 	kubeconfig := c.Kube.GetConfig()
 

--- a/cmd/up/space/list.go
+++ b/cmd/up/space/list.go
@@ -52,6 +52,8 @@ func (c *listCmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
+
 	cfg, err := upCtx.BuildSDKConfig()
 	if err != nil {
 		return err

--- a/cmd/up/space/upgrade.go
+++ b/cmd/up/space/upgrade.go
@@ -91,6 +91,7 @@ func (c *upgradeCmd) AfterApply(quiet config.QuietFlag) error { //nolint:gocyclo
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
 
 	kubeconfig, err := upCtx.Kubecfg.ClientConfig()
 	if err != nil {

--- a/cmd/up/team/team.go
+++ b/cmd/up/team/team.go
@@ -38,6 +38,8 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	if err != nil {
 		return err
 	}
+	upCtx.SetupLogging()
+
 	cfg, err := upCtx.BuildSDKConfig()
 	if err != nil {
 		return err
@@ -55,6 +57,8 @@ func PredictTeams() complete.Predictor {
 		if err != nil {
 			return nil
 		}
+		upCtx.SetupLogging()
+
 		cfg, err := upCtx.BuildSDKConfig()
 		if err != nil {
 			return nil

--- a/cmd/up/trace/cmd.go
+++ b/cmd/up/trace/cmd.go
@@ -72,6 +72,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
 
 	return nil
 }
@@ -208,6 +209,7 @@ func (c *Cmd) Run(ctx context.Context, kongCtx *kong.Context, upCtx *upbound.Con
 		return &unstructured.Unstructured{Object: query.GetResponse().Objects[0].Object.Object}, nil
 	}
 
+	upCtx.HideLogging()
 	app := NewApp("upbound trace", c.Resources, gkNames, categoryNames, poll, fetch)
 	return app.Run(ctx)
 }

--- a/cmd/up/uxp/uxp.go
+++ b/cmd/up/uxp/uxp.go
@@ -38,15 +38,14 @@ var (
 // that have Run() methods that receive it.
 func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 	upCtx, err := upbound.NewFromFlags(c.Flags)
+	upCtx.SetupLogging()
+
 	if err != nil {
 		return err
 	}
 	kubeconfig, err := kube.GetKubeConfig(c.Kubeconfig)
 	if err != nil {
 		return err
-	}
-	if upCtx.WrapTransport != nil {
-		kubeconfig.Wrap(upCtx.WrapTransport)
 	}
 	kongCtx.Bind(&install.Context{
 		Kubeconfig: kubeconfig,

--- a/cmd/up/version/version.go
+++ b/cmd/up/version/version.go
@@ -86,6 +86,7 @@ func (c *Cmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
 
 	return nil
 }

--- a/cmd/up/xpkg/batch.go
+++ b/cmd/up/xpkg/batch.go
@@ -25,14 +25,15 @@ import (
 	"text/template"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/parser"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/parser"
 
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/xpkg"
@@ -84,6 +85,7 @@ func (c *batchCmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
 
 	return nil
 }

--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kong"
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -33,6 +32,8 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up-sdk-go/service/repositories"
 	"github.com/upbound/up/internal/credhelper"
@@ -58,6 +59,8 @@ func (c *pushCmd) AfterApply(kongCtx *kong.Context) error {
 		return err
 	}
 	kongCtx.Bind(upCtx)
+	upCtx.SetupLogging()
+
 	return nil
 }
 

--- a/cmd/up/xpkg/xpextract.go
+++ b/cmd/up/xpkg/xpextract.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
@@ -31,6 +30,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/pterm/pterm"
 	"github.com/spf13/afero"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
 	"github.com/upbound/up/internal/upbound"
 	"github.com/upbound/up/internal/xpkg"
@@ -107,6 +108,8 @@ func (c *xpExtractCmd) AfterApply() error {
 		if err != nil {
 			return err
 		}
+		upCtx.SetupLogging()
+
 		name, err := name.ParseReference(c.Package, name.WithDefaultRegistry(upCtx.RegistryEndpoint.Hostname()))
 		if err != nil {
 			return errors.Wrap(err, errInvalidTag)

--- a/go.mod
+++ b/go.mod
@@ -161,7 +161,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-git/go-git/v5 v5.11.0 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.20.2 // indirect
@@ -265,7 +265,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.starlark.net v0.0.0-20230612165344-9532f5667272 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.26.0 // indirect
+	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
@@ -287,7 +287,7 @@ require (
 	k8s.io/apiserver v0.29.1 // indirect
 	k8s.io/cli-runtime v0.29.1
 	k8s.io/component-base v0.29.1 // indirect
-	k8s.io/klog/v2 v2.120.1 // indirect
+	k8s.io/klog/v2 v2.120.1
 	oras.land/oras-go v1.2.2 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/transport"
 )
 
 const (
@@ -67,7 +66,7 @@ func BuildCloudControlPlaneKubeconfig(proxy *url.URL, id string, token string, i
 	return conf
 }
 
-func VerifyKubeConfig(wrapTransport transport.WrapperFunc) func(cfg *api.Config) error {
+func VerifyKubeConfig() func(cfg *api.Config) error {
 	return func(cfg *api.Config) error {
 		clientConfig := clientcmd.NewDefaultClientConfig(*cfg, &clientcmd.ConfigOverrides{
 			CurrentContext: cfg.CurrentContext,
@@ -77,9 +76,6 @@ func VerifyKubeConfig(wrapTransport transport.WrapperFunc) func(cfg *api.Config)
 			return err
 		}
 		restConfig.Timeout = 2 * time.Second
-		if wrapTransport != nil {
-			restConfig.Wrap(wrapTransport)
-		}
 		clientset, err := kubernetes.NewForConfig(restConfig)
 		if err != nil {
 			return err

--- a/internal/logging/klog.go
+++ b/internal/logging/klog.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Upbound Inc.
+// All rights reserved
+
+package logging
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+)
+
+type KlogFilter func(msg string, keysAndValues ...interface{}) bool
+
+// SetFilteredKlogLogger sets log as the logger backend of klog, with debugLevel+3 as the
+// klog verbosity level. If debugLevel is 0, only request throttling messages are
+// logged. Further filters can be added to the logger by passing them as arguments.
+// Those filters also only apply for debugLevel 0.
+func SetFilteredKlogLogger(debugLevel int, log logr.Logger, preds ...KlogFilter) {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(fs)
+	_ = fs.Parse([]string{fmt.Sprintf("--v=%d", debugLevel+3)}) //nolint:errcheck // we couldn't do anything here anyway
+
+	preds = append(preds, requestThrottlingFilter)
+	if debugLevel == 0 {
+		preds = nil
+	}
+
+	klogr := logr.New(&klogFilter{LogSink: log.GetSink(), preds: preds})
+	klog.SetLogger(klogr)
+}
+
+type klogFilter struct {
+	logr.LogSink
+	preds []KlogFilter
+}
+
+func (l *klogFilter) Info(level int, msg string, keysAndValues ...interface{}) {
+	if len(l.preds) == 0 {
+		l.LogSink.Info(klogToLogrLevel(level), msg, keysAndValues...)
+		return
+	}
+	for _, pred := range l.preds {
+		if pred(msg, keysAndValues...) {
+			l.LogSink.Info(klogToLogrLevel(level), msg, keysAndValues...)
+			return
+		}
+	}
+}
+
+func (l *klogFilter) Enabled(_ int) bool {
+	return true
+}
+
+func klogToLogrLevel(klogLvl int) int {
+	if klogLvl > 3 {
+		return 1
+	}
+	return 0
+}
+
+func (l *klogFilter) WithCallDepth(depth int) logr.LogSink {
+	if delegate, ok := l.LogSink.(logr.CallDepthLogSink); ok {
+		return &klogFilter{LogSink: delegate.WithCallDepth(depth), preds: l.preds}
+	}
+
+	return l
+}
+
+// requestThrottlingFilter drops everything that is not a client-go throttling
+// message, compare:
+// https://github.com/kubernetes/client-go/blob/8c4efe8d079e405329f314fb789a41ac6af101dc/rest/request.go#L621
+func requestThrottlingFilter(msg string, _ ...interface{}) bool {
+	return strings.Contains(msg, "Waited for ") && strings.Contains(msg, "  request: ")
+}

--- a/internal/upbound/context.go
+++ b/internal/upbound/context.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	xplogging "github.com/crossplane/crossplane-runtime/pkg/logging"
+
 	"github.com/upbound/up/internal/logging"
 
 	"github.com/spf13/afero"

--- a/internal/upbound/context_test.go
+++ b/internal/upbound/context_test.go
@@ -112,9 +112,8 @@ func TestNewFromFlags(t *testing.T) {
 		opts  []Option
 	}
 	type want struct {
-		err     error
-		c       *Context
-		wantErr error
+		err error
+		c   *Context
 	}
 
 	cases := map[string]struct {


### PR DESCRIPTION
This PR sets up controller-runtime and klog logging. By default, klog verbosity is 3, but we filter by request throttling messages. With one or more of `-d` or `--debug`, or `--debug=<level>` verbosity can be increased. `-d -d -d` or `--debug=3` means klog verbosity `3+3`, to 6. With that (3), you see all the (client-go) http requests the binary is doing.