### PR TITLE
ctx: Always use the spaces ingress

### DIFF
--- a/cmd/up/ctx/actions_test.go
+++ b/cmd/up/ctx/actions_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestDisconnectedGroupAccept(t *testing.T) {
+	t.Parallel()
+
 	spaceExtension := upbound.NewDisconnectedV1Alpha1SpaceExtension("profile")
 	extensionMap := map[string]runtime.Object{upbound.ContextExtensionKeySpace: spaceExtension}
 
@@ -61,7 +63,7 @@ func TestDisconnectedGroupAccept(t *testing.T) {
 					"upbound": {Namespace: "group", Cluster: "upbound", AuthInfo: "upbound", Extensions: extensionMap},
 					"profile": {Namespace: "group", Cluster: "profile", AuthInfo: "profile"},
 				},
-				Clusters:  map[string]*clientcmdapi.Cluster{"upbound": {Server: "profile"}, "upbound-previous": {Server: "server1"}, "profile": {Server: "profile"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"upbound": {Server: "https://ingress", CertificateAuthorityData: []uint8{1, 2, 3}}, "upbound-previous": {Server: "server1"}, "profile": {Server: "profile"}},
 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": {Token: "profile"}, "upbound-previous": {Token: "token1"}, "profile": {Token: "profile"}},
 			},
 			wantLast: "profile",
@@ -87,7 +89,7 @@ func TestDisconnectedGroupAccept(t *testing.T) {
 					"upbound-previous": {Namespace: "namespace1", Cluster: "upbound-previous", AuthInfo: "upbound-previous"},
 					"profile":          {Namespace: "group", Cluster: "profile", AuthInfo: "profile"},
 				},
-				Clusters:  map[string]*clientcmdapi.Cluster{"upbound": {Server: "profile"}, "upbound-previous": {Server: "server1"}, "profile": {Server: "profile"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"upbound": {Server: "https://ingress", CertificateAuthorityData: []uint8{1, 2, 3}}, "upbound-previous": {Server: "server1"}, "profile": {Server: "profile"}},
 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": {Token: "profile"}, "upbound-previous": {Token: "token1"}, "profile": {Token: "profile"}},
 			},
 			wantLast: "upbound-previous",
@@ -113,7 +115,7 @@ func TestDisconnectedGroupAccept(t *testing.T) {
 					"upbound-previous": {Namespace: "namespace2", Cluster: "upbound", AuthInfo: "upbound"},
 					"profile":          {Namespace: "group", Cluster: "profile", AuthInfo: "profile"},
 				},
-				Clusters:  map[string]*clientcmdapi.Cluster{"upbound": {Server: "profile"}, "upbound-previous": {Server: "server1"}, "profile": {Server: "profile"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"upbound": {Server: "https://ingress", CertificateAuthorityData: []uint8{1, 2, 3}}, "upbound-previous": {Server: "server1"}, "profile": {Server: "profile"}},
 				AuthInfos: map[string]*clientcmdapi.AuthInfo{"upbound": {Token: "profile"}, "upbound-previous": {Token: "token1"}, "profile": {Token: "profile"}},
 			},
 			wantLast: "upbound-previous",
@@ -122,6 +124,8 @@ func TestDisconnectedGroupAccept(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var last string
 			var conf *clientcmdapi.Config
 			upCtx := &upbound.Context{Kubecfg: clientcmd.NewDefaultClientConfig(*tt.conf, nil)}
@@ -166,6 +170,8 @@ func TestDisconnectedGroupAccept(t *testing.T) {
 }
 
 func TestCloudGroupAccept(t *testing.T) {
+	t.Parallel()
+
 	spaceExtension := upbound.NewCloudV1Alpha1SpaceExtension("org", "space")
 	extensionMap := map[string]runtime.Object{upbound.ContextExtensionKeySpace: spaceExtension}
 	spaceAuth := clientcmdapi.AuthInfo{Token: "space"}
@@ -258,6 +264,8 @@ func TestCloudGroupAccept(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var last string
 			var conf *clientcmdapi.Config
 			upCtx := &upbound.Context{Kubecfg: clientcmd.NewDefaultClientConfig(*tt.conf, nil)}
@@ -303,6 +311,8 @@ func TestCloudGroupAccept(t *testing.T) {
 }
 
 func TestDisconnectedControlPlaneAccept(t *testing.T) {
+	t.Parallel()
+
 	spaceExtension := upbound.NewDisconnectedV1Alpha1SpaceExtension("profile")
 	extensionMap := map[string]runtime.Object{upbound.ContextExtensionKeySpace: spaceExtension}
 
@@ -453,6 +463,8 @@ func TestDisconnectedControlPlaneAccept(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var last string
 			var conf *clientcmdapi.Config
 			upCtx := &upbound.Context{Kubecfg: clientcmd.NewDefaultClientConfig(*tt.conf, nil)}
@@ -500,6 +512,8 @@ func TestDisconnectedControlPlaneAccept(t *testing.T) {
 }
 
 func TestCloudControlPlaneAccept(t *testing.T) {
+	t.Parallel()
+
 	spaceExtension := upbound.NewCloudV1Alpha1SpaceExtension("org", "space")
 	extensionMap := map[string]runtime.Object{upbound.ContextExtensionKeySpace: spaceExtension}
 
@@ -650,6 +664,8 @@ func TestCloudControlPlaneAccept(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			var last string
 			var conf *clientcmdapi.Config
 			upCtx := &upbound.Context{Kubecfg: clientcmd.NewDefaultClientConfig(*tt.conf, nil)}


### PR DESCRIPTION
### Description of your changes

Previously, when connecting to a disconnected space (or a group in a disconnected space), we used the hub context's apiserver address and auth for the returned context. We would like to make some APIs (e.g., query API) available only via the ingress, so we want to use the ingress address for all contexts regardless of whether spaces are disconnected, connected, or cloud.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.~

### How has this code been tested

Updated unit tests, manual testing with disconnected and cloud spaces.
