### PR TITLE
Use spaces-config configmap to validate spaces in up space attach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.22'
-  GOLANGCI_VERSION: 'v1.56.2'
+  GOLANGCI_VERSION: 'v1.61.0'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
@@ -86,7 +86,7 @@ jobs:
       # this action because it leaves 'annotations' (i.e. it comments on PRs to
       # point out linter violations).
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6
         with:
           version: ${{ env.GOLANGCI_VERSION }}
           skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,6 +174,12 @@ issues:
       - gosec
       - gas
 
+    # This is an ' integer overflow conversion' warning and looks like there are false positives currently.
+    # https://dev.to/ccoveille/about-the-gosec-g115-drama-or-how-i-faced-back-integer-conversion-overflow-in-go-1302
+    - text: "G115:"
+      linters:
+        - gosec
+
     # The Azure AddToUserAgent method appends to the existing user agent string.
     # It returns an error if you pass it an empty string lettinga you know the
     # user agent did not change, making it more of a warning.

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.gitCommit=$(shell git rev-parse 
 GO_SUBDIRS += cmd internal
 GO111MODULE = on
 GO_REQUIRED_VERSION = 1.22
-GOLANGCILINT_VERSION = 1.56.2
+GOLANGCILINT_VERSION = 1.61.0
 
 -include build/makelib/golang.mk
 

--- a/cmd/up/space/connect.go
+++ b/cmd/up/space/connect.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 
@@ -49,11 +50,12 @@ import (
 )
 
 const (
-	agentChart   = "agent"
-	agentNs      = "upbound-system"
-	agentSecret  = "space-token"
-	connConfMap  = "space-connect"
-	mxpConfigMap = "mxp-config"
+	agentChart      = "agent"
+	agentNs         = "upbound-system"
+	agentSecret     = "space-token"
+	connConfMap     = "space-connect"
+	spacesConfigMap = "spaces-config"
+	spacesConfigKey = "config.yaml"
 
 	keySpace   = "space"
 	keyToken   = "token"
@@ -139,14 +141,23 @@ func (c *connectCmd) AfterApply(kongCtx *kong.Context) error {
 
 // Run executes the connect command.
 func (c *connectCmd) Run(ctx context.Context, mgr *helm.Installer, kClient *kubernetes.Clientset, upCtx *upbound.Context, ac *accounts.Client, oc *organizations.Client, tc *tokens.Client, rc *robots.Client, rest *rest.Config) (rErr error) { //nolint:gocyclo
-	mxpConfig, err := kClient.CoreV1().ConfigMaps(agentNs).Get(ctx, mxpConfigMap, metav1.GetOptions{})
+	spacesCM, err := kClient.CoreV1().ConfigMaps(agentNs).Get(ctx, spacesConfigMap, metav1.GetOptions{})
 	if kerrors.IsNotFound(err) {
 		return errors.New("failed to detect Space. Please run `up space init` first.")
 	} else if err != nil {
-		return errors.Wrapf(err, `failed to get ConfigMap "%s/%s"`, agentNs, mxpConfigMap)
+		return errors.Wrapf(err, `failed to get ConfigMap "%s/%s"`, agentNs, spacesConfigMap)
 	}
-	if spaceAcc := mxpConfig.Data["account"]; spaceAcc != upCtx.Account {
-		return errors.Errorf("account of the Space %q and account of the profile %q mismatch. Use `--account=%s` to connect to the right organization.", spaceAcc, c.Upbound.Account, spaceAcc)
+
+	if spacesCM.Data == nil || spacesCM.Data[spacesConfigKey] == "" {
+		return errors.Errorf("%q not found in %q configmap", spacesConfigKey, spacesConfigMap)
+	}
+	sc := &SpacesConfig{}
+	if err = yaml.Unmarshal([]byte(spacesCM.Data[spacesConfigKey]), sc); err != nil {
+		return errors.Wrap(err, "cannot unmarshal spaces config")
+	}
+
+	if sc.Account != upCtx.Account {
+		return errors.Errorf("account of the Space %q and account of the profile %q mismatch. Use `--account=%s` to connect to the right organization.", sc.Account, c.Upbound.Account, sc.Account)
 	}
 
 	connectSpinner, err := upterm.CheckmarkSuccessSpinner.Start("Connecting Space to Upbound Console...")
@@ -660,4 +671,10 @@ func warnAndConfirmWithSpinner(spinner *pterm.SpinnerPrinter, warning string, ar
 		spinner.IsActive = true
 	}()
 	return warnAndConfirm(warning, args...)
+}
+
+// SpacesConfig struct represents the configuration settings for the spaces.
+type SpacesConfig struct {
+	// Account is the account name of the organization.
+	Account string `json:"account"`
 }

--- a/cmd/up/space/mirror/mirror.go
+++ b/cmd/up/space/mirror/mirror.go
@@ -74,7 +74,7 @@ func (c *Cmd) Run(ctx context.Context, printer upterm.ObjectPrinter) (rErr error
 		switch {
 		case os.IsNotExist(err):
 			// Directory does not exist, create it
-			if err := os.MkdirAll(c.ToDir, os.ModePerm); err != nil {
+			if err := os.MkdirAll(c.ToDir, 0750); err != nil {
 				return fmt.Errorf("failed to create directory: %w", err)
 			}
 		case err != nil:

--- a/cmd/up/team/get.go
+++ b/cmd/up/team/get.go
@@ -66,5 +66,5 @@ func (c *getCmd) Run(ctx context.Context, printer upterm.ObjectPrinter, ac *acco
 			return printer.Print(r, fieldNames, extractFields)
 		}
 	}
-	return fmt.Errorf("no team named \"" + c.Name + "\"")
+	return fmt.Errorf("no team named %q", c.Name)
 }

--- a/cmd/up/xpkg/push.go
+++ b/cmd/up/xpkg/push.go
@@ -77,7 +77,7 @@ type pushCmd struct {
 }
 
 // Run runs the push cmd.
-func (c *pushCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
+func (c *pushCmd) Run(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context) error { //nolint:gocyclo
 	// If package is not defined, attempt to find single package in current
 	// directory.
 	if len(c.Package) == 0 {
@@ -100,10 +100,10 @@ func (c *pushCmd) Run(p pterm.TextPrinter, upCtx *upbound.Context) error { //nol
 		}
 		imgs = append(imgs, img)
 	}
-	return PushImages(p, upCtx, imgs, c.Tag, c.Create, c.Flags.Profile)
+	return PushImages(ctx, p, upCtx, imgs, c.Tag, c.Create, c.Flags.Profile)
 }
 
-func PushImages(p pterm.TextPrinter, upCtx *upbound.Context, imgs []v1.Image, t string, create bool, profile string) error { //nolint:gocyclo
+func PushImages(ctx context.Context, p pterm.TextPrinter, upCtx *upbound.Context, imgs []v1.Image, t string, create bool, profile string) error { //nolint:gocyclo
 	tag, err := name.NewTag(t, name.WithDefaultRegistry(upCtx.RegistryEndpoint.Hostname()))
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func PushImages(p pterm.TextPrinter, upCtx *upbound.Context, imgs []v1.Image, t 
 		if err != nil {
 			return err
 		}
-		if err := repositories.NewClient(cfg).CreateOrUpdate(context.Background(), parts[0], parts[1]); err != nil {
+		if err := repositories.NewClient(cfg).CreateOrUpdate(ctx, parts[0], parts[1]); err != nil {
 			return errors.Wrap(err, errCreateRepo)
 		}
 	}
@@ -140,7 +140,7 @@ func PushImages(p pterm.TextPrinter, upCtx *upbound.Context, imgs []v1.Image, t 
 
 	// NOTE(hasheddan): the errgroup context is passed to each image write,
 	// meaning that if one fails it will cancel others that are in progress.
-	g, ctx := errgroup.WithContext(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 	for i, img := range imgs {
 		// pin range variables for use in go func
 		i, img := i, img

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/upbound/up
 
-go 1.22.1
+go 1.23.1
 
 require (
 	cloud.google.com/go/storage v1.36.0
@@ -39,7 +39,8 @@ require (
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
-	github.com/upbound/up-sdk-go v1.8.1-0.20240930100145-5e5f4d89101d
+	github.com/upbound/up-sdk-go v0.3.1-0.20241001164936-775e6eb0e36a
+	github.com/upbound/up-sdk-go/apis v1.8.1-0.20241001164936-775e6eb0e36a
 	github.com/upbound/up/pkg/migration v0.0.0-00010101000000-000000000000
 	github.com/willabides/kongplete v0.3.0
 	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a
@@ -94,7 +95,7 @@ require (
 	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/muesli/roff v0.1.0 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -481,8 +481,8 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20240117000934-35fc243c5815 h1:WzfWbQz/Ze8v6l++GGbGNFZnUShVpP/0xffCPLL+ax8=
-github.com/google/pprof v0.0.0-20240117000934-35fc243c5815/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
+github.com/google/pprof v0.0.0-20240207164012-fb44976bdcd5 h1:E/LAvt58di64hlYjx7AsNS6C/ysHWYo+2qPCZKTQhRo=
+github.com/google/pprof v0.0.0-20240207164012-fb44976bdcd5/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.5.0 h1:L16KZ3QvkFGpYhmp23iQip+mx1X39foEsqszjMNBm8A=
 github.com/google/rpmpack v0.5.0/go.mod h1:uqVAUVQLq8UY2hCDfmJ/+rtO3aw7qyhc90rCVEabEfI=
@@ -783,8 +783,9 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
@@ -841,8 +842,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
-github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rubenv/sql-migrate v1.4.0 h1:y4ndB3hq5tmjvQ8jcuqhLgeEqoxIjEidN5RaCkKOAAE=
 github.com/rubenv/sql-migrate v1.4.0/go.mod h1:lRxHt4vTgRJtpGbulUUYHA9dzfbBJXRt+PwUF/jeNYo=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -920,8 +921,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/upbound/up-sdk-go v1.8.1-0.20240930100145-5e5f4d89101d h1:KRQMSvK1hH8PwCtb9s+9NrMFFohspiylNNRJ52YJyic=
-github.com/upbound/up-sdk-go v1.8.1-0.20240930100145-5e5f4d89101d/go.mod h1:5wQULu+CrPVlfhdZ4x1LHESw9CV0uX1tCrcmuiULD14=
+github.com/upbound/up-sdk-go v0.3.1-0.20241001164936-775e6eb0e36a h1:TIaEZUCgYE6h7kxwKXDks083/DqgAOaZNZdO75V9LK4=
+github.com/upbound/up-sdk-go v0.3.1-0.20241001164936-775e6eb0e36a/go.mod h1:Y7uBp79VDN4JKYrANTqlr/O+NFpd1mEMUUDij4JInbQ=
+github.com/upbound/up-sdk-go/apis v1.8.1-0.20241001164936-775e6eb0e36a h1:i3t0C2ieNpPlvSSRDIvTd/5X1soja+qiank9aLAUBSg=
+github.com/upbound/up-sdk-go/apis v1.8.1-0.20241001164936-775e6eb0e36a/go.mod h1:Y052hGLZNRTt/iBa8GLHcGM5PfzmymXGAgxqxmmfkMI=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=

--- a/internal/xpkg/snapshot/composition.go
+++ b/internal/xpkg/snapshot/composition.go
@@ -159,7 +159,7 @@ func (p *PatchesValidator) validate(ctx context.Context, idx int, cd resource.Co
 		for _, e := range result.Errors {
 			var ve *verrors.Validation
 			if !errors.As(e, &ve) {
-				return []error{fmt.Errorf(errIncorrectErrType)}
+				return []error{errors.New(errIncorrectErrType)}
 			}
 			ie := &validator.Validation{
 				TypeCode: ve.Code(),


### PR DESCRIPTION
### Description of your changes

Spaces dropped `mxp-config` configmap, but `up space attach` still looks for it to validate a spaces installation. 

This PR fixes that by using the replacement configmap, namely `spaces-config`, that is available for a couple of releases.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested with a local spaces installation and verified that it can fetch the account information from the new configmap.
