### PR TITLE
install agent from the spaces registry

### DIFF
--- a/cmd/up/space/disconect.go
+++ b/cmd/up/space/disconect.go
@@ -17,7 +17,6 @@ package space
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -45,6 +44,8 @@ import (
 )
 
 type disconnectCmd struct {
+	Registry registryFlags `embed:""`
+
 	Upbound upbound.Flags     `embed:""`
 	Kube    upbound.KubeFlags `embed:""`
 
@@ -52,11 +53,6 @@ type disconnectCmd struct {
 }
 
 func (c *disconnectCmd) AfterApply(kongCtx *kong.Context) error {
-	registryURL, err := url.Parse(agentRegistry)
-	if err != nil {
-		return err
-	}
-
 	needsKube := true
 	if err := c.Kube.AfterApply(); err != nil {
 		if c.Space == "" {
@@ -112,7 +108,7 @@ func (c *disconnectCmd) AfterApply(kongCtx *kong.Context) error {
 
 	mgr, err := helm.NewManager(kubeconfig,
 		agentChart,
-		registryURL,
+		c.Registry.Repository,
 		with...,
 	)
 	if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -50,7 +50,7 @@ const (
 
 var (
 	version             string
-	agentVersion        string = "0.0.0-416.g084be68"
+	agentVersion        string = "0.0.0-429.g5433474"
 	mcpConnectorVersion string = "0.7.0"
 	gitCommit           string = "unknown-commit"
 	target              string = string(ReleaseTargetDebug)


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Now that spaces images moved into xpkg registry, install agent from there too.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
Created a space in kind and connected it, checked the images afterwards:

```bash
kubectl get pod -A -o json | jq '[.items[] | .spec.containers[] | .image] | sort | unique'
[
  "docker.io/kindest/kindnetd:v20240813-c6f155d6",
  "docker.io/kindest/local-path-provisioner:v20240813-c6f155d6",
  "quay.io/jetstack/cert-manager-cainjector:v1.11.0",
  "quay.io/jetstack/cert-manager-controller:v1.11.0",
  "quay.io/jetstack/cert-manager-webhook:v1.11.0",
  "registry.k8s.io/coredns/coredns:v1.11.1",
  "registry.k8s.io/etcd:3.5.15-0",
  "registry.k8s.io/ingress-nginx/controller:v1.8.1@sha256:e5c4824e7375fcf2a393e1c03c293b69759af37a9ca6abdb91b13d78a93da8bd",
  "registry.k8s.io/kube-apiserver:v1.31.0",
  "registry.k8s.io/kube-controller-manager:v1.31.0",
  "registry.k8s.io/kube-proxy:v1.31.0",
  "registry.k8s.io/kube-scheduler:v1.31.0",
  "xpkg.upbound.io/spaces-artifacts/agent:v0.0.0-429.g5433474",
  "xpkg.upbound.io/spaces-artifacts/envoy:v1.26-latest",
  "xpkg.upbound.io/spaces-artifacts/hyperspace:v1.7.0",
  "xpkg.upbound.io/spaces-artifacts/mxp-charts:v1.7.0"
]
```
