### PR TITLE
Introduce a cli option to add suffix for provider name during pushing the packages

### DIFF
--- a/cmd/up/xpkg/batch.go
+++ b/cmd/up/xpkg/batch.go
@@ -122,6 +122,8 @@ type batchCmd struct {
 	Create       bool     `help:"Create repository on push if it does not exist."`
 	BuildOnly    bool     `help:"Only build the smaller provider packages and do not attempt to push them to a package repository." default:"false"`
 
+	ProviderNameSuffixForPush string `help:"Suffix for provider name during pushing the packages. This suffix is added to the end of the provider name. If there is a service name for the corresponded provider, then the suffix will be added to the base provider name and the service-scoped name will be after this suffix.  Examples: provider-family-aws-suffix, provider-aws-suffix-s3" optional:"" env:"PROVIDER_NAME_SUFFIX_FOR_PUSH"`
+
 	// Common Upbound API configuration
 	Flags upbound.Flags `embed:""`
 }
@@ -335,7 +337,17 @@ func (c *batchCmd) getPackageRepo(s string) string {
 	return repo
 }
 
+func (c *batchCmd) getPackageRepoWithSuffix(s string) string {
+	if v, ok := c.PackageRepoOverride[s]; ok {
+		return fmt.Sprintf("%s-%s", v, c.ProviderNameSuffixForPush)
+	}
+	return fmt.Sprintf("%s-%s-%s", c.ProviderName, c.ProviderNameSuffixForPush, s)
+}
+
 func (c *batchCmd) getPackageURL(s string) string {
+	if c.ProviderNameSuffixForPush != "" {
+		return fmt.Sprintf(c.FamilyPackageURLFormat, c.getPackageRepoWithSuffix(s))
+	}
 	return fmt.Sprintf(c.FamilyPackageURLFormat, c.getPackageRepo(s))
 }
 


### PR DESCRIPTION
### Description of your changes

This PR introduces a cli option for `xpkg batch` command to add suffix for provider name during pushing the packages. 

Suffix for provider name during pushing the packages. This suffix is added to the end of the provider name. If there is a service name for the corresponded provider, then the suffix will be added to the base provider name and the service-scoped name will be after this suffix.  Examples: provider-family-aws-suffix, provider-aws-suffix-s3. There is also an env var for this cli option: `PROVIDER_NAME_SUFFIX_FOR_PUSH`.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

Tested locally:

```
make PROVIDER_NAME_SUFFIX_FOR_PUSH=<suffix> SUBPACKAGES="config cloudplatform" BRANCH_NAME=main XPKG_REG_ORGS=xpkg.dev-deba7a0e.u6d.dev/upbound VERSION="v1.8.0-up-test" publish
15:28:34 [ .. ] Batch processing smaller provider packages for: config cloudplatform
Pushing xpkg to xpkg.dev-deba7a0e.u6d.dev/upbound/provider-family-gcp-<suffix>:v1.8.0-up-test.
Pushing xpkg to xpkg.dev-deba7a0e.u6d.dev/upbound/provider-gcp-<suffix>-cloudplatform:v1.8.0-up-test.
xpkg pushed to xpkg.dev-deba7a0e.u6d.dev/upbound/provider-gcp-<suffix>-cloudplatform:v1.8.0-up-test
xpkg pushed to xpkg.dev-deba7a0e.u6d.dev/upbound/provider-family-gcp-<suffix>:v1.8.0-up-test
15:30:52 [ OK ] Done processing smaller provider packages for: config cloudplatform
```
