### PR TITLE
Drop healthy column from the up ctp get/list

### DIFF
--- a/cmd/up/controlplane/controlplane.go
+++ b/cmd/up/controlplane/controlplane.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	spacefieldNames = []string{"GROUP", "NAME", "CROSSPLANE", "READY", "HEALTHY", "MESSAGE", "AGE"}
+	spacefieldNames = []string{"GROUP", "NAME", "CROSSPLANE", "READY", "MESSAGE", "AGE"}
 )
 
 // BeforeReset is the first hook to run.
@@ -145,7 +145,6 @@ func extractSpaceFields(obj any) []string {
 		ctp.GetName(),
 		v,
 		string(ctp.GetCondition(xpcommonv1.TypeReady).Status),
-		string(ctp.GetCondition(spacesv1beta1.ConditionTypeHealthy).Status),
 		ctp.Status.Message,
 		formatAge(ptr.To(time.Since(ctp.CreationTimestamp.Time))),
 	}

--- a/internal/controlplane/controlplane.go
+++ b/internal/controlplane/controlplane.go
@@ -27,7 +27,6 @@ type Response struct {
 	Name              string
 	CrossplaneVersion string
 	Ready             string
-	Healthy           string
 	Message           string
 	Age               *time.Duration
 

--- a/internal/controlplane/space/space.go
+++ b/internal/controlplane/space/space.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
-
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -154,7 +152,6 @@ func convert(ctp *resources.ControlPlane) *controlplane.Response {
 		Name:              ctp.GetName(),
 		CrossplaneVersion: ctp.GetCrossplaneVersion(),
 		Ready:             string(ctp.GetCondition(xpcommonv1.TypeReady).Status),
-		Healthy:           string(ctp.GetCondition(v1beta1.ConditionTypeHealthy).Status),
 		Message:           ctp.GetMessage(),
 		Age:               ctp.GetAge(),
 		Cfg:               "",

--- a/internal/controlplane/space/space_test.go
+++ b/internal/controlplane/space/space_test.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	spacesv1beta1 "github.com/upbound/up-sdk-go/apis/spaces/v1beta1"
-
 	"github.com/google/go-cmp/cmp"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -430,7 +428,6 @@ func TestConvert(t *testing.T) {
 						Namespace: "default",
 					})
 					c.SetConditions([]xpcommonv1.Condition{xpcommonv1.Available()}...)
-					c.SetConditions(spacesv1beta1.Healthy())
 					c.SetMessage("")
 
 					return c
@@ -442,7 +439,6 @@ func TestConvert(t *testing.T) {
 					ID:       "mxp1",
 					Group:    "default",
 					Ready:    "True",
-					Healthy:  "True",
 					ConnName: "kubeconfig-ctp1",
 					Message:  "",
 				},
@@ -461,7 +457,6 @@ func TestConvert(t *testing.T) {
 						Namespace: "default",
 					})
 					c.SetConditions(xpcommonv1.Creating().WithMessage("something"))
-					c.SetConditions(spacesv1beta1.Healthy())
 					c.SetMessage("creating...")
 
 					return c
@@ -473,7 +468,6 @@ func TestConvert(t *testing.T) {
 					ID:       "mxp1",
 					Group:    "default",
 					Ready:    "False",
-					Healthy:  "True",
 					Message:  "creating...",
 					ConnName: "kubeconfig-ctp1",
 				},
@@ -487,17 +481,15 @@ func TestConvert(t *testing.T) {
 					c.SetName("ctp1")
 					c.SetControlPlaneID("mxp1")
 					c.SetConditions([]xpcommonv1.Condition{xpcommonv1.Available()}...)
-					c.SetConditions(spacesv1beta1.Healthy())
 
 					return c
 				}(),
 			},
 			want: want{
 				resp: &controlplane.Response{
-					Name:    "ctp1",
-					ID:      "mxp1",
-					Ready:   "True",
-					Healthy: "True",
+					Name:  "ctp1",
+					ID:    "mxp1",
+					Ready: "True",
 				},
 			},
 		},


### PR DESCRIPTION
### Description of your changes

We recently dropped the healthy column from `kubectl get ctp` output in favor of more detailed messages. This PR does the same with the up ctp get/list commands.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Before:

```
❯ up ctp list -A
GROUP     NAME   CROSSPLANE    READY   HEALTHY   MESSAGE     AGE
another   ctp2   1.16.2-up.2   True    True      Available   7m38s
default   test   1.16.2-up.2   True    True      Available   9m29s

❯ up ctp get test
GROUP     NAME   CROSSPLANE    READY   HEALTHY   MESSAGE     AGE
default   test   1.16.2-up.2   True    True      Available   9m35s
```

After:
```
❯ go run ./cmd/up ctp list -A
GROUP     NAME   CROSSPLANE    READY   MESSAGE     AGE
another   ctp2   1.16.2-up.2   True    Available   5m17s
default   test   1.16.2-up.2   True    Available   7m8s

❯ go run ./cmd/up ctp get test
GROUP     NAME   CROSSPLANE    READY   MESSAGE     AGE
default   test   1.16.2-up.2   True    Available   7m22s
```
