### PR TITLE
Bump spaces dependency xpkg.upbound.io/spaces-artifacts/vector to 0.41.1-distroless-libc

### DIFF
--- a/cmd/up/space/mirror/config.yaml
+++ b/cmd/up/space/mirror/config.yaml
@@ -77,4 +77,7 @@ oci:
         compatibleChartVersion: "1.5.x"
       - image: "xpkg.upbound.io/spaces-artifacts/vcluster:0.15.7"
       - image: "xpkg.upbound.io/spaces-artifacts/vector:0.30.0-distroless-libc"
+        compatibleChartVersion: "<1.8.0"
+      - image: "xpkg.upbound.io/spaces-artifacts/vector:0.41.1-distroless-libc"
+        compatibleChartVersion: ">=1.8.0"
       - image: "xpkg.upbound.io/spaces-artifacts/xgql:v0.2.0-rc.0.153.g0a1d4ae"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

We're planning to bump vector.dev dependency in spaces `v1.8` to `0.41.1-distroless-libc` to support workload identity federation in AKS clusters. This PR updates that dependency for `up space mirror`.

The image `xpkg.upbound.io/spaces-artifacts/vector:0.41.1-distroless-libc` has already been mirrored.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
